### PR TITLE
tests: Dashboard.Ui bUnit component tests (Phase 1 of #126)

### DIFF
--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -44,6 +44,7 @@
     <PackageVersion Include="LiteDB" Version="5.0.21" />
 
     <!-- Test Infrastructure -->
+    <PackageVersion Include="bunit" Version="2.5.3" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/BunitTestBase.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/BunitTestBase.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components
+{
+    /// <summary>
+    /// Base class for bUnit component tests. Registers MudBlazor services and
+    /// enables loose JSInterop so MudBlazor components (which call into JS for
+    /// ripples, popovers, etc.) can render without explicit interop mocks.
+    /// </summary>
+    public abstract class BunitTestBase : BunitContext
+    {
+        protected BunitTestBase()
+        {
+            Services.AddMudServices();
+            JSInterop.Mode = JSRuntimeMode.Loose;
+        }
+
+        /// <summary>
+        /// Registers a fake <see cref="AuthenticationStateProvider"/> that reports
+        /// the requested authenticated state.
+        /// </summary>
+        protected void RegisterAuthState(bool authenticated, string userName = "test-user")
+        {
+            Services.AddSingleton<AuthenticationStateProvider>(new FakeAuthenticationStateProvider(authenticated, userName));
+        }
+
+        /// <summary>
+        /// Renders a component wrapped with <see cref="MudPopoverProvider"/>, which
+        /// MudBlazor components that use popovers (e.g. MudSelect) require to be
+        /// present in the render tree. Attributes passed in are forwarded to the
+        /// target component as (name, value) pairs.
+        /// </summary>
+        protected IRenderedComponent<IComponent> RenderWithMudProvider<TComponent>(params (string Name, object Value)[] attributes)
+            where TComponent : IComponent
+        {
+            return Render(builder =>
+            {
+                builder.OpenComponent<MudPopoverProvider>(0);
+                builder.CloseComponent();
+                builder.OpenComponent<TComponent>(1);
+#pragma warning disable ASP0006 // Deterministic per-call: attribute order is stable in test setup.
+                var seq = 2;
+                foreach (var attr in attributes)
+                {
+                    builder.AddAttribute(seq++, attr.Name, attr.Value);
+                }
+#pragma warning restore ASP0006
+                builder.CloseComponent();
+            });
+        }
+
+        private sealed class FakeAuthenticationStateProvider : AuthenticationStateProvider
+        {
+            private readonly bool _authenticated;
+            private readonly string _userName;
+
+            public FakeAuthenticationStateProvider(bool authenticated, string userName)
+            {
+                _authenticated = authenticated;
+                _userName = userName;
+            }
+
+            public override Task<AuthenticationState> GetAuthenticationStateAsync()
+            {
+                var identity = _authenticated
+                    ? new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, _userName) }, authenticationType: "test")
+                    : new ClaimsIdentity();
+                return Task.FromResult(new AuthenticationState(new ClaimsPrincipal(identity)));
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/MainLayoutTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/MainLayoutTests.cs
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using Bunit;
+using Bunit.TestDoubles;
+using DotNetWorkQueue.Dashboard.Ui.Components.Layout;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Layout
+{
+    [TestClass]
+    public class MainLayoutTests : BunitTestBase
+    {
+        [TestMethod]
+        public void RendersLayout_WhenAuthDisabled()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = false });
+            RegisterAuthState(authenticated: false);
+
+            var cut = Render<MainLayout>();
+
+            cut.Markup.Should().Contain("DotNetWorkQueue Dashboard");
+        }
+
+        [TestMethod]
+        public void RendersLayout_WhenAuthEnabledAndAuthenticated()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+            RegisterAuthState(authenticated: true);
+
+            var cut = Render<MainLayout>();
+
+            cut.Markup.Should().Contain("DotNetWorkQueue Dashboard");
+        }
+
+        [TestMethod]
+        public void ShowsLogoutButton_WhenAuthEnabled()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+            RegisterAuthState(authenticated: true);
+
+            var cut = Render<MainLayout>();
+
+            cut.Markup.Should().Contain("Sign out");
+        }
+
+        [TestMethod]
+        public void DoesNotShowLogoutButton_WhenAuthDisabled()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = false });
+            RegisterAuthState(authenticated: false);
+
+            var cut = Render<MainLayout>();
+
+            cut.Markup.Should().NotContain("Sign out");
+        }
+
+        [TestMethod]
+        public void NavigatesToLogin_WhenAuthEnabledAndNotAuthenticated()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+            RegisterAuthState(authenticated: false);
+            var nav = Services.GetRequiredService<BunitNavigationManager>();
+
+            Render<MainLayout>();
+
+            nav.Uri.Should().EndWith("/login");
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/HomeTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/HomeTests.cs
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Collections.Generic;
+using Bunit;
+using Bunit.TestDoubles;
+using DotNetWorkQueue.Dashboard.Ui.Components.Pages;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
+{
+    [TestClass]
+    public class HomeTests : BunitTestBase
+    {
+        [TestMethod]
+        public void RedirectsToSingleSource_WhenNoSlugAndOneSourceConfigured()
+        {
+            var sources = new List<DashboardApiSourceConfig>
+            {
+                new() { Name = "Primary", BaseUrl = "https://example.com" }
+            };
+            RegisterDependencies(sources);
+            var nav = Services.GetRequiredService<BunitNavigationManager>();
+
+            Render<Home>();
+
+            nav.Uri.Should().EndWith("/source/primary");
+        }
+
+        [TestMethod]
+        public void ShowsSourceNotFound_WhenSlugDoesNotResolve()
+        {
+            var sources = new List<DashboardApiSourceConfig>
+            {
+                new() { Name = "Primary", BaseUrl = "https://a" },
+                new() { Name = "Secondary", BaseUrl = "https://b" }
+            };
+            RegisterDependencies(sources);
+
+            var cut = Render<Home>(ps => ps.Add(p => p.SourceSlug, "does-not-exist"));
+
+            cut.Markup.Should().Contain("not found");
+        }
+
+        [TestMethod]
+        public void RendersMultiSourceView_WhenNoSlugAndMultipleSourcesConfigured()
+        {
+            var sources = new List<DashboardApiSourceConfig>
+            {
+                new() { Name = "Alpha", BaseUrl = "https://a" },
+                new() { Name = "Beta", BaseUrl = "https://b" }
+            };
+            RegisterDependencies(sources);
+
+            var cut = Render<Home>();
+
+            cut.Markup.Should().Contain("Alpha");
+            cut.Markup.Should().Contain("Beta");
+        }
+
+        private void RegisterDependencies(IReadOnlyList<DashboardApiSourceConfig> sources)
+        {
+            var registry = Substitute.For<ISourceRegistry>();
+            registry.GetAll().Returns(sources);
+            foreach (var src in sources)
+                registry.GetBySlug(src.Slug).Returns(src);
+
+            var health = Substitute.For<ISourceHealthMonitor>();
+            foreach (var src in sources)
+                health.GetHealth(src.Slug).Returns(new SourceHealthState { Status = SourceHealthStatus.Healthy });
+
+            var multi = Substitute.For<IMultiSourceDashboardApiClient>();
+            var apiClient = Substitute.For<IDashboardApiClient>();
+            apiClient.GetConnectionsAsync().Returns(new List<DotNetWorkQueue.Dashboard.Ui.Models.ConnectionResponse>());
+            var knownSlugs = new HashSet<string>();
+            foreach (var src in sources)
+                knownSlugs.Add(src.Slug);
+            // Match production: known slugs return the client, unknown slugs throw KeyNotFoundException.
+            multi.GetClientForSource(Arg.Any<string>()).Returns(call =>
+            {
+                var slug = call.Arg<string>();
+                if (knownSlugs.Contains(slug))
+                    return apiClient;
+                throw new KeyNotFoundException();
+            });
+
+            Services.AddSingleton(registry);
+            Services.AddSingleton(health);
+            Services.AddSingleton(multi);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using Bunit;
+using Bunit.TestDoubles;
+using DotNetWorkQueue.Dashboard.Ui.Components.Pages;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
+{
+    [TestClass]
+    public class LoginTests : BunitTestBase
+    {
+        [TestMethod]
+        public void RendersSignInButton_WhenAuthEnabled()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+
+            var cut = Render<Login>();
+
+            cut.Markup.Should().Contain("Sign In");
+            cut.Markup.Should().Contain("Dashboard Login");
+        }
+
+        [TestMethod]
+        public void ShowsErrorAlert_WhenErrorQueryParamPresent()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+            var nav = Services.GetRequiredService<BunitNavigationManager>();
+            nav.NavigateTo("/login?error=1");
+
+            var cut = Render<Login>();
+
+            cut.Markup.Should().Contain("Invalid username or password.");
+        }
+
+        [TestMethod]
+        public void DoesNotShowErrorAlert_WhenNoErrorQueryParam()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+
+            var cut = Render<Login>();
+
+            cut.Markup.Should().NotContain("Invalid username or password.");
+        }
+
+        [TestMethod]
+        public void NavigatesToRoot_WhenAuthDisabled()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = false });
+            var nav = Services.GetRequiredService<BunitNavigationManager>();
+
+            Render<Login>();
+
+            nav.Uri.Should().Be(nav.BaseUri);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
@@ -1,0 +1,142 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudBlazor;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
+{
+    [TestClass]
+    public class HistoryTabTests : BunitTestBase
+    {
+        private static readonly Guid TestQueueId = Guid.NewGuid();
+
+        [TestMethod]
+        public void LoadsHistory_OnInitialization()
+        {
+            var api = CreateApiWithRecords();
+            var snackbar = Substitute.For<ISnackbar>();
+
+            RenderHistoryTab(api, snackbar);
+
+            api.Received(1).GetHistoryAsync(TestQueueId, 0, 25, null);
+        }
+
+        [TestMethod]
+        public void HidesPurgeButton_WhenReadOnly()
+        {
+            var api = CreateApiWithRecords(totalCount: 5);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar, readOnly: true);
+
+            cut.Markup.Should().NotContain("Purge History");
+        }
+
+        [TestMethod]
+        public void HidesPurgeButton_WhenNoRecords()
+        {
+            var api = CreateApiWithRecords(totalCount: 0);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+
+            cut.Markup.Should().NotContain("Purge History");
+        }
+
+        [TestMethod]
+        public void ShowsPurgeButton_WhenWritableAndHasRecords()
+        {
+            var api = CreateApiWithRecords(totalCount: 3);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+
+            cut.Markup.Should().Contain("Purge History");
+        }
+
+        [TestMethod]
+        public void ShowsErrorAlert_WhenLoadHistoryThrows()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetHistoryAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int?>())
+                .Returns<Task<PagedResponse<HistoryResponse>>>(_ => throw new InvalidOperationException("boom"));
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+
+            cut.Markup.Should().Contain("boom");
+        }
+
+        [TestMethod]
+        public void RendersExpandControl_ForRecordsWithExceptions()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetHistoryAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int?>())
+                .Returns(new PagedResponse<HistoryResponse>
+                {
+                    Items = new List<HistoryResponse>
+                    {
+                        new()
+                        {
+                            QueueId = "abc-123",
+                            Status = 3,
+                            EnqueuedUtc = DateTime.UtcNow,
+                            ExceptionText = "SpecificErrorMarker"
+                        }
+                    },
+                    TotalCount = 1
+                });
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+
+            cut.Markup.Should().Contain("Expand exception");
+        }
+
+        private IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> RenderHistoryTab(IDashboardApiClient api, ISnackbar snackbar, bool readOnly = false)
+        {
+            return RenderWithMudProvider<HistoryTab>(
+                (nameof(HistoryTab.QueueId), TestQueueId),
+                (nameof(HistoryTab.Api), api),
+                (nameof(HistoryTab.Snackbar), snackbar),
+                (nameof(HistoryTab.ReadOnly), readOnly));
+        }
+
+        private static IDashboardApiClient CreateApiWithRecords(long totalCount = 1)
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetHistoryAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int?>())
+                .Returns(new PagedResponse<HistoryResponse>
+                {
+                    Items = new List<HistoryResponse>(),
+                    TotalCount = totalCount
+                });
+            return api;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/DotNetWorkQueue.Dashboard.Ui.Tests.csproj
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/DotNetWorkQueue.Dashboard.Ui.Tests.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
+    <PackageReference Include="bunit" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />


### PR DESCRIPTION
## Summary
Phase 1 of #126 — adds **bUnit 2.5.3** and **18 component tests** covering Razor components that were sitting at 0% coverage.

## Coverage added
| Component | Tests | What's exercised |
|---|---|---|
| `Pages/Login.razor` | 4 | sign-in render, `?error=1` alert, no-error default, auth-disabled redirect |
| `Layout/MainLayout.razor` | 5 | auth-disabled render, authenticated render, logout visibility, unauthenticated redirect to /login |
| `Shared/HistoryTab.razor` | 6 | loads on init, purge button visibility matrix, error-alert on load failure, expand control for exception rows |
| `Pages/Home.razor` | 3 | single-source redirect, source-not-found alert, multi-source grouped view |

Shared `BunitTestBase` registers MudBlazor services + loose JSInterop; `RenderWithMudProvider<T>()` wraps components that need `MudPopoverProvider` in the render tree (MudSelect / MudTable internals).

## Test plan
- [x] `dotnet build` — clean on net10.0 + net8.0
- [x] `dotnet test Source/DotNetWorkQueue.Dashboard.Ui.Tests` — 66/66 passing on both TFMs (48 existing + 18 new)
- [ ] Jenkins matrix green on this PR

## Phase 2 (incoming on this branch)
- New `DotNetWorkQueue.Dashboard.Ui.E2E.Tests` project with Playwright + WebApplicationFactory
- 2-3 smoke flows (login → drill down → History expand; auth-disabled path)
- New Jenkins stage 15 using `mcr.microsoft.com/playwright/dotnet` image

Marked draft until Jenkins is green and Phase 2 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)