### PR TITLE
chore(deps): dependency refresh + OpenTelemetry CVE-2026-40894 fix (0.9.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.9.37 — 2026-05-28
+- CVE fix: `OpenTelemetry` 1.15.2 → 1.15.3 — clears the transitive `OpenTelemetry.Api` advisory CVE-2026-40894 / GHSA-g94r-2vxg-569j (NU1902, moderate: excessive memory allocation when parsing OpenTelemetry propagation headers)
+- Removed the now-obsolete `<WarningsNotAsErrors>NU1902</WarningsNotAsErrors>` from `Transport.SQLite.csproj` (added in 0.9.36 / ISSUE-032 solely to keep that advisory visible without failing the Release build)
+- Dependency refresh across `Directory.Packages.props` — shipping: `Microsoft.Data.SqlClient` 7.0.1, `Npgsql` 10.0.3, `SimpleInjector` 5.5.2, `StackExchange.Redis` 2.13.17, `MudBlazor` 9.5.0, `CronExpressionDescriptor` 2.48.0, `Cronos` 0.13.0, `Microsoft.SourceLink.GitHub` 10.0.300, and `Microsoft.Extensions.Caching.Memory` / `Microsoft.Extensions.Configuration.Binder` / `Microsoft.Extensions.Http` / `System.Diagnostics.DiagnosticSource` / `System.Security.Cryptography.Xml` → 10.0.8
+- Test tooling: `coverlet.collector` 8.0.1 → 10.0.1 (2-major), `MSTest.TestAdapter` / `MSTest.TestFramework` 4.2.3, `Microsoft.NET.Test.Sdk` 18.6.0, `Microsoft.Testing.Extensions.Retry` 2.2.3, `bunit` 2.7.2, `Microsoft.Playwright` / `Microsoft.Playwright.MSTest` 1.60.0, `Microsoft.AspNetCore.TestHost` (net10) 10.0.8
+- `FluentAssertions` intentionally held at 6.12.2 (last MIT-licensed release); `Microsoft.AspNetCore.TestHost` net8 target held on the 8.0.x line
+- No API surface changes
+
 ### 0.9.36 — 2026-05-16
 - Feature: transactional outbox pattern on SqlServer and PostgreSQL transports via opt-in `IRelationalProducerQueue<T>` capability cast; the caller supplies a `DbTransaction` and the queue INSERT joins the caller's business transaction (GitHub #138)
 - Memory, Redis, LiteDb, and SQLite are unchanged; callers that don't reach for the new interface see the same `IProducerQueue<T>` they always have

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <Version>0.9.36</Version>
+    <Version>0.9.37</Version>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <DebugType>portable</DebugType>

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -5,60 +5,60 @@
     <PackageVersion Include="GuerrillaNtp" Version="3.1.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="Polly.Core" Version="8.6.6" />
-    <PackageVersion Include="SimpleInjector" Version="5.5.1" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.6" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
-    <PackageVersion Include="Cronos" Version="0.12.0" />
-    <PackageVersion Include="CronExpressionDescriptor" Version="2.45.0" />
+    <PackageVersion Include="SimpleInjector" Version="5.5.2" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.8" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
+    <PackageVersion Include="Cronos" Version="0.13.0" />
+    <PackageVersion Include="CronExpressionDescriptor" Version="2.48.0" />
 
     <!-- TaskScheduling -->
     <PackageVersion Include="DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler" Version="0.5.0" />
 
     <!-- Build tooling -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
 
     <!-- Dashboard -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
-    <PackageVersion Include="MudBlazor" Version="9.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="MudBlazor" Version="9.5.0" />
 
     <!-- Transport: SQL Server -->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
 
     <!-- Transport: PostgreSQL -->
-    <PackageVersion Include="Npgsql" Version="10.0.2" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
 
     <!-- Transport: SQLite -->
     <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />
 
     <!-- Transport: Redis -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.12.14" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
 
     <!-- Transport: LiteDB -->
     <PackageVersion Include="LiteDB" Version="5.0.21" />
 
     <!-- Test Infrastructure -->
-    <PackageVersion Include="bunit" Version="2.5.3" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="bunit" Version="2.7.2" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="CompareNETObjects" Version="4.84.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="2.2.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.2.1" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.54.0" />
-    <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.54.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="2.2.3" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
+    <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.60.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="8.0.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="Tynamix.ObjectFiller" Version="1.5.9" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
@@ -68,6 +68,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/Source/DotNetWorkQueue.Transport.SQLite/DotNetWorkQueue.Transport.SQLite.csproj
+++ b/Source/DotNetWorkQueue.Transport.SQLite/DotNetWorkQueue.Transport.SQLite.csproj
@@ -29,7 +29,6 @@ https://github.com/blehnen/DotNetWorkQueue/blob/master/CHANGELOG.md </PackageRel
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<WarningsAsErrors />
-		<WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
@@ -37,14 +36,12 @@ https://github.com/blehnen/DotNetWorkQueue/blob/master/CHANGELOG.md </PackageRel
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<WarningsAsErrors />
-		<WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
 	</PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- **Security fix:** `OpenTelemetry` 1.15.2 → 1.15.3 clears the transitive `OpenTelemetry.Api` advisory **CVE-2026-40894 / GHSA-g94r-2vxg-569j** (NU1902, moderate — excessive memory allocation parsing OpenTelemetry propagation headers). With the advisory gone, the `<WarningsNotAsErrors>NU1902</WarningsNotAsErrors>` workaround added in 0.9.36 (ISSUE-032) is removed from `Transport.SQLite.csproj`.
- **Dependency refresh** across `Directory.Packages.props` — see CHANGELOG for the full list. Shipping highlights: SqlClient 7.0.1, Npgsql 10.0.3, SimpleInjector 5.5.2, StackExchange.Redis 2.13.17, MudBlazor 9.5.0, Cronos 0.13.0, SourceLink 10.0.300, and the Microsoft.Extensions/System.* set → 10.0.8.
- **Test tooling:** coverlet.collector 8.0.1 → 10.0.1 (2-major), MSTest 4.2.3, Test.Sdk 18.6.0, Retry 2.2.3, bunit 2.7.2, Playwright 1.60.0, TestHost(net10) 10.0.8.
- **Version** 0.9.36 → 0.9.37.

### Deliberately held back
- `FluentAssertions` stays at **6.12.2** (last MIT-licensed release).
- `Microsoft.AspNetCore.TestHost` net8 target stays on the **8.0.x** line (only the net10 target bumped).

## Local verification
- `dotnet restore` (full solution): **zero NU19xx** warnings.
- `dotnet build DotNetWorkQueueNoTests.sln -c Release -p:CI=true`: **0 warnings / 0 errors** under `TreatWarningsAsErrors` — confirms SQLite builds clean without the NU1902 suppression.
- `DotNetWorkQueue.Tests`: **905 passed / 0 failed**.

## Reviewer attention
- **MudBlazor 9.3.0 → 9.5.0** — Dashboard UI; covered by bUnit + Playwright stages.
- **Playwright 1.54.0 → 1.60.0** — the E2E agent may need `playwright install` for updated browser binaries.
- **Cronos 0.12.0 → 0.13.0** — core cron parsing; leans on the JobScheduler integration stage.

## Test plan
- [x] Jenkins: 14 integration stages green (full transport matrix incl. JobScheduler, Dashboard UI E2E)
- [x] CodeRabbit review
- [ ] After green: push `v0.9.37` tag to trigger `publish.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.9.37

* **Chores**
  * Version updated to 0.9.37
  * Security patch applied to OpenTelemetry (1.15.2 → 1.15.3) addressing CVE-2026-40894
  * Refreshed dependencies across core libraries, tooling, and test infrastructure
  * Removed obsolete build configuration suppression
  * No API surface changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blehnen/DotNetWorkQueue/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->