### PR TITLE
docs(readme): reword Docker single-container note

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [Wiki](https://github.com/blehnen/DotNetWorkQueue/wiki) for in-depth doc
 
 **Docker**
 
-A pre-built Docker image runs both the Dashboard UI and API in a single container — no separate API container needed:
+A pre-built Docker image runs both the Dashboard UI and API in one container, so you don't have to run the API separately:
 
 ```bash
 docker pull blehnen74/dotnetworkqueue-dashboard:latest


### PR DESCRIPTION
Small README wording fix, separate from the 0.9.38 release PR (#157).

Replaces a tailing-negation fragment in the Docker section:

- before: `...in a single container — no separate API container needed:`
- after: `...in one container, so you don't have to run the API separately:`

No content or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker section to clarify that the pre-built dashboard image runs both the UI and API in a single container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->