### PR TITLE
ci: serialize Jenkinsfile runs via lockable-resource

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,17 @@
 pipeline {
     agent none
 
+    // Serialize all Jenkinsfile runs across the entire repository — only one
+    // pipeline (PR, master, or any branch) executes at a time. The 14-stage
+    // parallel matrix consumes a large slice of the agent pool per run; without
+    // this lock, two concurrent PRs can saturate it. Queued runs wait their
+    // turn rather than starve agents from each other. Lockable Resources plugin
+    // provides this — the named resource doesn't need to be pre-defined; it's
+    // created on first use.
+    options {
+        lock(resource: 'dotnetworkqueue-ci')
+    }
+
     environment {
         DOTNET_CLI_TELEMETRY_OPTOUT = '1'
         DOTNET_NOLOGO = '1'


### PR DESCRIPTION
## Why

Jenkins agent pool gets overloaded when multiple PRs run concurrently. Each Jenkinsfile run launches 14 parallel integration-test stages, so two concurrent runs demand 28 executor slots. The recent triple-PR situation (#143 + #145 + #146) tipped the pool.

## What this PR does

Adds a single `lock(resource: 'dotnetworkqueue-ci')` to the Jenkinsfile's `options` block. Uses the Lockable Resources plugin (already present in standard Jenkins installs). Effect: only ONE Jenkinsfile run executes anywhere in the repo at a time; second/third/etc. queue.

## Tradeoff

Serial queuing makes wall-clock time grow linearly with queue depth. With ~50-min builds, three queued PRs take ~2.5h end-to-end vs ~50min parallel. If that's too slow in practice, the follow-up upgrade is the "Throttle Concurrent Builds" plugin with `Max Total Concurrent Builds = 2` (lets 2 PRs run in parallel, third waits).

## Test plan

- [ ] Jenkins green on this PR
- [ ] After merge: observe that subsequent PRs queue rather than run in parallel
- [ ] If serialization is too slow, escalate to Throttle plugin (separate PR)

## Note

The PR itself ironically triggers one more concurrent build on top of the current queue (#143, #145). After merge, the throttle takes effect for all future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)