### PR TITLE
ci: publish test results to Jenkins UI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,50 +28,62 @@ pipeline {
                 sh '''
                     dotnet test "Source/DotNetWorkQueue.Tests/DotNetWorkQueue.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-core
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-core \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/DotNetWorkQueue.Transport.RelationalDatabase.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-relational
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-relational \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Transport.SqlServer.Tests/DotNetWorkQueue.Transport.SqlServer.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-sqlserver
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-sqlserver \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/DotNetWorkQueue.Transport.PostgreSQL.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-postgresql
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-postgresql \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Transport.Redis.Tests/DotNetWorkQueue.Transport.Redis.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-redis
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-redis \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Transport.SQLite.Tests/DotNetWorkQueue.Transport.SQLite.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-sqlite
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-sqlite \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Transport.LiteDb.Tests/DotNetWorkQueue.Transport.LiteDb.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-litedb
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-litedb \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Transport.Memory.Tests/DotNetWorkQueue.Transport.Memory.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-memory
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-memory \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Dashboard.Api.Tests/DotNetWorkQueue.Dashboard.Api.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-dashboard-api
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-dashboard-api \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Dashboard.Client.Tests/DotNetWorkQueue.Dashboard.Client.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-dashboard-client
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-dashboard-client \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
 
                     dotnet test "Source/DotNetWorkQueue.Dashboard.Ui.Tests/DotNetWorkQueue.Dashboard.Ui.Tests.csproj" \
                         -f net10.0 --no-build -c Debug \
-                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-dashboard-ui
+                        --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/unit-dashboard-ui \
+                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
                 '''
 
                 stash includes: 'coverage/**/*.xml', name: 'unit-coverage'
+                stash includes: 'junit-results/**/*.xml', name: 'junit-unit', allowEmpty: true
             }
         }
 
@@ -81,17 +93,21 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 0, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        withCredentials([string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN')]) {
-                            sh 'echo "$SQLSERVER_CONN" > "Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/bin/Debug/net10.0/connectionstring.txt"'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            withCredentials([string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN')]) {
+                                sh 'echo "$SQLSERVER_CONN" > "Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/bin/Debug/net10.0/connectionstring.txt"'
+                            }
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/DotNetWorkQueue.Transport.SqlServer.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-sqlserver \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
+                                    -- --retry-failed-tests 1
+                            '''
                         }
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/DotNetWorkQueue.Transport.SqlServer.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-sqlserver \
-                                -- --retry-failed-tests 1
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-sqlserver'
+                        stash includes: 'coverage/**/*.xml', name: 'cov-sqlserver', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-sqlserver', allowEmpty: true
                     }
                 }
 
@@ -99,17 +115,21 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 5, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        withCredentials([string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN')]) {
-                            sh 'echo "$SQLSERVER_CONN" > "Source/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            withCredentials([string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN')]) {
+                                sh 'echo "$SQLSERVER_CONN" > "Source/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
+                            }
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-sqlserver-linq \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
+                                    -- --retry-failed-tests 1
+                            '''
                         }
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-sqlserver-linq \
-                                -- --retry-failed-tests 1
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-sqlserver-linq'
+                        stash includes: 'coverage/**/*.xml', name: 'cov-sqlserver-linq', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-sqlserver-linq', allowEmpty: true
                     }
                 }
 
@@ -117,17 +137,21 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 10, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        withCredentials([string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN')]) {
-                            sh 'echo "$POSTGRESQL_CONN" > "Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            withCredentials([string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN')]) {
+                                sh 'echo "$POSTGRESQL_CONN" > "Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
+                            }
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-postgresql \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
+                                    -- --retry-failed-tests 1
+                            '''
                         }
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-postgresql \
-                                -- --retry-failed-tests 1
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-postgresql'
+                        stash includes: 'coverage/**/*.xml', name: 'cov-postgresql', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-postgresql', allowEmpty: true
                     }
                 }
 
@@ -135,17 +159,21 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 15, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        withCredentials([string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN')]) {
-                            sh 'echo "$POSTGRESQL_CONN" > "Source/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            withCredentials([string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN')]) {
+                                sh 'echo "$POSTGRESQL_CONN" > "Source/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
+                            }
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-postgresql-linq \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
+                                    -- --retry-failed-tests 1
+                            '''
                         }
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-postgresql-linq \
-                                -- --retry-failed-tests 1
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-postgresql-linq'
+                        stash includes: 'coverage/**/*.xml', name: 'cov-postgresql-linq', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-postgresql-linq', allowEmpty: true
                     }
                 }
 
@@ -153,17 +181,21 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 20, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        withCredentials([string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')]) {
-                            sh 'echo "$REDIS_CONN" > "Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/bin/Debug/net10.0/connectionstring.txt"'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            withCredentials([string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')]) {
+                                sh 'echo "$REDIS_CONN" > "Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/bin/Debug/net10.0/connectionstring.txt"'
+                            }
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/DotNetWorkQueue.Transport.Redis.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-redis \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
+                                    -- --retry-failed-tests 1
+                            '''
                         }
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/DotNetWorkQueue.Transport.Redis.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-redis \
-                                -- --retry-failed-tests 1
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-redis'
+                        stash includes: 'coverage/**/*.xml', name: 'cov-redis', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-redis', allowEmpty: true
                     }
                 }
 
@@ -171,17 +203,21 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 25, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        withCredentials([string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')]) {
-                            sh 'echo "$REDIS_CONN" > "Source/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            withCredentials([string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')]) {
+                                sh 'echo "$REDIS_CONN" > "Source/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
+                            }
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-redis-linq \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
+                                    -- --retry-failed-tests 1
+                            '''
                         }
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-redis-linq \
-                                -- --retry-failed-tests 1
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-redis-linq'
+                        stash includes: 'coverage/**/*.xml', name: 'cov-redis-linq', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-redis-linq', allowEmpty: true
                     }
                 }
 
@@ -189,13 +225,17 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 30, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-sqlite
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-sqlite'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-sqlite \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+                            '''
+                        }
+                        stash includes: 'coverage/**/*.xml', name: 'cov-sqlite', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-sqlite', allowEmpty: true
                     }
                 }
 
@@ -203,13 +243,17 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 35, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-sqlite-linq
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-sqlite-linq'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-sqlite-linq \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+                            '''
+                        }
+                        stash includes: 'coverage/**/*.xml', name: 'cov-sqlite-linq', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-sqlite-linq', allowEmpty: true
                     }
                 }
 
@@ -217,13 +261,17 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 40, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/DotNetWorkQueue.Transport.LiteDb.IntegrationTests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-litedb
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-litedb'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/DotNetWorkQueue.Transport.LiteDb.IntegrationTests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-litedb \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+                            '''
+                        }
+                        stash includes: 'coverage/**/*.xml', name: 'cov-litedb', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-litedb', allowEmpty: true
                     }
                 }
 
@@ -231,13 +279,17 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 45, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.LiteDB.Linq.Integration.Tests/DotNetWorkQueue.Transport.LiteDb.Linq.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-litedb-linq
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-litedb-linq'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.LiteDB.Linq.Integration.Tests/DotNetWorkQueue.Transport.LiteDb.Linq.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-litedb-linq \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+                            '''
+                        }
+                        stash includes: 'coverage/**/*.xml', name: 'cov-litedb-linq', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-litedb-linq', allowEmpty: true
                     }
                 }
 
@@ -245,13 +297,17 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 50, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/DotNetWorkQueue.Transport.Memory.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-memory
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-memory'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/DotNetWorkQueue.Transport.Memory.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-memory \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+                            '''
+                        }
+                        stash includes: 'coverage/**/*.xml', name: 'cov-memory', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-memory', allowEmpty: true
                     }
                 }
 
@@ -259,13 +315,17 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 55, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-memory-linq
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-memory-linq'
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-memory-linq \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+                            '''
+                        }
+                        stash includes: 'coverage/**/*.xml', name: 'cov-memory-linq', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-memory-linq', allowEmpty: true
                     }
                 }
 
@@ -273,24 +333,28 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 60, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        withCredentials([
-                            string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN'),
-                            string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN'),
-                            string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')
-                        ]) {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            withCredentials([
+                                string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN'),
+                                string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN'),
+                                string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')
+                            ]) {
+                                sh '''
+                                    echo "$SQLSERVER_CONN" > "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"
+                                    echo "$POSTGRESQL_CONN" > "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/bin/Debug/net10.0/connectionstring-postgresql.txt"
+                                    echo "$REDIS_CONN" > "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/bin/Debug/net10.0/connectionstring-redis.txt"
+                                '''
+                            }
                             sh '''
-                                echo "$SQLSERVER_CONN" > "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"
-                                echo "$POSTGRESQL_CONN" > "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/bin/Debug/net10.0/connectionstring-postgresql.txt"
-                                echo "$REDIS_CONN" > "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/bin/Debug/net10.0/connectionstring-redis.txt"
+                                dotnet test "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/DotNetWorkQueue.Dashboard.Api.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-dashboard \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
                             '''
                         }
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/DotNetWorkQueue.Dashboard.Api.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug \
-                                --settings Source/coverage.runsettings --collect:"XPlat Code Coverage" --results-directory coverage/int-dashboard
-                        '''
-                        stash includes: 'coverage/**/*.xml', name: 'cov-dashboard'
+                        stash includes: 'coverage/**/*.xml', name: 'cov-dashboard', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-dashboard', allowEmpty: true
                     }
                 }
 
@@ -298,11 +362,15 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 65, unit: 'SECONDS')
-                        sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
-                        sh '''
-                            dotnet test "Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests.csproj" \
-                                -f net10.0 -c Debug
-                        '''
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+                            '''
+                        }
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-taskscheduler', allowEmpty: true
                     }
                 }
 
@@ -315,18 +383,22 @@ pipeline {
                     agent { label 'docker' }
                     steps {
                         sleep(time: 70, unit: 'SECONDS')
-                        sh '''
-                            dotnet build "Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.csproj" -c Debug
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh '''
+                                dotnet build "Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.csproj" -c Debug
 
-                            # Install Playwright browsers (Chromium only) + apt system deps.
-                            dotnet exec \
-                                --runtimeconfig Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/bin/Debug/net10.0/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.runtimeconfig.json \
-                                Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/bin/Debug/net10.0/Microsoft.Playwright.dll \
-                                install --with-deps chromium
+                                # Install Playwright browsers (Chromium only) + apt system deps.
+                                dotnet exec \
+                                    --runtimeconfig Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/bin/Debug/net10.0/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.runtimeconfig.json \
+                                    Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/bin/Debug/net10.0/Microsoft.Playwright.dll \
+                                    install --with-deps chromium
 
-                            dotnet test "Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.csproj" \
-                                --no-build -c Debug
-                        '''
+                                dotnet test "Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.csproj" \
+                                    --no-build -c Debug \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+                            '''
+                        }
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-e2e', allowEmpty: true
                     }
                 }
             }
@@ -335,20 +407,21 @@ pipeline {
         stage('Coverage Report') {
             agent { label 'docker' }
             steps {
-                unstash 'unit-coverage'
-                unstash 'cov-sqlserver'
-                unstash 'cov-sqlserver-linq'
-                unstash 'cov-postgresql'
-                unstash 'cov-postgresql-linq'
-                unstash 'cov-redis'
-                unstash 'cov-redis-linq'
-                unstash 'cov-sqlite'
-                unstash 'cov-sqlite-linq'
-                unstash 'cov-litedb'
-                unstash 'cov-litedb-linq'
-                unstash 'cov-memory'
-                unstash 'cov-memory-linq'
-                unstash 'cov-dashboard'
+                script {
+                    def covStashes = [
+                        'unit-coverage',
+                        'cov-sqlserver', 'cov-sqlserver-linq',
+                        'cov-postgresql', 'cov-postgresql-linq',
+                        'cov-redis', 'cov-redis-linq',
+                        'cov-sqlite', 'cov-sqlite-linq',
+                        'cov-litedb', 'cov-litedb-linq',
+                        'cov-memory', 'cov-memory-linq',
+                        'cov-dashboard'
+                    ]
+                    covStashes.each { s ->
+                        try { unstash s } catch (Exception e) { echo "Coverage unstash '${s}' skipped: ${e.message}" }
+                    }
+                }
 
                 withCredentials([string(credentialsId: 'reportgenerator-license', variable: 'REPORTGENERATOR_LICENSE')]) {
                     sh '''
@@ -365,27 +438,75 @@ pipeline {
                     '''
                 }
 
-                withCredentials([string(credentialsId: 'codecov-token', variable: 'CODECOV_TOKEN')]) {
-                    sh '''
-                        curl -Os https://cli.codecov.io/latest/linux/codecov
-                        chmod +x codecov
-                        ./codecov upload-process --file coverage/report/Cobertura.xml --token "$CODECOV_TOKEN" || echo "Codecov upload failed (non-fatal)"
-                    '''
-                }
-
                 publishHTML(target: [
-                    allowMissing: false,
+                    allowMissing: true,
                     alwaysLinkToLastBuild: true,
                     keepAll: true,
                     reportDir: 'coverage/report',
                     reportFiles: 'index.html',
                     reportName: 'Code Coverage Report'
                 ])
+
+                stash includes: 'coverage/report/Cobertura.xml', name: 'merged-cobertura', allowEmpty: true
+            }
+        }
+
+        stage('Codecov Upload') {
+            // Only upload coverage when the build is clean. A failed stage above
+            // marks currentBuild.currentResult as FAILURE, which skips this step
+            // while still letting the local HTML report (above) publish for the
+            // failed build's coverage view.
+            when {
+                expression { currentBuild.currentResult == 'SUCCESS' }
+            }
+            agent { label 'docker' }
+            steps {
+                script {
+                    try { unstash 'merged-cobertura' } catch (Exception e) { echo "merged-cobertura unstash skipped: ${e.message}" }
+                }
+                withCredentials([string(credentialsId: 'codecov-token', variable: 'CODECOV_TOKEN')]) {
+                    sh '''
+                        if [ ! -f coverage/report/Cobertura.xml ]; then
+                            echo "No merged Cobertura report found; skipping codecov upload."
+                            exit 0
+                        fi
+                        curl -Os https://cli.codecov.io/latest/linux/codecov
+                        chmod +x codecov
+                        ./codecov upload-process --file coverage/report/Cobertura.xml --token "$CODECOV_TOKEN" || echo "Codecov upload failed (non-fatal)"
+                    '''
+                }
             }
         }
     }
 
     post {
+        always {
+            // Pipeline-level post action — agent is `none`, so wrap in a node.
+            // Unstash each per-stage junit bundle inside its own try/catch so an
+            // early-stage failure that never produced a stash doesn't break the
+            // publish for the rest. The junit step itself is tolerant of empty
+            // results via allowEmptyResults.
+            node('docker') {
+                script {
+                    def junitStashes = [
+                        'junit-unit',
+                        'junit-sqlserver', 'junit-sqlserver-linq',
+                        'junit-postgresql', 'junit-postgresql-linq',
+                        'junit-redis', 'junit-redis-linq',
+                        'junit-sqlite', 'junit-sqlite-linq',
+                        'junit-litedb', 'junit-litedb-linq',
+                        'junit-memory', 'junit-memory-linq',
+                        'junit-dashboard',
+                        'junit-taskscheduler',
+                        'junit-e2e'
+                    ]
+                    junitStashes.each { s ->
+                        try { unstash s } catch (Exception e) { echo "JUnit unstash '${s}' skipped: ${e.message}" }
+                    }
+                }
+                junit allowEmptyResults: true, testResults: 'junit-results/**/*.xml'
+            }
+        }
         failure {
             echo 'Pipeline failed. Check stage logs for details.'
         }

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -13,4 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
+
+  <!-- Test-project-only: JUnit XML logger so Jenkins can publish test results.
+       Scoped via project-name suffix so non-test projects don't pick up the dep. -->
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
+    <PackageReference Include="JunitXml.TestLogger" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -57,6 +57,7 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.54.0" />
     <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.54.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="JunitXml.TestLogger" Version="8.0.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
     <PackageVersion Include="Tynamix.ObjectFiller" Version="1.5.9" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

- Add `JunitXml.TestLogger` 8.0.0 to `Directory.Packages.props` and reference it from `Source/Directory.Build.props` under a `$(MSBuildProjectName.EndsWith('Tests'))` condition — so only test projects pick up the dep.
- Add `--logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"` to every `dotnet test` invocation in the Jenkinsfile. `{assembly}.{framework}` placeholders make filenames per-assembly so stages writing into a shared workspace dir don't collide.
- Stash `junit-results/**/*.xml` from every stage (including TaskScheduler Distributed and Dashboard UI E2E, which previously stashed nothing) with a per-stage name (`junit-sqlserver`, `junit-e2e`, etc.).
- Add a pipeline-level `post { always { node('docker') { ... } } }` that unstashes each junit bundle inside its own `try/catch` (so an early-stage failure that never produced a stash doesn't break publish for the rest) and calls `junit allowEmptyResults: true, testResults: 'junit-results/**/*.xml'`.
- Wrap each integration-test parallel branch in `catchError(buildResult: 'FAILURE', stageResult: 'FAILURE')` so a single failing transport stage no longer aborts subsequent stages — Coverage Report and the JUnit publish then still run.
- Split the Codecov upload out of `Coverage Report` into its own `Codecov Upload` stage with `when { expression { currentBuild.currentResult == 'SUCCESS' } }`. The local HTML report and `publishHTML` keep running unconditionally so coverage is visible on failed builds too.

## Verification

- `dotnet restore` on `DotNetWorkQueue.Transport.Memory.Tests` resolves `JunitXml.TestLogger/8.0.0` cleanly (only pre-existing OpenTelemetry NU1902 warning).
- `dotnet list package` confirms test project picks up `JunitXml.TestLogger 8.0.0` while non-test project (`DotNetWorkQueue.Transport.Memory`) does not — scoping condition works.
- Local smoke test: `dotnet test ... --logger "junit;LogFilePath=..."` against `Transport.Memory.Tests` produced a well-formed JUnit XML with 38 testcase entries.

## Test plan

- [ ] Jenkins build runs successfully on this PR and the "Test Results" link appears in the Jenkins build sidebar with all 14 stages' test counts aggregated.
- [ ] Verify codecov still receives upload on a successful master merge.
- [ ] Force-fail one integration stage (locally, by editing connection string) and confirm Coverage Report still runs and `junit` step still publishes results from the surviving stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with improved test result collection and reporting across unit, integration, and end-to-end tests.
  * Strengthened pipeline reliability with better error handling and test retry logic.
  * Improved code coverage tracking and reporting with automated upload integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blehnen/DotNetWorkQueue/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->