### PR TITLE
feat: AssemblyPaths config for user POCO DLLs in dashboard

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/AssemblyPathTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/AssemblyPathTests.cs
@@ -1,0 +1,124 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.IO;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
+using DotNetWorkQueue.Dashboard.Api.Models;
+using DotNetWorkQueue.Transport.Memory;
+using DotNetWorkQueue.Transport.Memory.Basic;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
+{
+    [TestClass]
+    public class AssemblyPathTests
+    {
+        private DashboardTestServer _server;
+        private TransportFixture<MemoryDashboardInit, MessageQueueCreation> _fixture;
+        private Guid _queueId;
+        private string _pluginDir;
+
+        [TestInitialize]
+        public async Task InitializeAsync()
+        {
+            _pluginDir = Path.Combine(Path.GetTempPath(), "dnwq-test-plugins-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_pluginDir);
+
+            var queueName = QueueNameGenerator.Create();
+            var connStr = ConnectionStrings.Memory;
+
+            _fixture = new TransportFixture<MemoryDashboardInit, MessageQueueCreation>(
+                queueName, connStr);
+
+            _fixture.SendMessages<FakeMessage>(3);
+
+            _server = await DashboardTestServer.CreateAsync(options =>
+            {
+                options.EnableSwagger = false;
+                options.AssemblyPaths = new[] { _pluginDir };
+                options.AddConnection<MemoryDashboardInit>(connStr,
+                    serviceRegister => serviceRegister.RegisterNonScopedSingleton(_fixture.Scope),
+                    conn => conn.AddQueue(queueName));
+            });
+
+            var connections = await _server.Client.GetFromJsonAsync<ConnectionResponse[]>(
+                "api/v1/dashboard/connections");
+            var queues = await _server.Client.GetFromJsonAsync<QueueInfoResponse[]>(
+                $"api/v1/dashboard/connections/{connections[0].Id}/queues");
+            _queueId = queues[0].Id;
+        }
+
+        [TestCleanup]
+        public async Task CleanupAsync()
+        {
+            if (_server != null) await _server.DisposeAsync();
+            _fixture?.Dispose();
+            if (Directory.Exists(_pluginDir))
+                Directory.Delete(_pluginDir, true);
+        }
+
+        [TestMethod]
+        public async Task MessageBody_ResolvedWithAssemblyPaths()
+        {
+            var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
+                $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=1");
+            var messageId = paged.Items[0].QueueId;
+
+            var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
+                $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
+
+            body.Body.Should().NotBeNullOrEmpty();
+            body.TypeName.Should().Contain("FakeMessage");
+        }
+
+        [TestMethod]
+        public async Task MessageBody_EmptyPluginDir_StillWorks()
+        {
+            // Plugin dir exists but has no DLLs — body should still resolve
+            // because FakeMessage is already in the AppDomain
+            var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
+                $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=1");
+            var messageId = paged.Items[0].QueueId;
+
+            var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
+                $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
+
+            body.Body.Should().NotBeNullOrEmpty();
+        }
+
+        [TestMethod]
+        public async Task MessageBody_NonexistentPluginDir_DoesNotCrash()
+        {
+            // Delete the plugin dir before querying — should not throw
+            Directory.Delete(_pluginDir, true);
+
+            var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
+                $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=1");
+            var messageId = paged.Items[0].QueueId;
+
+            var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
+                $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
+
+            body.Body.Should().NotBeNullOrEmpty();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardOptionsTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardOptionsTests.cs
@@ -109,5 +109,24 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
             opts.EnableCors.Should().BeTrue();
             opts.CorsOrigins.Should().ContainSingle().Which.Should().Be("http://localhost:5000");
         }
+
+        [TestMethod]
+        public void AssemblyPaths_Defaults_To_Empty()
+        {
+            var opts = new DashboardOptions();
+            opts.AssemblyPaths.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void AssemblyPaths_Can_Be_Set()
+        {
+            var opts = new DashboardOptions
+            {
+                AssemblyPaths = new[] { "/app/plugins", "/opt/dlls" }
+            };
+            opts.AssemblyPaths.Should().HaveCount(2);
+            opts.AssemblyPaths[0].Should().Be("/app/plugins");
+            opts.AssemblyPaths[1].Should().Be("/opt/dlls");
+        }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Services/DashboardServiceTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Services/DashboardServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DotNetWorkQueue.Dashboard.Api.Configuration;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Dashboard.Api.Services;
 using DotNetWorkQueue.Exceptions;
@@ -30,7 +31,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
         public void GetConnections_Returns_All_Registered_Connections()
         {
             var api = CreateApi(out _, out _);
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
 
             var result = service.GetConnections();
 
@@ -43,7 +44,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
         public void GetQueues_Returns_Queues_For_Connection()
         {
             var api = CreateApi(out var connectionId, out _);
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
 
             var result = service.GetQueues(connectionId);
 
@@ -55,7 +56,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
         public void GetQueues_Throws_For_Unknown_ConnectionId()
         {
             var api = CreateApi(out _, out _);
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
 
             var act = () => service.GetQueues(Guid.NewGuid());
 
@@ -76,7 +77,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             }));
             container.GetInstance<IQueryHandlerAsync<GetDashboardStatusCountsQuery, DashboardStatusCounts>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetStatusAsync(queueId);
 
             result.Waiting.Should().Be(10);
@@ -104,7 +105,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             creation.BaseTransportOptions.Returns(options);
             container.GetInstance<IQueueCreation>().Returns(creation);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = service.GetFeatures(queueId);
 
             result.EnableStatus.Should().BeTrue();
@@ -124,7 +125,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.HandleAsync(Arg.Any<GetDashboardMessageCountQuery>()).Returns(Task.FromResult(42L));
             container.GetInstance<IQueryHandlerAsync<GetDashboardMessageCountQuery, long>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageCountAsync(queueId, null);
 
             result.Should().Be(42L);
@@ -141,7 +142,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.HandleAsync(Arg.Any<GetDashboardMessageDetailQuery>()).Returns(Task.FromResult((DashboardMessage)null));
             container.GetInstance<IQueryHandlerAsync<GetDashboardMessageDetailQuery, DashboardMessage>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageDetailAsync(queueId, "999");
 
             result.Should().BeNull();
@@ -159,7 +160,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
                 Task.FromResult(System.Text.Encoding.UTF8.GetBytes("{\"test\":true}")));
             container.GetInstance<IQueryHandlerAsync<GetDashboardConfigurationQuery, byte[]>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetConfigurationAsync(queueId);
 
             result.ConfigurationJson.Should().Be("{\"test\":true}");
@@ -181,7 +182,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             }));
             container.GetInstance<IQueryHandlerAsync<GetDashboardJobsQuery, IReadOnlyList<DashboardJob>>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetJobsByConnectionAsync(connectionId);
 
             result.Should().HaveCount(1);
@@ -206,7 +207,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
                 { connectionId, connectionInfo }
             });
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetJobsByConnectionAsync(connectionId);
 
             result.Should().BeEmpty();
@@ -216,7 +217,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
         public async Task GetJobsByConnection_Throws_For_Unknown_ConnectionId()
         {
             var api = CreateApi(out _, out _);
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
 
             var act = async () => await service.GetJobsByConnectionAsync(Guid.NewGuid());
 
@@ -297,7 +298,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
 
             container.GetInstance<IMessageFactory>().Returns(new MessageFactory());
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -319,7 +320,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.HandleAsync(Arg.Any<GetDashboardMessageBodyQuery>()).Returns(Task.FromResult((DashboardMessageBody)null));
             container.GetInstance<IQueryHandlerAsync<GetDashboardMessageBodyQuery, DashboardMessageBody>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "999");
 
             result.Should().BeNull();
@@ -348,7 +349,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             compositeSerialization.InternalSerializer.Returns(internalSerializer);
             container.GetInstance<ICompositeSerialization>().Returns(compositeSerialization);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -380,7 +381,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             compositeSerialization.InternalSerializer.Returns(internalSerializer);
             container.GetInstance<ICompositeSerialization>().Returns(compositeSerialization);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageHeadersAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -399,7 +400,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.HandleAsync(Arg.Any<GetDashboardMessageHeadersQuery>()).Returns(Task.FromResult((DashboardMessageHeaders)null));
             container.GetInstance<IQueryHandlerAsync<GetDashboardMessageHeadersQuery, DashboardMessageHeaders>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageHeadersAsync(queueId, "999");
 
             result.Should().BeNull();
@@ -427,7 +428,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             compositeSerialization.InternalSerializer.Returns(internalSerializer);
             container.GetInstance<ICompositeSerialization>().Returns(compositeSerialization);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageHeadersAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -450,7 +451,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
                 },
                 bodyValue: "hello");
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -470,7 +471,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
                 },
                 bodyValue: "hello");
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -492,7 +493,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
                 },
                 bodyValue: "hello");
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -585,7 +586,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             standardHeaders.StandardHeaders.MessageInterceptorGraph.Returns(messageInterceptorGraphData);
             container.GetInstance<IHeaders>().Returns(standardHeaders);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -640,7 +641,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             standardHeaders.StandardHeaders.MessageInterceptorGraph.Returns(messageInterceptorGraphData);
             container.GetInstance<IHeaders>().Returns(standardHeaders);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -692,7 +693,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             standardHeaders.StandardHeaders.MessageInterceptorGraph.Returns(messageInterceptorGraphData);
             container.GetInstance<IHeaders>().Returns(standardHeaders);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -747,7 +748,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
 
             container.GetInstance<IMessageFactory>().Returns(new MessageFactory());
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetMessageBodyAsync(queueId, "42");
 
             result.Should().NotBeNull();
@@ -770,7 +771,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.Handle(Arg.Any<DashboardDeleteMessageCommand>()).Returns(1L);
             container.GetInstance<ICommandHandlerWithOutput<DashboardDeleteMessageCommand, long>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.DeleteMessageAsync(queueId, "42");
 
             result.Should().BeTrue();
@@ -787,7 +788,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.Handle(Arg.Any<DashboardDeleteMessageCommand>()).Returns(0L);
             container.GetInstance<ICommandHandlerWithOutput<DashboardDeleteMessageCommand, long>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.DeleteMessageAsync(queueId, "999");
 
             result.Should().BeFalse();
@@ -804,7 +805,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.Handle(Arg.Any<DashboardDeleteAllErrorMessagesCommand>()).Returns(7L);
             container.GetInstance<ICommandHandlerWithOutput<DashboardDeleteAllErrorMessagesCommand, long>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.DeleteAllErrorMessagesAsync(queueId);
 
             result.Should().Be(7L);
@@ -821,7 +822,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.Handle(Arg.Any<DashboardRequeueErrorMessageCommand>()).Returns(1L);
             container.GetInstance<ICommandHandlerWithOutput<DashboardRequeueErrorMessageCommand, long>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.RequeueErrorMessageAsync(queueId, "42");
 
             result.Should().BeTrue();
@@ -838,7 +839,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.Handle(Arg.Any<DashboardRequeueErrorMessageCommand>()).Returns(0L);
             container.GetInstance<ICommandHandlerWithOutput<DashboardRequeueErrorMessageCommand, long>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.RequeueErrorMessageAsync(queueId, "999");
 
             result.Should().BeFalse();
@@ -855,7 +856,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.Handle(Arg.Any<DashboardResetStaleMessageCommand>()).Returns(1L);
             container.GetInstance<ICommandHandlerWithOutput<DashboardResetStaleMessageCommand, long>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.ResetStaleMessageAsync(queueId, "42");
 
             result.Should().BeTrue();
@@ -872,7 +873,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             handler.Handle(Arg.Any<DashboardResetStaleMessageCommand>()).Returns(0L);
             container.GetInstance<ICommandHandlerWithOutput<DashboardResetStaleMessageCommand, long>>().Returns(handler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.ResetStaleMessageAsync(queueId, "999");
 
             result.Should().BeFalse();
@@ -889,7 +890,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             bodyHandler.HandleAsync(Arg.Any<GetDashboardMessageBodyQuery>()).Returns(Task.FromResult((DashboardMessageBody)null));
             container.GetInstance<IQueryHandlerAsync<GetDashboardMessageBodyQuery, DashboardMessageBody>>().Returns(bodyHandler);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.EditMessageBodyAsync(queueId, "999","{}");
 
             result.Should().Be(EditMessageBodyResult.NotFound);
@@ -907,7 +908,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
                 },
                 messageStatus: 0);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.EditMessageBodyAsync(queueId, "42","\"hello\"");
 
             result.Should().Be(EditMessageBodyResult.TypeUnresolvable);
@@ -926,7 +927,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
                 },
                 messageStatus: 1);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.EditMessageBodyAsync(queueId, "42","\"hello\"");
 
             result.Should().Be(EditMessageBodyResult.MessageBeingProcessed);
@@ -945,7 +946,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
                 },
                 messageStatus: 0);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.EditMessageBodyAsync(queueId, "42","{ not valid json");
 
             result.Should().Be(EditMessageBodyResult.InvalidJson);
@@ -964,7 +965,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
                 },
                 messageStatus: 0);
 
-            var service = new DashboardService(api, NullLogger<DashboardService>.Instance);
+            var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.EditMessageBodyAsync(queueId, "42","\"hello world\"");
 
             result.Should().Be(EditMessageBodyResult.Success);

--- a/Source/DotNetWorkQueue.Dashboard.Api/Configuration/DashboardOptions.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Configuration/DashboardOptions.cs
@@ -84,6 +84,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Configuration
         public int ConsumerStaleThresholdSeconds { get; set; } = 90;
 
         /// <summary>
+        /// Additional directories to scan for user message-type assemblies (POCO DLLs).
+        /// Used by the dashboard to deserialize message bodies for display.
+        /// In Docker, mount a volume to one of these paths and place your DLLs there.
+        /// </summary>
+        public string[] AssemblyPaths { get; set; } = Array.Empty<string>();
+
+        /// <summary>
         /// Internal list of connection registrations.
         /// </summary>
         internal List<DashboardConnectionRegistration> ConnectionRegistrations { get; } = new List<DashboardConnectionRegistration>();

--- a/Source/DotNetWorkQueue.Dashboard.Api/DashboardExtensions.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/DashboardExtensions.cs
@@ -161,6 +161,7 @@ namespace DotNetWorkQueue.Dashboard.Api
             {
                 options.EnableSwagger = dashboardSection.GetValue("EnableSwagger", true);
                 options.ApiKey = dashboardSection.GetValue<string>("ApiKey") ?? string.Empty;
+                options.AssemblyPaths = dashboardSection.GetSection("AssemblyPaths").Get<string[]>() ?? Array.Empty<string>();
 
                 foreach (var conn in dashboardSection.GetSection("Connections").GetChildren())
                 {

--- a/Source/DotNetWorkQueue.Dashboard.Api/Services/DashboardService.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Services/DashboardService.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using DotNetWorkQueue.Dashboard.Api.Configuration;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Factory;
@@ -45,11 +46,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Services
     {
         private readonly IDashboardApi _dashboardApi;
         private readonly ILogger<DashboardService> _logger;
+        private readonly string[] _assemblyPaths;
 
-        public DashboardService(IDashboardApi dashboardApi, ILogger<DashboardService> logger)
+        public DashboardService(IDashboardApi dashboardApi, ILogger<DashboardService> logger, DashboardOptions options)
         {
             _dashboardApi = dashboardApi;
             _logger = logger;
+            _assemblyPaths = options.AssemblyPaths ?? Array.Empty<string>();
         }
 
         /// <inheritdoc />
@@ -462,16 +465,17 @@ namespace DotNetWorkQueue.Dashboard.Api.Services
         /// <see cref="Type"/>. Stage 1 checks the AppDomain (embedded scenario). Stage 2 tries
         /// to load the assembly from <see cref="AppContext.BaseDirectory"/> (standalone scenario
         /// where the user has placed their POCO DLLs in the dashboard's bin folder).
+        /// Stage 3 searches any additional directories configured in
+        /// <see cref="DashboardOptions.AssemblyPaths"/>.
         /// Returns null if the type cannot be resolved; never throws.
         /// </summary>
-        private static Type ResolveMessageBodyType(string portableName)
+        private Type ResolveMessageBodyType(string portableName)
         {
             // Stage 1: already loaded in AppDomain
             var type = Type.GetType(portableName);
             if (type != null)
                 return type;
 
-            // Stage 2: try loading from bin folder
             // portableName format: "TypeFullName, AssemblySimpleName"
             var commaIndex = portableName.IndexOf(',');
             if (commaIndex < 0)
@@ -479,8 +483,26 @@ namespace DotNetWorkQueue.Dashboard.Api.Services
 
             var typeFullName = portableName[..commaIndex].Trim();
             var assemblySimpleName = portableName[(commaIndex + 1)..].Trim();
-            var assemblyPath = Path.Combine(AppContext.BaseDirectory, assemblySimpleName + ".dll");
+            var dllFileName = assemblySimpleName + ".dll";
 
+            // Stage 2: try loading from bin folder
+            var resolved = TryLoadType(Path.Combine(AppContext.BaseDirectory, dllFileName), typeFullName);
+            if (resolved != null)
+                return resolved;
+
+            // Stage 3: try configured assembly paths
+            foreach (var dir in _assemblyPaths)
+            {
+                resolved = TryLoadType(Path.Combine(dir, dllFileName), typeFullName);
+                if (resolved != null)
+                    return resolved;
+            }
+
+            return null;
+        }
+
+        private static Type TryLoadType(string assemblyPath, string typeFullName)
+        {
             if (!File.Exists(assemblyPath))
                 return null;
 

--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -53,6 +53,9 @@ RUN if [ ! -e /usr/lib/x86_64-linux-gnu/libdl.so ]; then \
 WORKDIR /app
 COPY --from=build /app/publish .
 
+# Default plugin directory for user POCO assemblies (volume-mount your DLLs here)
+RUN mkdir -p /app/plugins
+
 USER $APP_UID
 
 ENV ASPNETCORE_URLS=http://+:8080

--- a/docker/dashboard/README.md
+++ b/docker/dashboard/README.md
@@ -127,6 +127,46 @@ Match the mount paths to the `ConnectionString` values in `appsettings.json`:
 { "Transport": "LiteDb",  "ConnectionString": "Filename=/data/litedb/myqueue.litedb" }
 ```
 
+## User Message Assemblies (POCO DLLs)
+
+The dashboard deserializes message bodies for display. If your queues contain custom POCO types, the dashboard needs access to those assemblies to show typed message content instead of raw bytes.
+
+### Option 1: Volume mount
+
+Mount a directory containing your DLLs and tell the dashboard where to look:
+
+```bash
+docker run -d \
+  --name dnwq-dashboard \
+  -p 8080:8080 \
+  -v "$(pwd)/appsettings.json:/app/appsettings.json:ro" \
+  -v "/path/to/your/dlls:/app/plugins:ro" \
+  blehnen74/dotnetworkqueue-dashboard:latest
+```
+
+Add the path to your `appsettings.json`:
+
+```json
+{
+  "Dashboard": {
+    "AssemblyPaths": ["/app/plugins"]
+  }
+}
+```
+
+### Option 2: Derived image
+
+Build a custom image that includes your DLLs:
+
+```dockerfile
+FROM blehnen74/dotnetworkqueue-dashboard:latest
+COPY MyMessages.dll /app/plugins/
+```
+
+Use the same `AssemblyPaths` configuration as above.
+
+Multiple paths are supported — the dashboard searches them in order after checking the application's own bin directory.
+
 ## External API Mode
 
 To point the UI at a separately hosted Dashboard API instead of running in-process, omit the `Dashboard:Connections` section and set:

--- a/docker/dashboard/appsettings.example.json
+++ b/docker/dashboard/appsettings.example.json
@@ -17,6 +17,7 @@
   "Dashboard": {
     "EnableSwagger": true,
     "ApiKey": "",
+    "AssemblyPaths": ["/app/plugins"],
     "Connections": [
       {
         "Transport": "SqlServer",


### PR DESCRIPTION
## Summary
- Add `DashboardOptions.AssemblyPaths` (`string[]`) — additional directories to scan for user message-type assemblies when deserializing message bodies for display
- Extend `ResolveMessageBodyType` with a third stage that searches configured paths after the AppDomain and bin folder
- Bind `AssemblyPaths` from `IConfiguration` for JSON-driven setup (Docker self-contained mode)
- Create `/app/plugins` directory in Dockerfile as a default mount point
- Document both volume-mount and derived-image approaches in the Docker README

## Test plan
- [x] 197 unit tests pass (net8.0 + net10.0) — includes 2 new `AssemblyPaths` config tests
- [x] 3 new integration tests pass (net8.0 + net10.0): body resolution with plugin dir, empty plugin dir, nonexistent plugin dir
- [ ] CI passes on all targets
- [ ] Manual: Docker build + run with volume-mounted DLL

🤖 Generated with [Claude Code](https://claude.com/claude-code)