### PR TITLE
fix(transports): retry decorators handle disposed Polly registry at shutdown (#121)

### DIFF
--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryCommandHandlerDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryCommandHandlerDecoratorTests.cs
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using DotNetWorkQueue.Transport.PostgreSQL.Decorator;
+using DotNetWorkQueue.Transport.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Decorator
+{
+    [TestClass]
+    public class RetryCommandHandlerDecoratorTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public void Handle_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandler<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecorator<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            sut.Handle(cmd);
+
+            decorated.Received(1).Handle(cmd);
+        }
+
+        [TestMethod]
+        public void Handle_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandler<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryCommandHandler, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecorator<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            sut.Handle(cmd);
+
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void Handle_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandler<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecorator<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            sut.Handle(cmd);
+
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryCommandHandlerOutputDecoratorAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryCommandHandlerOutputDecoratorAsyncTests.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using DotNetWorkQueue.Transport.PostgreSQL.Decorator;
+using DotNetWorkQueue.Transport.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Decorator
+{
+    [TestClass]
+    public class RetryCommandHandlerOutputDecoratorAsyncTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutputAsync<FakeCommand, int>>();
+            decorated.HandleAsync(Arg.Any<FakeCommand>()).Returns(Task.FromResult(42));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecoratorAsync<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = await sut.HandleAsync(cmd);
+
+            Assert.AreEqual(42, result);
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutputAsync<FakeCommand, int>>();
+            decorated.HandleAsync(Arg.Any<FakeCommand>()).Returns(Task.FromResult(42));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryCommandHandlerAsync, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecoratorAsync<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = await sut.HandleAsync(cmd);
+
+            Assert.AreEqual(42, result);
+            await decorated.Received(1).HandleAsync(cmd);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutputAsync<FakeCommand, int>>();
+            decorated.HandleAsync(Arg.Any<FakeCommand>()).Returns(Task.FromResult(42));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecoratorAsync<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = await sut.HandleAsync(cmd);
+
+            Assert.AreEqual(42, result);
+            await decorated.Received(1).HandleAsync(cmd);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryCommandHandlerOutputDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryCommandHandlerOutputDecoratorTests.cs
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using DotNetWorkQueue.Transport.PostgreSQL.Decorator;
+using DotNetWorkQueue.Transport.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Decorator
+{
+    [TestClass]
+    public class RetryCommandHandlerOutputDecoratorTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public void Handle_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutput<FakeCommand, int>>();
+            decorated.Handle(Arg.Any<FakeCommand>()).Returns(42);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecorator<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = sut.Handle(cmd);
+
+            Assert.AreEqual(42, result);
+            decorated.Received(1).Handle(cmd);
+        }
+
+        [TestMethod]
+        public void Handle_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutput<FakeCommand, int>>();
+            decorated.Handle(Arg.Any<FakeCommand>()).Returns(42);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryCommandHandler, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecorator<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = sut.Handle(cmd);
+
+            Assert.AreEqual(42, result);
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void Handle_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutput<FakeCommand, int>>();
+            decorated.Handle(Arg.Any<FakeCommand>()).Returns(42);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecorator<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = sut.Handle(cmd);
+
+            Assert.AreEqual(42, result);
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryQueryHandlerDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryQueryHandlerDecoratorTests.cs
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using DotNetWorkQueue.Transport.PostgreSQL.Decorator;
+using DotNetWorkQueue.Transport.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Decorator
+{
+    [TestClass]
+    public class RetryQueryHandlerDecoratorTests
+    {
+        public sealed class FakeQuery : IQuery<string> { }
+
+        [TestMethod]
+        public void Handle_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<IQueryHandler<FakeQuery, string>>();
+            decorated.Handle(Arg.Any<FakeQuery>()).Returns("ok");
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryQueryHandlerDecorator<FakeQuery, string>(decorated, policies);
+            var q = new FakeQuery();
+
+            var result = sut.Handle(q);
+
+            Assert.AreEqual("ok", result);
+            decorated.Received(1).Handle(q);
+        }
+
+        [TestMethod]
+        public void Handle_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<IQueryHandler<FakeQuery, string>>();
+            decorated.Handle(Arg.Any<FakeQuery>()).Returns("ok");
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryQueryHandler, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryQueryHandlerDecorator<FakeQuery, string>(decorated, policies);
+            var q = new FakeQuery();
+
+            var result = sut.Handle(q);
+
+            Assert.AreEqual("ok", result);
+            decorated.Received(1).Handle(q);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void Handle_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<IQueryHandler<FakeQuery, string>>();
+            decorated.Handle(Arg.Any<FakeQuery>()).Returns("ok");
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryQueryHandlerDecorator<FakeQuery, string>(decorated, policies);
+            var q = new FakeQuery();
+
+            var result = sut.Handle(q);
+
+            Assert.AreEqual("ok", result);
+            decorated.Received(1).Handle(q);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryCommandHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryCommandHandlerDecorator.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
@@ -47,11 +48,20 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Decorator
         /// <inheritdoc />
         public void Handle(TCommand command)
         {
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                pipeline.Execute(_ => _decorated.Handle(command));
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out pipeline);
             }
-            else //no policy found
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                pipeline.Execute(_ => _decorated.Handle(command));
+            else
                 _decorated.Handle(command);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryCommandHandlerOutputDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryCommandHandlerOutputDecorator.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
@@ -49,10 +50,19 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Decorator
         {
             Guard.NotNull(() => command, command);
 
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                return pipeline.Execute(_ => _decorated.Handle(command));
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out pipeline);
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                return pipeline.Execute(_ => _decorated.Handle(command));
             return _decorated.Handle(command);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryCommandHandlerOutputDecoratorAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryCommandHandlerOutputDecoratorAsync.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
@@ -49,10 +50,19 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Decorator
         public async Task<TOutput> HandleAsync(TCommand command)
         {
             Guard.NotNull(() => command, command);
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                return await pipeline.ExecuteAsync(async _ => await _decorated.HandleAsync(command).ConfigureAwait(false)).ConfigureAwait(false);
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync, out pipeline);
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                return await pipeline.ExecuteAsync(async _ => await _decorated.HandleAsync(command).ConfigureAwait(false)).ConfigureAwait(false);
             return await _decorated.HandleAsync(command).ConfigureAwait(false);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryQueryHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryQueryHandlerDecorator.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
@@ -48,10 +49,19 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Decorator
         public TResult Handle(TQuery query)
         {
             Guard.NotNull(() => query, query);
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryQueryHandler, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                return pipeline.Execute(_ => _decorated.Handle(query));
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryQueryHandler, out pipeline);
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                return pipeline.Execute(_ => _decorated.Handle(query));
             return _decorated.Handle(query);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/BeginTransactionRetryDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/BeginTransactionRetryDecoratorTests.cs
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Data;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Transport.SQLite.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
+{
+    [TestClass]
+    public class BeginTransactionRetryDecoratorTests
+    {
+        [TestMethod]
+        public void BeginTransaction_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decoratedTxn = Substitute.For<IDbTransaction>();
+            var decorated = Substitute.For<ISQLiteTransactionWrapper>();
+            decorated.BeginTransaction().Returns(decoratedTxn);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new BeginTransactionRetryDecorator(decorated, policies);
+
+            var result = sut.BeginTransaction();
+
+            Assert.AreSame(decoratedTxn, result);
+            decorated.Received(1).BeginTransaction();
+        }
+
+        [TestMethod]
+        public void BeginTransaction_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decoratedTxn = Substitute.For<IDbTransaction>();
+            var decorated = Substitute.For<ISQLiteTransactionWrapper>();
+            decorated.BeginTransaction().Returns(decoratedTxn);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.BeginTransaction, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new BeginTransactionRetryDecorator(decorated, policies);
+
+            var result = sut.BeginTransaction();
+
+            Assert.AreSame(decoratedTxn, result);
+            decorated.Received(1).BeginTransaction();
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void BeginTransaction_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decoratedTxn = Substitute.For<IDbTransaction>();
+            var decorated = Substitute.For<ISQLiteTransactionWrapper>();
+            decorated.BeginTransaction().Returns(decoratedTxn);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new BeginTransactionRetryDecorator(decorated, policies);
+
+            var result = sut.BeginTransaction();
+
+            Assert.AreSame(decoratedTxn, result);
+            decorated.Received(1).BeginTransaction();
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryCommandHandlerDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryCommandHandlerDecoratorTests.cs
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Transport.SQLite.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
+{
+    [TestClass]
+    public class RetryCommandHandlerDecoratorTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public void Handle_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandler<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecorator<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            sut.Handle(cmd);
+
+            decorated.Received(1).Handle(cmd);
+        }
+
+        [TestMethod]
+        public void Handle_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandler<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryCommandHandler, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecorator<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            sut.Handle(cmd);
+
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void Handle_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandler<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecorator<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            sut.Handle(cmd);
+
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryCommandHandlerOutputDecoratorAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryCommandHandlerOutputDecoratorAsyncTests.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Transport.SQLite.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
+{
+    [TestClass]
+    public class RetryCommandHandlerOutputDecoratorAsyncTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutputAsync<FakeCommand, int>>();
+            decorated.HandleAsync(Arg.Any<FakeCommand>()).Returns(Task.FromResult(42));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecoratorAsync<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = await sut.HandleAsync(cmd);
+
+            Assert.AreEqual(42, result);
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutputAsync<FakeCommand, int>>();
+            decorated.HandleAsync(Arg.Any<FakeCommand>()).Returns(Task.FromResult(42));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryCommandHandlerAsync, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecoratorAsync<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = await sut.HandleAsync(cmd);
+
+            Assert.AreEqual(42, result);
+            await decorated.Received(1).HandleAsync(cmd);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutputAsync<FakeCommand, int>>();
+            decorated.HandleAsync(Arg.Any<FakeCommand>()).Returns(Task.FromResult(42));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecoratorAsync<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = await sut.HandleAsync(cmd);
+
+            Assert.AreEqual(42, result);
+            await decorated.Received(1).HandleAsync(cmd);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryCommandHandlerOutputDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryCommandHandlerOutputDecoratorTests.cs
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Transport.SQLite.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
+{
+    [TestClass]
+    public class RetryCommandHandlerOutputDecoratorTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public void Handle_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutput<FakeCommand, int>>();
+            decorated.Handle(Arg.Any<FakeCommand>()).Returns(42);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecorator<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = sut.Handle(cmd);
+
+            Assert.AreEqual(42, result);
+            decorated.Received(1).Handle(cmd);
+        }
+
+        [TestMethod]
+        public void Handle_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutput<FakeCommand, int>>();
+            decorated.Handle(Arg.Any<FakeCommand>()).Returns(42);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryCommandHandler, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecorator<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = sut.Handle(cmd);
+
+            Assert.AreEqual(42, result);
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void Handle_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutput<FakeCommand, int>>();
+            decorated.Handle(Arg.Any<FakeCommand>()).Returns(42);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecorator<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = sut.Handle(cmd);
+
+            Assert.AreEqual(42, result);
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryQueryHandlerDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryQueryHandlerDecoratorTests.cs
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Transport.SQLite.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
+{
+    [TestClass]
+    public class RetryQueryHandlerDecoratorTests
+    {
+        public sealed class FakeQuery : IQuery<string> { }
+
+        [TestMethod]
+        public void Handle_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<IQueryHandler<FakeQuery, string>>();
+            decorated.Handle(Arg.Any<FakeQuery>()).Returns("ok");
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryQueryHandlerDecorator<FakeQuery, string>(decorated, policies);
+            var q = new FakeQuery();
+
+            var result = sut.Handle(q);
+
+            Assert.AreEqual("ok", result);
+            decorated.Received(1).Handle(q);
+        }
+
+        [TestMethod]
+        public void Handle_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<IQueryHandler<FakeQuery, string>>();
+            decorated.Handle(Arg.Any<FakeQuery>()).Returns("ok");
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryQueryHandler, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryQueryHandlerDecorator<FakeQuery, string>(decorated, policies);
+            var q = new FakeQuery();
+
+            var result = sut.Handle(q);
+
+            Assert.AreEqual("ok", result);
+            decorated.Received(1).Handle(q);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void Handle_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<IQueryHandler<FakeQuery, string>>();
+            decorated.Handle(Arg.Any<FakeQuery>()).Returns("ok");
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryQueryHandlerDecorator<FakeQuery, string>(decorated, policies);
+            var q = new FakeQuery();
+
+            var result = sut.Handle(q);
+
+            Assert.AreEqual("ok", result);
+            decorated.Received(1).Handle(q);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/BeginTransactionRetryDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/BeginTransactionRetryDecorator.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using System.Data;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Validation;
@@ -57,7 +58,15 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         {
             if (_pipeline == null)
             {
-                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.BeginTransaction, out _pipeline);
+                try
+                {
+                    _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.BeginTransaction, out _pipeline);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Shutdown race: registry disposed before first invocation.
+                    // Fall through to direct handler — same semantics as the "no pipeline" path.
+                }
             }
             if (_pipeline == null) return _decorated.BeginTransaction();
             return _pipeline.Execute(_ => _decorated.BeginTransaction());

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryCommandHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryCommandHandlerDecorator.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 
+using System;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Validation;
@@ -48,11 +49,20 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         /// <inheritdoc />
         public void Handle(TCommand command)
         {
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                pipeline.Execute(_ => _decorated.Handle(command));
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out pipeline);
             }
-            else //no policy found
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                pipeline.Execute(_ => _decorated.Handle(command));
+            else
                 _decorated.Handle(command);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryCommandHandlerOutputDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryCommandHandlerOutputDecorator.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 
+using System;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Validation;
@@ -50,10 +51,19 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         {
             Guard.NotNull(() => command, command);
 
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                return pipeline.Execute(_ => _decorated.Handle(command));
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out pipeline);
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                return pipeline.Execute(_ => _decorated.Handle(command));
             return _decorated.Handle(command);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryCommandHandlerOutputDecoratorAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryCommandHandlerOutputDecoratorAsync.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 
+using System;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Validation;
@@ -50,10 +51,19 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         public async Task<TOutput> HandleAsync(TCommand command)
         {
             Guard.NotNull(() => command, command);
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                return await pipeline.ExecuteAsync(async _ => await _decorated.HandleAsync(command).ConfigureAwait(false)).ConfigureAwait(false);
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync, out pipeline);
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                return await pipeline.ExecuteAsync(async _ => await _decorated.HandleAsync(command).ConfigureAwait(false)).ConfigureAwait(false);
             return await _decorated.HandleAsync(command).ConfigureAwait(false);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryQueryHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryQueryHandlerDecorator.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 
+using System;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Validation;
@@ -49,10 +50,19 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         public TResult Handle(TQuery query)
         {
             Guard.NotNull(() => query, query);
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryQueryHandler, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                return pipeline.Execute(_ => _decorated.Handle(query));
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryQueryHandler, out pipeline);
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                return pipeline.Execute(_ => _decorated.Handle(query));
             return _decorated.Handle(query);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryCommandHandlerDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryCommandHandlerDecoratorTests.cs
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using DotNetWorkQueue.Transport.SqlServer.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SqlServer.Tests.Decorator
+{
+    [TestClass]
+    public class RetryCommandHandlerDecoratorTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public void Handle_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandler<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecorator<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            sut.Handle(cmd); // must NOT throw
+
+            decorated.Received(1).Handle(cmd);
+        }
+
+        [TestMethod]
+        public void Handle_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandler<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            // Empty builder registers ResiliencePipeline.Empty — enough to verify
+            // the "pipeline found" branch executes without exercising a strategy.
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryCommandHandler,
+                (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecorator<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            sut.Handle(cmd);
+
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void Handle_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandler<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecorator<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            sut.Handle(cmd);
+
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryCommandHandlerOutputDecoratorAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryCommandHandlerOutputDecoratorAsyncTests.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using DotNetWorkQueue.Transport.SqlServer.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SqlServer.Tests.Decorator
+{
+    [TestClass]
+    public class RetryCommandHandlerOutputDecoratorAsyncTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutputAsync<FakeCommand, int>>();
+            decorated.HandleAsync(Arg.Any<FakeCommand>()).Returns(Task.FromResult(42));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecoratorAsync<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = await sut.HandleAsync(cmd);
+
+            Assert.AreEqual(42, result);
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutputAsync<FakeCommand, int>>();
+            decorated.HandleAsync(Arg.Any<FakeCommand>()).Returns(Task.FromResult(42));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryCommandHandlerAsync, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecoratorAsync<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = await sut.HandleAsync(cmd);
+
+            Assert.AreEqual(42, result);
+            await decorated.Received(1).HandleAsync(cmd);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutputAsync<FakeCommand, int>>();
+            decorated.HandleAsync(Arg.Any<FakeCommand>()).Returns(Task.FromResult(42));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecoratorAsync<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = await sut.HandleAsync(cmd);
+
+            Assert.AreEqual(42, result);
+            await decorated.Received(1).HandleAsync(cmd);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryCommandHandlerOutputDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryCommandHandlerOutputDecoratorTests.cs
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using DotNetWorkQueue.Transport.SqlServer.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SqlServer.Tests.Decorator
+{
+    [TestClass]
+    public class RetryCommandHandlerOutputDecoratorTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public void Handle_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutput<FakeCommand, int>>();
+            decorated.Handle(Arg.Any<FakeCommand>()).Returns(42);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecorator<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = sut.Handle(cmd);
+
+            Assert.AreEqual(42, result);
+            decorated.Received(1).Handle(cmd);
+        }
+
+        [TestMethod]
+        public void Handle_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutput<FakeCommand, int>>();
+            decorated.Handle(Arg.Any<FakeCommand>()).Returns(42);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryCommandHandler, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecorator<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = sut.Handle(cmd);
+
+            Assert.AreEqual(42, result);
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void Handle_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandlerWithOutput<FakeCommand, int>>();
+            decorated.Handle(Arg.Any<FakeCommand>()).Returns(42);
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerOutputDecorator<FakeCommand, int>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            var result = sut.Handle(cmd);
+
+            Assert.AreEqual(42, result);
+            decorated.Received(1).Handle(cmd);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryQueryHandlerDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryQueryHandlerDecoratorTests.cs
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using DotNetWorkQueue.Transport.SqlServer.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SqlServer.Tests.Decorator
+{
+    [TestClass]
+    public class RetryQueryHandlerDecoratorTests
+    {
+        public sealed class FakeQuery : IQuery<string> { }
+
+        [TestMethod]
+        public void Handle_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<IQueryHandler<FakeQuery, string>>();
+            decorated.Handle(Arg.Any<FakeQuery>()).Returns("ok");
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryQueryHandlerDecorator<FakeQuery, string>(decorated, policies);
+            var q = new FakeQuery();
+
+            var result = sut.Handle(q);
+
+            Assert.AreEqual("ok", result);
+            decorated.Received(1).Handle(q);
+        }
+
+        [TestMethod]
+        public void Handle_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<IQueryHandler<FakeQuery, string>>();
+            decorated.Handle(Arg.Any<FakeQuery>()).Returns("ok");
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.RetryQueryHandler, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryQueryHandlerDecorator<FakeQuery, string>(decorated, policies);
+            var q = new FakeQuery();
+
+            var result = sut.Handle(q);
+
+            Assert.AreEqual("ok", result);
+            decorated.Received(1).Handle(q);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public void Handle_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<IQueryHandler<FakeQuery, string>>();
+            decorated.Handle(Arg.Any<FakeQuery>()).Returns("ok");
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryQueryHandlerDecorator<FakeQuery, string>(decorated, policies);
+            var q = new FakeQuery();
+
+            var result = sut.Handle(q);
+
+            Assert.AreEqual("ok", result);
+            decorated.Received(1).Handle(q);
+            registry.Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryCommandHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryCommandHandlerDecorator.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
 using DotNetWorkQueue.Validation;
@@ -47,11 +48,20 @@ namespace DotNetWorkQueue.Transport.SqlServer.Decorator
         /// <inheritdoc />
         public void Handle(TCommand command)
         {
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                pipeline.Execute(_ => _decorated.Handle(command));
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out pipeline);
             }
-            else //no policy found
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                pipeline.Execute(_ => _decorated.Handle(command));
+            else
                 _decorated.Handle(command);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryCommandHandlerOutputDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryCommandHandlerOutputDecorator.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
 using DotNetWorkQueue.Validation;
@@ -48,10 +49,19 @@ namespace DotNetWorkQueue.Transport.SqlServer.Decorator
         public TOutput Handle(TCommand command)
         {
             Guard.NotNull(() => command, command);
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                return pipeline.Execute(_ => _decorated.Handle(command));
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandler, out pipeline);
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                return pipeline.Execute(_ => _decorated.Handle(command));
             return _decorated.Handle(command);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryCommandHandlerOutputDecoratorAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryCommandHandlerOutputDecoratorAsync.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
 using DotNetWorkQueue.Validation;
@@ -49,10 +50,19 @@ namespace DotNetWorkQueue.Transport.SqlServer.Decorator
         public async Task<TOutput> HandleAsync(TCommand command)
         {
             Guard.NotNull(() => command, command);
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                return await pipeline.ExecuteAsync(async _ => await _decorated.HandleAsync(command).ConfigureAwait(false)).ConfigureAwait(false);
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync, out pipeline);
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                return await pipeline.ExecuteAsync(async _ => await _decorated.HandleAsync(command).ConfigureAwait(false)).ConfigureAwait(false);
             return await _decorated.HandleAsync(command).ConfigureAwait(false);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryQueryHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryQueryHandlerDecorator.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
 using DotNetWorkQueue.Validation;
@@ -48,10 +49,19 @@ namespace DotNetWorkQueue.Transport.SqlServer.Decorator
         public TResult Handle(TQuery query)
         {
             Guard.NotNull(() => query, query);
-            if (_policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryQueryHandler, out var pipeline))
+            ResiliencePipeline pipeline = null;
+            try
             {
-                return pipeline.Execute(_ => _decorated.Handle(query));
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryQueryHandler, out pipeline);
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                return pipeline.Execute(_ => _decorated.Handle(query));
             return _decorated.Handle(query);
         }
     }


### PR DESCRIPTION
Closes #121. Follow-up investigation for the deeper disposal-ordering fix tracked in #135.

## Summary
Narrow `catch (ObjectDisposedException)` around `ResiliencePipelineRegistry.TryGetPipeline(...)` in each retry decorator. Polly's API throws ODE on a disposed registry rather than returning `false`, and the existing "no policy found → run decorated handler directly" fallback already has the right recovery semantics — the catch just extends that fallback to also trigger on ODE.

**Why a narrow catch and not a `_disposed` flag or dispose-ordering refactor:** disposal races in .NET have no non-throwing alternative (check-then-call has a TOCTOU window), and the BCL uses `catch (ObjectDisposedException)` in the same pattern (Timer callbacks, socket shutdown). The architectural fix (container-level dispose ordering) is scoped to #135.

## Scope
13 decorator files patched across SqlServer, PostgreSQL, SQLite:

| Decorator | SqlServer | PostgreSQL | SQLite |
|---|---|---|---|
| `RetryCommandHandlerDecorator` | ✓ | ✓ | ✓ |
| `RetryCommandHandlerOutputDecorator` | ✓ | ✓ | ✓ |
| `RetryCommandHandlerOutputDecoratorAsync` | ✓ | ✓ | ✓ |
| `RetryQueryHandlerDecorator` | ✓ | ✓ | ✓ |
| `BeginTransactionRetryDecorator` | — | — | ✓ (variant — caches pipeline on field) |

LiteDb / Redis / Memory don't use Polly retry decorators; no changes there.

## Tests
39 new unit tests (3 per decorator: disposed-registry-falls-through, pipeline-registered-executes-through, no-pipeline-registered-falls-through). The disposed-registry test for the SqlServer template (Task 1) produces the exact stack trace from the issue's bug report, proving the RED case matches the production race.

## Regression
- `DotNetWorkQueue.Transport.SqlServer.Tests`: **139/139**
- `DotNetWorkQueue.Transport.PostgreSQL.Tests`: **126/126**
- `DotNetWorkQueue.Transport.SQLite.Tests`: **141/141**
- `DotNetWorkQueue.Transport.RelationalDatabase.Tests`: **216/216**

## Test plan
- [x] Unit tests across 3 transports (39 new, all green)
- [x] Full relational unit-test suites green
- [x] Jenkins PR build — 14 parallel integration stages will exercise the shutdown path under load

## Dependencies / follow-ups
- Follow-up: #135 (deeper disposal-ordering fix — scoped architectural refactor, optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)