### PR TITLE
docs(xml): hyperlink outbox-pattern.md + correct stale Ordinal comparator docs

### DIFF
--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/ExternalTransactionValidator.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/ExternalTransactionValidator.cs
@@ -32,9 +32,11 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
     ///   <item><description>Connection state is <see cref="ConnectionState.Open"/> (throws <see cref="InvalidOperationException"/>).</description></item>
     ///   <item><description>Database name reported by the connection (via the injected
     ///       <see cref="IExternalDbNameExtractor"/>) equals the queue's configured
-    ///       database (via <see cref="IConnectionInformation.Container"/>). Comparison is
-    ///       <see cref="StringComparison.Ordinal"/>; per-provider case semantics are
-    ///       encoded by the extractor's normalization. Mismatch throws
+    ///       database (via <see cref="IConnectionInformation.Container"/>). Both registered
+    ///       extractors are pass-through; comparison is
+    ///       <see cref="StringComparison.Ordinal"/>, so case differences between the
+    ///       caller's connection-string catalog and the queue's configured
+    ///       <c>Container</c> will fail this check on both transports. Mismatch throws
     ///       <see cref="InvalidOperationException"/> with both database names in the
     ///       message.</description></item>
     /// </list>

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/IExternalDbNameExtractor.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/IExternalDbNameExtractor.cs
@@ -22,14 +22,14 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
 {
     /// <summary>
     /// Extracts the canonical database name from an open <see cref="DbConnection"/> for
-    /// use by <see cref="Basic.ExternalTransactionValidator"/>. Per-provider implementations
-    /// supply the appropriate name comparison semantics:
-    /// <list type="bullet">
-    ///   <item><description>SqlServer uses case-insensitive comparison (<c>StringComparer.OrdinalIgnoreCase</c>).</description></item>
-    ///   <item><description>PostgreSQL uses case-sensitive comparison (<c>StringComparer.Ordinal</c>) to match the database's quoted-identifier semantics.</description></item>
-    /// </list>
-    /// Implementations live in <c>Transport.SqlServer</c> (Phase 3) and
-    /// <c>Transport.PostgreSQL</c> (Phase 4); Phase 2 ships only this contract.
+    /// use by <see cref="Basic.ExternalTransactionValidator"/>. Both registered transport
+    /// implementations (<c>Transport.SqlServer</c> and <c>Transport.PostgreSQL</c>) return
+    /// <c>connection.Database</c> verbatim (pass-through, no case normalization). The
+    /// validator compares the result against <see cref="IConnectionInformation.Container"/>
+    /// using <c>StringComparison.Ordinal</c> — so both transports use case-sensitive,
+    /// byte-verbatim comparison. Callers whose connection strings differ in catalog case
+    /// from the queue's configured <c>Container</c> will see a cross-database validation
+    /// failure even when the underlying database engine would treat the names as identical.
     /// </summary>
     public interface IExternalDbNameExtractor
     {

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/IRelationalProducerQueue.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/IRelationalProducerQueue.cs
@@ -34,8 +34,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
     /// <remarks>
     /// On the transaction-aware path the producer never commits, rolls back, or disposes the
     /// caller's transaction or its connection. The retry decorator is bypassed (the
-    /// caller owns retry policy). See <c>docs/outbox-pattern.md</c> for the full
-    /// lifecycle contract (Phase 7).
+    /// caller owns retry policy). See
+    /// <see href="https://github.com/blehnen/DotNetWorkQueue/blob/master/docs/outbox-pattern.md">docs/outbox-pattern.md</see>
+    /// for the full lifecycle contract.
     /// </remarks>
     public interface IRelationalProducerQueue<TMessage> : IProducerQueue<TMessage>
         where TMessage : class

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerExternalDbNameExtractor.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerExternalDbNameExtractor.cs
@@ -29,15 +29,11 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
     /// from the parsed connection string) is therefore case-sensitive.
     /// </summary>
     /// <remarks>
-    /// Earlier implementations applied <c>ToUpperInvariant</c> on the extractor side but
-    /// did not apply symmetric normalization on the <c>Container</c> side, causing a
-    /// validator-mismatch when the actual SqlServer catalog case differed from the
-    /// uppercased extractor output. Pass-through aligns the SqlServer extractor with
-    /// PostgreSQL's pass-through approach (Phase 4 CONTEXT-4 Decision 2) and avoids the
-    /// symmetry gap. Users must configure <c>Database=&lt;name&gt;</c> in the connection
-    /// string with the exact case as the actual SqlServer catalog (typical and easy to
-    /// satisfy; SqlClient's <c>conn.Database</c> after open returns the canonical name
-    /// from <c>sys.databases</c>).
+    /// Configure <c>Database=&lt;name&gt;</c> in the connection string with the exact case as
+    /// the actual SqlServer catalog. After the connection opens, SqlClient's
+    /// <c>conn.Database</c> returns the canonical name from <c>sys.databases</c>, which
+    /// must equal the queue's configured <see cref="IConnectionInformation.Container"/>
+    /// byte-for-byte under <see cref="System.StringComparison.Ordinal"/> comparison.
     /// </remarks>
     public sealed class SqlServerExternalDbNameExtractor : IExternalDbNameExtractor
     {

--- a/docs/outbox-pattern.md
+++ b/docs/outbox-pattern.md
@@ -3,33 +3,33 @@
 ## Overview
 
 The transactional outbox pattern guarantees that a queue message and a business database write
-either both commit or both roll back. It solves the dual-write problem that arises when your
-application must write to a database table and enqueue a message as part of a single logical
-operation.
+either both commit or both roll back. It solves the dual-write problem: your application needs to
+write a row to its own tables and enqueue a message in one logical operation, and you cannot
+afford to have one succeed while the other fails.
 
-DotNetWorkQueue's default producer opens and manages its own database connection and transaction
-internally. That design is correct for fire-and-forget enqueue, but it precludes the outbox
-pattern because the queue INSERT is not part of your business transaction. The opt-in surface for
-the outbox pattern is `IRelationalProducerQueue<T>`, a derived interface that accepts a
-caller-supplied `DbTransaction` and performs all queue INSERTs inside it without ever committing,
-rolling back, or disposing the caller's resources.
+DotNetWorkQueue's default producer opens and manages its own connection and transaction. That is
+the right default for fire-and-forget enqueue, but it precludes the outbox pattern because the
+queue INSERT is not part of the caller's business transaction. `IRelationalProducerQueue<T>` is
+the opt-in surface that fixes this: a derived interface that accepts a caller-supplied
+`DbTransaction`, runs all queue INSERTs inside it, and never commits, rolls back, or disposes the
+caller's resources.
 
 ## Quick Start
 
 ### Prerequisites
 
 - Your queue transport must be **SqlServer or PostgreSQL**. Memory, Redis, LiteDb, and SQLite do
-  not implement `IRelationalProducerQueue<T>` — see [Supported Transports](#supported-transports).
+  not implement `IRelationalProducerQueue<T>`. See [Supported Transports](#supported-transports).
 - Queue tables must exist before the first `Send` call. Run `CreateQueue()` once at deployment
-  time — see [Schema Deployment Prerequisite](#schema-deployment-prerequisite).
+  time. See [Schema Deployment Prerequisite](#schema-deployment-prerequisite).
 
 ### Example: SqlServer
 
-The example below shows a complete vertical slice: set up the queue, open a connection and
-transaction, perform a business INSERT, enqueue the event, and commit — atomically.
+The example below shows the full flow: set up the queue, open a connection and transaction,
+write a business row, enqueue the event, then commit atomically.
 
-`SendAsync` overloads with the same signatures exist on `IRelationalProducerQueue<T>` for
-async callers; the sync form is shown here for clarity.
+`IRelationalProducerQueue<T>` has `SendAsync` overloads with matching signatures. The sync form
+is shown here.
 
 ```csharp
 using System.Data;
@@ -47,11 +47,10 @@ public class OrderCreatedEvent
 }
 
 // --- One-time setup (at application startup) ---
-// NOTE: connection string shown for tutorial clarity only. In production, load
-// credentials from a secrets manager (Azure Key Vault, AWS Secrets Manager, etc.)
-// and use a least-privilege account, not `sa`. The `TrustServerCertificate=true`
-// flag below is appropriate only for local development against a self-signed
-// cert — remove it (or pin a trusted CA) for any non-local environment.
+// Sample connection string, not for production use. Load credentials from a
+// secrets manager and use a least-privilege account, not `sa`.
+// `TrustServerCertificate=true` is for local dev against a self-signed cert
+// only; remove it (or pin a trusted CA) anywhere else.
 var conn = new QueueConnection(
     "MyEvents",
     "Server=localhost;Database=AppDb;User Id=sa;Password=...;TrustServerCertificate=true");
@@ -93,36 +92,33 @@ transaction.Commit();
 
 To retry the whole operation on a transient failure, wrap the block from `sqlConn.Open()` to
 `transaction.Commit()` in your own retry policy (e.g., Polly). The producer does not retry on the
-caller-transaction path — see [Retry Contract](#retry-contract).
+caller-transaction path. See [Retry Contract](#retry-contract).
 
 #### PostgreSQL note
 
 The same pattern works with `NpgsqlConnection`, `NpgsqlTransaction`, and
 `PostgreSqlMessageQueueInit` as the transport initializer. The capability cast succeeds
-identically. The only behavioral difference is how the DB-name validator compares the connection's
-reported database name against the queue's configured catalog — covered in
-[Database-Name Comparison Semantics](#database-name-comparison-semantics).
+identically. The only behavioral difference is in how the DB-name validator compares the
+connection's reported database against the queue's configured catalog. That difference is covered
+in [Database-Name Comparison Semantics](#database-name-comparison-semantics).
 
 ## Reference
 
 ### Lifecycle Contract
 
-The caller owns the connection and transaction for their entire lifetime. The producer participates
-as a guest:
+The caller owns the connection and transaction. The producer does not manage them:
 
-- The producer **never** calls `transaction.Commit()`, `transaction.Rollback()`, `transaction.Dispose()`, `conn.Close()`,
-  or `conn.Dispose()`.
-- The producer performs its queue INSERTs (message body, metadata, status) using the connection
-  and transaction you supply via `transaction.Connection` and the `transaction` reference directly. It uses no other
-  connection.
-- `IConnectionHolder` and `IConnectionHolderFactory` — the internal machinery that manages
-  owned connections on the normal send path — are bypassed entirely on the caller-transaction path.
-- After `Send` returns, the transaction is still open. You decide whether to commit or roll back.
-- If you roll back after a successful `Send`, the queue row is rolled back too. No message is
-  delivered. This is the guarantee the pattern provides.
-- ADO.NET transactions are not thread-safe. Do not call `Send(msg, transaction)` concurrently with your
-  own writes on the same transaction from another thread. This matches the standard ADO.NET
-  threading contract.
+- The producer **never** calls `transaction.Commit()`, `transaction.Rollback()`,
+  `transaction.Dispose()`, `conn.Close()`, or `conn.Dispose()`.
+- All queue INSERTs (message body, metadata, status) run on the supplied `transaction` and its
+  `transaction.Connection`. The producer opens no other connection.
+- The internal `IConnectionHolder` machinery used on the standard send path is bypassed on the
+  caller-transaction path.
+- After `Send` returns, the transaction is still open. Commit or roll back when you are ready.
+- A rollback after a successful `Send` rolls back the queue row too, so no message is delivered.
+  That is the guarantee.
+- ADO.NET transactions are not thread-safe. Do not call `Send(msg, transaction)` concurrently with
+  writes on the same transaction from another thread. Same rule as the rest of ADO.NET.
 
 See PROJECT.md §Ownership & Threading Contract for the authoritative contract language.
 
@@ -152,8 +148,8 @@ See PROJECT.md §Functional Implementation and `IRetrySkippable.cs` for implemen
 ### Schema Deployment Prerequisite
 
 Queue tables must exist in your database before the first `Send` on the caller-transaction path.
-The outbox path does not auto-create tables — DDL inside the caller's transaction is the wrong
-contract for this pattern (see PROJECT.md §Non-Goals).
+The outbox path does not auto-create tables. Running DDL inside the caller's transaction would
+be the wrong contract for this pattern (see PROJECT.md §Non-Goals).
 
 Deploy the schema once at application startup or as part of your database migration:
 
@@ -177,9 +173,9 @@ that retrieves the name from the open connection:
 | SqlServer  | `SqlServerExternalDbNameExtractor`  | `Ordinal`      |
 | PostgreSQL | `PostgreSqlExternalDbNameExtractor` | `Ordinal`      |
 
-Both extractors return `connection.Database` verbatim — no `ToUpperInvariant`, no normalization.
-The comparison is always `StringComparison.Ordinal` (byte-for-byte). Configure the `Database=`
-key in your connection string with the exact case as the catalog name in your server.
+Both extractors return `connection.Database` verbatim, with no `ToUpperInvariant` or other
+normalization. The comparison is `StringComparison.Ordinal` (byte-for-byte). Configure the
+`Database=` key in your connection string with the exact case as the catalog name on the server.
 
 For SqlServer, `SqlConnection.Database` after open returns the canonical name from
 `sys.databases`, so the case you used when creating the database is what the extractor sees.
@@ -195,6 +191,6 @@ The exception message includes both the connection's reported name and the queue
   transports implements `IRelationalProducerQueue<T>` and the `is` capability cast succeeds.
 
 - **Not supported:** Memory, Redis, LiteDb, SQLite. The producer instances returned by these
-  transports do not implement `IRelationalProducerQueue<T>`. The `is` cast returns false and
-  no `NotSupportedException` is thrown — the interface is simply absent, so misconfigured
-  callers fail at the cast rather than at the first `Send`.
+  transports do not implement `IRelationalProducerQueue<T>`. The `is` cast returns false; no
+  `NotSupportedException` is thrown. The interface is simply absent, so a misconfigured caller
+  fails at the cast rather than at the first `Send`.


### PR DESCRIPTION
## Summary

Two related XML-doc fixes on the outbox public surface, both surfaced during post-merge follow-up on the outbox milestone (PR #138).

### ISSUE-041 — `IRelationalProducerQueue<T>` XML doc hyperlink

The reference to `docs/outbox-pattern.md` was a plain-text `<c>` code-span:
```xml
<!-- before -->
See <c>docs/outbox-pattern.md</c> for the full lifecycle contract (Phase 7).
```

Now uses `<see href>` with the stable master URL (available now that PR #138 is merged):
```xml
<!-- after -->
See <see href="https://github.com/blehnen/DotNetWorkQueue/blob/master/docs/outbox-pattern.md">docs/outbox-pattern.md</see> for the full lifecycle contract.
```

(Also dropped the internal `(Phase 7)` shorthand — same lesson the Phase 7 simplifier flagged on `docs/outbox-pattern.md` line 197.)

### ISSUE-039 (code half) — Stale "SqlServer uses OrdinalIgnoreCase" XML docs

Three XML doc summaries claimed:
- `IExternalDbNameExtractor`: "SqlServer uses case-insensitive comparison (`StringComparer.OrdinalIgnoreCase`)"
- `ExternalTransactionValidator`: "per-provider case semantics are encoded by the extractor's normalization"
- `SqlServerExternalDbNameExtractor.remarks`: detailed history of the asymmetric design

These were true under the **original** asymmetric design, but became incorrect after the Phase 3 extractor pass-through fix (commit `994e1404` in PR #138):
- Both extractors are now pass-through (return `connection.Database` verbatim).
- `ExternalTransactionValidator.Validate()` compares with `StringComparison.Ordinal` (line 90) — already true; unchanged.
- **Net effect:** both transports now use case-sensitive, byte-verbatim comparison.

Updated all three XML doc summaries to reflect the actual behavior. The `SqlServerExternalDbNameExtractor.remarks` history paragraph was replaced with operational guidance ("configure `Database=<name>` with the exact case as the actual SqlServer catalog").

`docs/outbox-pattern.md` already correctly describes the Ordinal-on-both-sides behavior (Phase 7 builder caught this during authoring); only the XML doc surface needed alignment.

## Test plan

- [x] Per-project Release `-p:CI=true` build clean (0 errors, 0 CS1591) on both `Transport.RelationalDatabase` and `Transport.SqlServer`
- [x] No logic changes; XML doc text only
- [ ] Jenkins full matrix green (CI will run)

## Closes

- ISSUE-041 (XML doc hyperlink)
- ISSUE-039 partial — the code-side XML docs. PROJECT.md text update remains tracked (it's a Shipyard tracking artifact, lower priority than user-facing XML docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Clarified database-name comparison behavior, emphasizing that catalog names must match exactly with case-sensitive comparison.
  * Enhanced outbox pattern documentation with improved explanations of transactional contracts and connection-string configuration safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blehnen/DotNetWorkQueue/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->