### PR TITLE
ci: auto-publish dashboard docker image on v* tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -196,3 +196,48 @@ jobs:
             echo "- NuGet feed: https://api.nuget.org/v3/index.json"
             echo "- Release URL: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  docker-publish:
+    name: Build and push dashboard Docker image
+    needs: publish
+    # Same dry-run semantics as the NuGet publish job: skipped entirely when
+    # workflow_dispatch is invoked with dry_run=true.
+    if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/dashboard/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            blehnen74/dotnetworkqueue-dashboard:${{ steps.ver.outputs.version }}
+            blehnen74/dotnetworkqueue-dashboard:latest
+
+      - name: Job summary
+        run: |
+          {
+            echo "## Docker publish summary"
+            echo ""
+            echo "- Image: blehnen74/dotnetworkqueue-dashboard"
+            echo "- Tags pushed: ${{ steps.ver.outputs.version }}, latest"
+            echo "- Platforms: linux/amd64"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a `docker-publish` job to `.github/workflows/publish.yml` that fires after the NuGet `publish` job succeeds on a `v<version>` tag push. Builds from the existing `docker/dashboard/Dockerfile` and pushes `blehnen74/dotnetworkqueue-dashboard:<version>` + `:latest` to Docker Hub.

Closes #122.

## What changes

- New workflow job `docker-publish` with `needs: publish`
- Login via `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` secrets (already configured in repo settings per operator confirmation)
- `docker/setup-buildx-action@v3` + `docker/login-action@v3` + `docker/build-push-action@v6`
- Single-platform `linux/amd64` for now; multi-arch is an optional follow-up tracked in #122

## Dry-run behavior

Matches the NuGet publish job — `docker-publish` is skipped entirely when `workflow_dispatch` is invoked with `dry_run=true`. Operational dry-runs still exercise `verify-gate` + `build-pack` without touching Docker Hub.

## Failure isolation

`docker-publish` runs AFTER the NuGet `publish` job. If Docker Hub push fails, NuGet is already published (irreversible) — manual `docker push` recovery is still available. This preserves the rule that the irreversible step (NuGet) happens first and dockerhub is a downstream nice-to-have.

## Test plan

- [ ] PR-level Jenkins 14-stage matrix green (no source changes, but the project's Multibranch Pipeline still runs per convention)
- [ ] PR-level GitHub Actions CI green
- [ ] Workflow syntax validated (no editor errors)
- [ ] After merge + the next tag push, `blehnen74/dotnetworkqueue-dashboard:<version>` appears on Docker Hub
- [ ] `:latest` alias updates

## Related

Next release cycle: v0.9.34 will be the first release using this automated path (assuming this PR merges before the tag is pushed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)