### PR TITLE
Release 0.9.38 — Npgsql 10.x + SQLite admin Count fixes (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.9.38 — 2026-06-03
+- Fix: `IAdminApi.Count(connId, QueueStatusAdmin.*)` on the PostgreSQL transport threw `InvalidCastException` under Npgsql 10.x — the shared relational `GetQueueCountQueryPrepareHandler` bound the raw `QueueStatusAdmin` enum to an `Int32` parameter, which Npgsql 10.x's stricter writer rejects (pre-10.x silently coerced it). Now casts the enum to `int` (GitHub #155)
+- Fix: the same status-filtered admin `Count` path threw `SQLiteException: unknown error — Insufficient parameters supplied to the command` on the SQLite transport — the parameter was bound as `@Status` while the SQL placeholder is lowercase `@status`, and System.Data.SQLite binds parameter names case-sensitively (Npgsql and Microsoft.Data.SqlClient fold case, so PG and SQL Server were unaffected). Parameter name now matches the SQL casing (GitHub #155)
+- Test: deterministic status-filtered `Count` coverage across PostgreSQL, SQL Server, and SQLite (the path was previously dead behind a `runTime > 10` guard that never ran, which is why both bugs shipped) plus a unit guard on `GetQueueCountQueryPrepareHandler`
+- No API surface changes
+
 ### 0.9.37 — 2026-05-28
 - CVE fix: `OpenTelemetry` 1.15.2 → 1.15.3 — clears the transitive `OpenTelemetry.Api` advisory CVE-2026-40894 / GHSA-g94r-2vxg-569j (NU1902, moderate: excessive memory allocation when parsing OpenTelemetry propagation headers)
 - Removed the now-obsolete `<WarningsNotAsErrors>NU1902</WarningsNotAsErrors>` from `Transport.SQLite.csproj` (added in 0.9.36 / ISSUE-032 solely to keep that advisory visible without failing the Release build)

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <Version>0.9.37</Version>
+    <Version>0.9.38</Version>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
Release **0.9.38**. Bumps `Source/Directory.Build.props` `<Version>` and adds the CHANGELOG entry.

## What ships
Fixes for GitHub #155 (merged via PR #156), packaged for NuGet so the samples can move off the local build:

- **Npgsql 10.x:** `IAdminApi.Count(connId, QueueStatusAdmin.*)` no longer throws `InvalidCastException` — the shared relational prepare handler now casts the `QueueStatusAdmin` enum to `int` before binding it to the `Int32` parameter.
- **SQLite:** the same status-filtered `Count` path no longer throws `Insufficient parameters supplied to the command` — the parameter name now matches the lowercase `@status` SQL placeholder (System.Data.SQLite binds parameter names case-sensitively).
- **Coverage:** deterministic status-filtered `Count` tests across PostgreSQL, SQL Server, and SQLite (the path was previously dead) + a unit guard on `GetQueueCountQueryPrepareHandler`.

No API surface changes.

## Release process
After this merges and the master Jenkins build is green, push the `v0.9.38` tag to trigger `publish.yml` (verify-gate → build-pack → publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queue status counting issues with PostgreSQL and SQLite database transports, improving reliability in production environments.
  * Resolved database compatibility issues that could cause errors during queue status administration operations.

* **Tests**
  * Added comprehensive test coverage for queue status counting functionality across PostgreSQL, SQL Server, and SQLite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->