### PR TITLE
chore(deps): dependency refresh + bump to 0.9.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 0.9.39 — 2026-06-23
-- Dependency refresh across `Directory.Packages.props` (notably `StackExchange.Redis` 2.13.17 → 3.0.0); `FluentAssertions` held at 6.12.2 (last MIT-licensed release). No API surface changes
+- Dependency refresh across `Directory.Packages.props` (OpenTelemetry, Polly.Core, Swashbuckle.AspNetCore, Microsoft.Extensions.*, test tooling). `StackExchange.Redis` held at 2.13.17 and `FluentAssertions` at 6.12.2 (last MIT-licensed release). No API surface changes
 
 ### 0.9.38 — 2026-06-03
 - Fix: `IAdminApi.Count(connId, QueueStatusAdmin.*)` on the PostgreSQL transport threw `InvalidCastException` under Npgsql 10.x — the shared relational `GetQueueCountQueryPrepareHandler` bound the raw `QueueStatusAdmin` enum to an `Int32` parameter, which Npgsql 10.x's stricter writer rejects (pre-10.x silently coerced it). Now casts the enum to `int` (GitHub #155)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.9.39 — 2026-06-23
+- Dependency refresh across `Directory.Packages.props` (notably `StackExchange.Redis` 2.13.17 → 3.0.0); `FluentAssertions` held at 6.12.2 (last MIT-licensed release). No API surface changes
+
 ### 0.9.38 — 2026-06-03
 - Fix: `IAdminApi.Count(connId, QueueStatusAdmin.*)` on the PostgreSQL transport threw `InvalidCastException` under Npgsql 10.x — the shared relational `GetQueueCountQueryPrepareHandler` bound the raw `QueueStatusAdmin` enum to an `Int32` parameter, which Npgsql 10.x's stricter writer rejects (pre-10.x silently coerced it). Now casts the enum to `int` (GitHub #155)
 - Fix: the same status-filtered admin `Count` path threw `SQLiteException: unknown error — Insufficient parameters supplied to the command` on the SQLite transport — the parameter was bound as `@Status` while the SQL placeholder is lowercase `@status`, and System.Data.SQLite binds parameter names case-sensitively (Npgsql and Microsoft.Data.SqlClient fold case, so PG and SQL Server were unaffected). Parameter name now matches the SQL casing (GitHub #155)

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <Version>0.9.38</Version>
+    <Version>0.9.39</Version>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <DebugType>portable</DebugType>

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -5,13 +5,13 @@
     <PackageVersion Include="GuerrillaNtp" Version="3.1.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="Polly.Core" Version="8.6.6" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="Polly.Core" Version="8.7.0" />
     <PackageVersion Include="SimpleInjector" Version="5.5.2" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.8" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
-    <PackageVersion Include="CronExpressionDescriptor" Version="2.48.0" />
+    <PackageVersion Include="CronExpressionDescriptor" Version="2.50.0" />
 
     <!-- TaskScheduling -->
     <PackageVersion Include="DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler" Version="0.5.0" />
@@ -20,9 +20,9 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
 
     <!-- Dashboard -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageVersion Include="MudBlazor" Version="9.5.0" />
 
     <!-- Transport: SQL Server -->
@@ -35,10 +35,10 @@
     <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />
 
     <!-- Transport: Redis -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.0.0" />
 
     <!-- Transport: LiteDB -->
     <PackageVersion Include="LiteDB" Version="5.0.21" />
@@ -50,7 +50,7 @@
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="CompareNETObjects" Version="4.84.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="2.2.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.2.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.2.3" />
@@ -58,16 +58,16 @@
     <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.60.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="8.0.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="Tynamix.ObjectFiller" Version="1.5.9" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <!-- Microsoft.AspNetCore.TestHost: TFM-conditional versions -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.28" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
-    <PackageVersion Include="StackExchange.Redis" Version="3.0.0" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
 
     <!-- Transport: LiteDB -->
     <PackageVersion Include="LiteDB" Version="5.0.21" />


### PR DESCRIPTION
## Summary

Routine dependency refresh for the **0.9.39** release. Updates outdated NuGet packages in the central `Source/Directory.Packages.props`, bumps `<Version>` to `0.9.39`, and adds a one-line changelog entry. No API or behavior changes — versions only.

## Package updates

| Package | From | To | Notes |
|---|---|---|---|
| Swashbuckle.AspNetCore | 10.1.7 | 10.2.3 | |
| OpenTelemetry (+ OTLP exporter) | 1.15.3 | 1.16.0 | |
| Polly.Core | 8.6.6 | 8.7.0 | |
| CronExpressionDescriptor | 2.48.0 | 2.50.0 | |
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.7.0 | |
| Microsoft.Extensions.{Caching.Memory, Configuration.Binder, Http} | 10.0.8 | 10.0.9 | |
| System.Diagnostics.DiagnosticSource | 10.0.8 | 10.0.9 | |
| System.Security.Cryptography.Xml | 10.0.8 | 10.0.9 | |
| Microsoft.AspNetCore.TestHost (net10 / net8) | 10.0.8 / 8.0.26 | 10.0.9 / 8.0.28 | per-TFM lines held |

**Held back:**
- `StackExchange.Redis` stays at **2.13.17** — the 3.0.0 bump caused thread-pool-starvation timeouts on the synchronous Lua (EVAL/SCRIPT) path under concurrent load (intermittent 15s operation timeouts in the Redis integration suite). 3.x migration tracked in #161.
- `FluentAssertions` stays at **6.12.2** — last MIT-licensed release; replacement tracked in #159.

## Local verification

- `dotnet build Source/DotNetWorkQueueNoTests.sln -c Release -p:CI=true` → **0 warnings, 0 errors** (net10.0 + net8.0)
- `DotNetWorkQueue.Tests` → 905 passed
- `DotNetWorkQueue.Transport.Redis.Tests` (unit) → 187 passed
- In-memory integration (POCO + LINQ) → 57 + 20 passed

## History

The initial commit included `StackExchange.Redis` 3.0.0; Jenkins surfaced intermittent EVAL/SCRIPT timeouts (thread-pool starvation, not a connectivity issue — replies arrived within ~33ms but no worker thread was free before the 15s sync timeout). Reverted in `9f7733db`; see #161 for the proper 3.x migration (dedicated `SocketManager` / `SetMinThreads` / async Lua).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Released version 0.9.39 with refreshed dependency versions across core packages, dashboard components, Redis/transport components, and test tooling
  * Kept key pins consistent (e.g., StackExchange.Redis 2.13.17 and FluentAssertions 6.12.2)
  * No API surface changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->