### PR TITLE
Inbox held-transaction batch send: true multi-row insert (SQL Server + PostgreSQL) (#167)

### DIFF
--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Inbox/PostgreSqlInboxBatchSendTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Inbox/PostgreSqlInboxBatchSendTests.cs
@@ -97,6 +97,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Inbox
                     transaction.Rollback();
                 }
 
+                // Rollback is synchronous, so the first poll already observes 0 (no lag to wait out).
                 AssertQueueRowCount(qc, 0);
                 AssertBusinessRowCountStaysAt(ConnectionInfo.ConnectionString, businessTable, 0);
             }
@@ -157,13 +158,21 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Inbox
             {
                 try
                 {
+                    // The multi-row body insert succeeds; the per-message meta insert then hits the
+                    // dropped MetaData table and the batch handler throws. The held-transaction path
+                    // performs no table-existence pre-check, so the throw originates at the insert and
+                    // propagates out of Send (no swallow into per-message results).
                     producer.RelationalProducer.Send(BuildBatch(3), transaction);
                 }
                 catch
                 {
                     threw = true;
                 }
-                transaction.Rollback();
+                finally
+                {
+                    // Roll back defensively; never let a rollback error mask the assertion below.
+                    try { transaction.Rollback(); } catch { /* already in the error path */ }
+                }
             }
 
             Assert.IsTrue(threw, "Held-transaction batch send must throw on a DB failure, not swallow it.");

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Inbox/PostgreSqlInboxBatchSendTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Inbox/PostgreSqlInboxBatchSendTests.cs
@@ -1,0 +1,341 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Collections.Generic;
+using System.Data;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.Messages;
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using DotNetWorkQueue.Transport.RelationalDatabase;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Npgsql;
+
+namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Inbox
+{
+    /// <summary>
+    /// Integration tests for the PostgreSQL inbox held-transaction batch send (#167): a true
+    /// multi-row insert performed inside the caller's transaction. Proves commit/rollback
+    /// visibility, that the caller's connection is left open and usable, that a real DB failure
+    /// throws (rather than being swallowed into per-message results), one result id per message,
+    /// and that the unnest/RETURNING + ascending-sort id recovery preserves caller input order
+    /// across a multi-chunk batch inside a single external transaction.
+    /// </summary>
+    [TestClass]
+    public class PostgreSqlInboxBatchSendTests : PostgreSqlInboxIntegrationTestBase
+    {
+        [TestMethod]
+        public void SendBatch_Commit_AllRowsVisible()
+        {
+            const int batchSize = 5;
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+            var businessTable = NewBusinessTableName();
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            CreateBusinessTable(ConnectionInfo.ConnectionString, businessTable);
+            try
+            {
+                using var producer = CreateRelationalProducer(qc);
+                using var conn = new NpgsqlConnection(ConnectionInfo.ConnectionString);
+                conn.Open();
+
+                using (var transaction = conn.BeginTransaction())
+                {
+                    var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
+                    Assert.IsFalse(result.HasErrors, "batch send reported errors");
+                    for (var i = 0; i < batchSize; i++)
+                        InsertBusinessRowOnInboxTransaction(transaction, businessTable, i, $"row{i}");
+                    transaction.Commit();
+                }
+
+                AssertQueueRowCount(qc, batchSize);
+                AssertBusinessRowCountFromSeparateConnection(ConnectionInfo.ConnectionString, businessTable, batchSize);
+            }
+            finally
+            {
+                DropBusinessTable(ConnectionInfo.ConnectionString, businessTable);
+            }
+        }
+
+        [TestMethod]
+        public void SendBatch_Rollback_NoRowsVisible()
+        {
+            const int batchSize = 5;
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+            var businessTable = NewBusinessTableName();
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            CreateBusinessTable(ConnectionInfo.ConnectionString, businessTable);
+            try
+            {
+                using var producer = CreateRelationalProducer(qc);
+                using var conn = new NpgsqlConnection(ConnectionInfo.ConnectionString);
+                conn.Open();
+
+                using (var transaction = conn.BeginTransaction())
+                {
+                    var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
+                    Assert.IsFalse(result.HasErrors, "batch send reported errors");
+                    for (var i = 0; i < batchSize; i++)
+                        InsertBusinessRowOnInboxTransaction(transaction, businessTable, i, $"row{i}");
+                    transaction.Rollback();
+                }
+
+                AssertQueueRowCount(qc, 0);
+                AssertBusinessRowCountStaysAt(ConnectionInfo.ConnectionString, businessTable, 0);
+            }
+            finally
+            {
+                DropBusinessTable(ConnectionInfo.ConnectionString, businessTable);
+            }
+        }
+
+        [TestMethod]
+        public void SendBatch_ConnectionStillOpenAndUsable()
+        {
+            const int batchSize = 3;
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            using var producer = CreateRelationalProducer(qc);
+            using var conn = new NpgsqlConnection(ConnectionInfo.ConnectionString);
+            conn.Open();
+
+            using (var transaction = conn.BeginTransaction())
+            {
+                var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
+                Assert.IsFalse(result.HasErrors, "batch send reported errors");
+
+                Assert.AreEqual(ConnectionState.Open, conn.State, "caller connection must remain open");
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.Transaction = transaction;
+                    cmd.CommandText = "SELECT 1";
+                    Assert.AreEqual(1, (int)cmd.ExecuteScalar(), "connection must still be usable after send");
+                }
+
+                transaction.Commit();
+            }
+
+            AssertQueueRowCount(qc, batchSize);
+        }
+
+        [TestMethod]
+        public void SendBatch_ForcedFailure_Throws()
+        {
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            using var producer = CreateRelationalProducer(qc);
+
+            // Drop the MetaData table so the per-message meta insert inside the batch path fails with
+            // a real SQL error. The held-transaction path must propagate it (throw) rather than
+            // swallow it into per-message results — the caller owns the rollback.
+            DropMetaDataTable(qc);
+
+            using var conn = new NpgsqlConnection(ConnectionInfo.ConnectionString);
+            conn.Open();
+
+            var threw = false;
+            using (var transaction = conn.BeginTransaction())
+            {
+                try
+                {
+                    producer.RelationalProducer.Send(BuildBatch(3), transaction);
+                }
+                catch
+                {
+                    threw = true;
+                }
+                transaction.Rollback();
+            }
+
+            Assert.IsTrue(threw, "Held-transaction batch send must throw on a DB failure, not swallow it.");
+        }
+
+        [TestMethod]
+        public void SendBatch_ResultIds_OnePerMessage()
+        {
+            const int batchSize = 4;
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            using var producer = CreateRelationalProducer(qc);
+            using var conn = new NpgsqlConnection(ConnectionInfo.ConnectionString);
+            conn.Open();
+
+            using (var transaction = conn.BeginTransaction())
+            {
+                var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
+                Assert.IsFalse(result.HasErrors, "batch send reported errors");
+                Assert.AreEqual(batchSize, result.Count, "one result per message");
+
+                var ids = new HashSet<long>();
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.IsTrue(result[i].SentMessage.MessageId.HasValue, "each result must carry a message id");
+                    var id = (long)result[i].SentMessage.MessageId.Id.Value;
+                    Assert.IsTrue(id > 0, "message id must be a positive value");
+                    ids.Add(id);
+                }
+                Assert.AreEqual(batchSize, ids.Count, "message ids must be distinct");
+
+                transaction.Commit();
+            }
+
+            AssertQueueRowCount(qc, batchSize);
+        }
+
+        [TestMethod]
+        public void SendBatch_MultiChunk_IdsInInputOrder()
+        {
+            // Validates the unnest/RETURNING + ascending-sort id recovery across a MULTI-CHUNK batch
+            // inside one external transaction (the #162 → #167 ordering concern). BatchSize=2 with 5
+            // messages forces 3 chunks; recovered ids must be strictly increasing in caller input order
+            // (each chunk's bigserial ids are assigned in ORDER BY ord, and later chunks get higher ids).
+            const int batchSize = 5;
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+
+            using var queue = CreateQueueWithBatchSize(qc, batchSize: 2);
+            using var producer = CreateRelationalProducer(qc);
+            using var conn = new NpgsqlConnection(ConnectionInfo.ConnectionString);
+            conn.Open();
+
+            using (var transaction = conn.BeginTransaction())
+            {
+                var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
+                Assert.IsFalse(result.HasErrors, "batch send reported errors");
+                Assert.AreEqual(batchSize, result.Count, "one result per message");
+
+                long previous = 0;
+                for (var i = 0; i < result.Count; i++)
+                {
+                    var id = (long)result[i].SentMessage.MessageId.Id.Value;
+                    Assert.IsTrue(id > previous,
+                        $"recovered ids must be strictly increasing in input order across chunks (index {i}: {id} <= {previous})");
+                    previous = id;
+                }
+
+                transaction.Commit();
+            }
+
+            AssertQueueRowCount(qc, batchSize);
+        }
+
+        // ----- Producer resolution + capability cast (mirrors the outbox base) -----
+        private sealed class ProducerScope : System.IDisposable
+        {
+            public QueueContainer<PostgreSqlMessageQueueInit> Creator { get; init; }
+            public IProducerQueue<FakeMessage> Producer { get; init; }
+            public IRelationalProducerQueue<FakeMessage> RelationalProducer { get; init; }
+
+            public void Dispose()
+            {
+                Producer?.Dispose();
+                Creator?.Dispose();
+            }
+        }
+
+        private static ProducerScope CreateRelationalProducer(QueueConnection queueConnection)
+        {
+            var creator = new QueueContainer<PostgreSqlMessageQueueInit>();
+            var producer = creator.CreateProducer<FakeMessage>(queueConnection);
+            Assert.IsInstanceOfType(producer, typeof(IRelationalProducerQueue<FakeMessage>),
+                "PostgreSQL producer must implement IRelationalProducerQueue<T> (#167 inbox batch path)");
+            return new ProducerScope
+            {
+                Creator = creator,
+                Producer = producer,
+                RelationalProducer = (IRelationalProducerQueue<FakeMessage>)producer
+            };
+        }
+
+        // ----- Queue creation with an explicit BatchSize (for the multi-chunk ordering test) -----
+        private QueueScope CreateQueueWithBatchSize(QueueConnection queueConnection, int batchSize)
+        {
+            var queueCreator = new QueueCreationContainer<PostgreSqlMessageQueueInit>();
+            var oCreation = queueCreator.GetQueueCreation<PostgreSqlMessageQueueCreation>(queueConnection);
+            oCreation.Options.EnableStatus = false;
+            oCreation.Options.EnableStatusTable = false;
+            oCreation.Options.EnableHeartBeat = false;
+            oCreation.Options.EnableDelayedProcessing = false;
+            oCreation.Options.EnableMessageExpiration = false;
+            oCreation.Options.EnableHoldTransactionUntilMessageCommitted = true;
+            oCreation.Options.EnablePriority = false;
+            oCreation.Options.BatchSize = batchSize;
+
+            var result = oCreation.CreateQueue();
+            Assert.IsTrue(result.Success, result.ErrorMessage);
+
+            return new QueueScope
+            {
+                QueueCreator = queueCreator,
+                OCreation = oCreation,
+                Scope = oCreation.Scope
+            };
+        }
+
+        // ----- Batch builder -----
+        private static List<QueueMessage<FakeMessage, IAdditionalMessageData>> BuildBatch(int count)
+        {
+            var list = new List<QueueMessage<FakeMessage, IAdditionalMessageData>>(count);
+            for (var i = 0; i < count; i++)
+                list.Add(new QueueMessage<FakeMessage, IAdditionalMessageData>(
+                    GenerateMessage.Create<FakeMessage>(), null));
+            return list;
+        }
+
+        // ----- Queue MetaData row count (polling, NOT snapshot — CLAUDE.md lesson) -----
+        private static long CountQueueMessages(QueueConnection queueConnection)
+        {
+            var info = new SqlConnectionInformation(queueConnection);
+            var helper = new TableNameHelper(info);
+            using var conn = new NpgsqlConnection(queueConnection.Connection);
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT COUNT(*) FROM {helper.MetaDataName}";
+            return (long)cmd.ExecuteScalar();
+        }
+
+        private static void AssertQueueRowCount(QueueConnection queueConnection, long expected, int timeoutMs = 5000)
+        {
+            var deadline = System.DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            long actual = -1;
+            while (System.DateTime.UtcNow < deadline)
+            {
+                actual = CountQueueMessages(queueConnection);
+                if (actual == expected) return;
+                System.Threading.Thread.Sleep(100);
+            }
+            Assert.AreEqual(expected, actual,
+                $"Queue row count did not converge to {expected} within {timeoutMs}ms (last observed: {actual}).");
+        }
+
+        private static void DropMetaDataTable(QueueConnection queueConnection)
+        {
+            var info = new SqlConnectionInformation(queueConnection);
+            var helper = new TableNameHelper(info);
+            using var conn = new NpgsqlConnection(queueConnection.Connection);
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"DROP TABLE IF EXISTS {helper.MetaDataName}";
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Inbox/PostgreSqlInboxBatchSendTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Inbox/PostgreSqlInboxBatchSendTests.cs
@@ -250,12 +250,15 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Inbox
         // ----- Producer resolution + capability cast (mirrors the outbox base) -----
         private sealed class ProducerScope : System.IDisposable
         {
+            private int _disposed;
+
             public QueueContainer<PostgreSqlMessageQueueInit> Creator { get; init; }
             public IProducerQueue<FakeMessage> Producer { get; init; }
             public IRelationalProducerQueue<FakeMessage> RelationalProducer { get; init; }
 
             public void Dispose()
             {
+                if (System.Threading.Interlocked.Exchange(ref _disposed, 1) != 0) return;
                 Producer?.Dispose();
                 Creator?.Dispose();
             }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/PostgreSqlRelationalProducerQueueTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/PostgreSqlRelationalProducerQueueTests.cs
@@ -27,6 +27,7 @@ using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using Microsoft.Extensions.Logging;
@@ -51,12 +52,21 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             ICommandHandlerWithOutputAsync<SendMessageCommand, long> asyncHandler = null,
             ExternalTransactionValidator validator = null,
             ISentMessageFactory sentFactory = null,
-            IMessageFactory messageFactory = null)
+            IMessageFactory messageFactory = null,
+            ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages> syncBatchHandler = null,
+            ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages> asyncBatchHandler = null)
         {
             syncHandler ??= Substitute.For<ICommandHandlerWithOutput<SendMessageCommand, long>>();
             syncHandler.Handle(Arg.Any<SendMessageCommand>()).Returns(42L);
             asyncHandler ??= Substitute.For<ICommandHandlerWithOutputAsync<SendMessageCommand, long>>();
             asyncHandler.HandleAsync(Arg.Any<SendMessageCommand>()).Returns(Task.FromResult(42L));
+
+            syncBatchHandler ??= Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            syncBatchHandler.Handle(Arg.Any<SendMessageCommandBatch>())
+                .Returns(new QueueOutputMessages(new List<IQueueOutputMessage>()));
+            asyncBatchHandler ??= Substitute.For<ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages>>();
+            asyncBatchHandler.HandleAsync(Arg.Any<SendMessageCommandBatch>())
+                .Returns(Task.FromResult(new QueueOutputMessages(new List<IQueueOutputMessage>())));
 
             if (validator == null)
             {
@@ -95,7 +105,16 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
                 Substitute.For<ILogger>(),
                 generateHeaders,
                 addStandardHeaders,
-                syncHandler, asyncHandler, validator, sentFactory, messageFactory);
+                syncHandler, asyncHandler, syncBatchHandler, asyncBatchHandler,
+                validator, sentFactory, messageFactory);
+        }
+
+        private static List<QueueMessage<TestMessage, IAdditionalMessageData>> BuildBatch(int count)
+        {
+            var list = new List<QueueMessage<TestMessage, IAdditionalMessageData>>(count);
+            for (var i = 0; i < count; i++)
+                list.Add(new QueueMessage<TestMessage, IAdditionalMessageData>(new TestMessage(), null));
+            return list;
         }
 
         // Helper: build a non-NpgsqlTransaction DbTransaction for guard/validator tests.
@@ -203,6 +222,95 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             // Cast guard throws for the non-NpgsqlTransaction; validator already fired once.
             try { sut.Send(msgs, transaction); } catch (InvalidOperationException) { /* expected */ }
             extractor.Received(1).Extract(Arg.Any<DbConnection>());
+        }
+
+        // ----- Held-transaction batch dispatch (#167) -----
+        //
+        // GuardNpgsqlTransaction requires a concrete NpgsqlTransaction (cannot be substituted without
+        // a live connection), so the full public override cannot be driven past the guard in a unit
+        // test. The build-and-dispatch seam (DispatchBatch/DispatchBatchAsync, internal via
+        // InternalsVisibleTo) is exercised directly with a substitute DbTransaction. The handler-side
+        // "reuse caller connection, attach Transaction, never commit/rollback" guarantees need a real
+        // transaction and are covered by the PostgreSQL inbox integration tests (PLAN-3.2).
+
+        [TestMethod]
+        public void SendBatch_DispatchesBatchCommand_NotPerMessageSend()
+        {
+            var batch = Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            batch.Handle(Arg.Any<SendMessageCommandBatch>())
+                .Returns(new QueueOutputMessages(new List<IQueueOutputMessage>()));
+            var single = Substitute.For<ICommandHandlerWithOutput<SendMessageCommand, long>>();
+
+            var sut = BuildSut(syncHandler: single, syncBatchHandler: batch);
+            sut.DispatchBatch(BuildBatch(3), BuildNonNpgsqlTransaction());
+
+            batch.Received(1).Handle(Arg.Any<SendMessageCommandBatch>());
+            single.DidNotReceive().Handle(Arg.Any<SendMessageCommand>()); // not a SendOne loop
+        }
+
+        [TestMethod]
+        public void SendBatch_BatchHandlerReceivesExternalTransaction()
+        {
+            SendMessageCommandBatch captured = null;
+            var batch = Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            batch.Handle(Arg.Do<SendMessageCommandBatch>(c => captured = c))
+                .Returns(new QueueOutputMessages(new List<IQueueOutputMessage>()));
+
+            var sut = BuildSut(syncBatchHandler: batch);
+            var transaction = BuildNonNpgsqlTransaction();
+            sut.DispatchBatch(BuildBatch(2), transaction);
+
+            Assert.IsInstanceOfType(captured, typeof(RelationalSendMessageCommandBatch));
+            Assert.AreSame(transaction, ((RelationalSendMessageCommandBatch)captured).ExternalTransaction);
+            Assert.AreEqual(2, captured.Messages.Count);
+        }
+
+        [TestMethod]
+        public void SendBatch_NeverCallsCommitRollbackOnCallerTransaction()
+        {
+            var sut = BuildSut();
+            var transaction = BuildNonNpgsqlTransaction();
+            sut.DispatchBatch(BuildBatch(2), transaction);
+
+            transaction.DidNotReceive().Commit();
+            transaction.DidNotReceive().Rollback();
+        }
+
+        [TestMethod]
+        public async Task SendBatchAsync_DispatchesBatchCommandAsync()
+        {
+            var batch = Substitute.For<ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages>>();
+            batch.HandleAsync(Arg.Any<SendMessageCommandBatch>())
+                .Returns(Task.FromResult(new QueueOutputMessages(new List<IQueueOutputMessage>())));
+
+            var sut = BuildSut(asyncBatchHandler: batch);
+            await sut.DispatchBatchAsync(BuildBatch(3), BuildNonNpgsqlTransaction());
+
+            await batch.Received(1).HandleAsync(Arg.Any<SendMessageCommandBatch>());
+        }
+
+        [TestMethod]
+        public void SendBatch_ForwardsBatchHandlerException()
+        {
+            var batch = Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            batch.When(b => b.Handle(Arg.Any<SendMessageCommandBatch>()))
+                .Do(_ => throw new InvalidOperationException("boom"));
+
+            var sut = BuildSut(syncBatchHandler: batch);
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
+                () => sut.DispatchBatch(BuildBatch(2), BuildNonNpgsqlTransaction()));
+            StringAssert.Contains(ex.Message, "boom"); // propagated, not swallowed into per-message results
+        }
+
+        [TestMethod]
+        public void SendBatch_NonNpgsqlTransaction_ThrowsAndDoesNotDispatch()
+        {
+            var batch = Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            var sut = BuildSut(syncBatchHandler: batch);
+
+            Assert.ThrowsExactly<InvalidOperationException>(
+                () => sut.Send(BuildBatch(2), BuildNonNpgsqlTransaction()));
+            batch.DidNotReceive().Handle(Arg.Any<SendMessageCommandBatch>());
         }
 
         // ----- DI smoke test (PROJECT.md §Success Criteria #3) -----

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandBatchHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandBatchHandler.cs
@@ -25,6 +25,7 @@ using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Messages;
 using DotNetWorkQueue.Serialization;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
@@ -98,6 +99,11 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
 
             BatchSendValidation.GuardNoScheduledJobs(messages, _jobSchedulerMetaData);
 
+            // Inbox (held-transaction) batch path: when the caller supplied a transaction, reuse
+            // its connection/transaction instead of opening our own (and never commit it).
+            if (command is RelationalSendMessageCommandBatch rel && rel.ExternalTransaction != null)
+                return HandleExternalTransaction(rel);
+
             var options = _options.Value;
             var batchSizer = new SendBatchSize(SendMessageBatch.SafeMaxBatchSize,
                 options.BatchSize > 0 ? options.BatchSize : (int?)null);
@@ -136,6 +142,34 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                     }
                 }
             }
+            return new QueueOutputMessages(results.ToList());
+        }
+
+        /// <summary>
+        /// Inbox (held-transaction) batch path. Runs the same multi-row body insert and per-message
+        /// meta/status rows as <see cref="Handle"/>, but on the caller-supplied connection and
+        /// transaction. The caller owns the commit/rollback, so this method opens nothing, commits
+        /// nothing, and wraps nothing — any failure propagates so the caller can roll back.
+        /// </summary>
+        private QueueOutputMessages HandleExternalTransaction(RelationalSendMessageCommandBatch rel)
+        {
+            var npgsqlTransaction = (NpgsqlTransaction)rel.ExternalTransaction;
+            var npgsqlConn = (NpgsqlConnection)npgsqlTransaction.Connection;
+
+            var messages = rel.Messages;
+            var options = _options.Value;
+            var batchSizer = new SendBatchSize(SendMessageBatch.SafeMaxBatchSize,
+                options.BatchSize > 0 ? options.BatchSize : (int?)null);
+
+            var results = new IQueueOutputMessage[messages.Count];
+            var globalIndex = 0;
+            foreach (var chunk in messages.Partition(batchSizer.BatchSize(messages.Count)))
+            {
+                ProcessChunk(npgsqlConn, npgsqlTransaction, chunk, options, results, ref globalIndex);
+            }
+
+            // Caller owns the transaction lifecycle — deliberately no Commit/Rollback/Dispose/Close
+            // and no try/catch wrapper (failures propagate so the caller can roll back).
             return new QueueOutputMessages(results.ToList());
         }
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
@@ -26,6 +26,7 @@ using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Messages;
 using DotNetWorkQueue.Serialization;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
@@ -92,6 +93,11 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
 
             BatchSendValidation.GuardNoScheduledJobs(messages, _jobSchedulerMetaData);
 
+            // Inbox (held-transaction) batch path: when the caller supplied a transaction, reuse
+            // its connection/transaction instead of opening our own (and never commit it).
+            if (command is RelationalSendMessageCommandBatch rel && rel.ExternalTransaction != null)
+                return await HandleExternalTransactionAsync(rel).ConfigureAwait(false);
+
             var options = _options.Value;
             var batchSizer = new SendBatchSize(SendMessageBatch.SafeMaxBatchSize,
                 options.BatchSize > 0 ? options.BatchSize : (int?)null);
@@ -131,6 +137,35 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                     }
                 }
             }
+            return new QueueOutputMessages(results.ToList());
+        }
+
+        /// <summary>
+        /// Inbox (held-transaction) batch path. Runs the same multi-row body insert and per-message
+        /// meta/status rows as <see cref="HandleAsync"/>, but on the caller-supplied connection and
+        /// transaction. The caller owns the commit/rollback, so this method opens nothing, commits
+        /// nothing, and wraps nothing — any failure propagates so the caller can roll back.
+        /// </summary>
+        private async Task<QueueOutputMessages> HandleExternalTransactionAsync(RelationalSendMessageCommandBatch rel)
+        {
+            var npgsqlTransaction = (NpgsqlTransaction)rel.ExternalTransaction;
+            var npgsqlConn = (NpgsqlConnection)npgsqlTransaction.Connection;
+
+            var messages = rel.Messages;
+            var options = _options.Value;
+            var batchSizer = new SendBatchSize(SendMessageBatch.SafeMaxBatchSize,
+                options.BatchSize > 0 ? options.BatchSize : (int?)null);
+
+            var results = new IQueueOutputMessage[messages.Count];
+            var globalIndex = 0;
+            foreach (var chunk in messages.Partition(batchSizer.BatchSize(messages.Count)))
+            {
+                globalIndex = await ProcessChunkAsync(npgsqlConn, npgsqlTransaction, chunk, options, results, globalIndex)
+                    .ConfigureAwait(false);
+            }
+
+            // Caller owns the transaction lifecycle — deliberately no Commit/Rollback/Dispose/Close
+            // and no try/catch wrapper (failures propagate so the caller can roll back).
             return new QueueOutputMessages(results.ToList());
         }
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSqlRelationalProducerQueue.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSqlRelationalProducerQueue.cs
@@ -51,6 +51,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
     {
         private readonly ICommandHandlerWithOutput<SendMessageCommand, long> _sendHandler;
         private readonly ICommandHandlerWithOutputAsync<SendMessageCommand, long> _sendHandlerAsync;
+        private readonly ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages> _sendBatchHandler;
+        private readonly ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages> _sendBatchHandlerAsync;
         private readonly ExternalTransactionValidator _validator;
         private readonly ISentMessageFactory _sentMessageFactory;
         private readonly IMessageFactory _messageFactory;
@@ -67,6 +69,11 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
         /// <param name="addStandardMessageHeaders">Standard header populator.</param>
         /// <param name="sendHandler">Registered sync handler for <see cref="SendMessageCommand"/>.</param>
         /// <param name="sendHandlerAsync">Registered async handler for <see cref="SendMessageCommand"/>.</param>
+        /// <param name="sendBatchHandler">Registered sync handler for <see cref="SendMessageCommandBatch"/>
+        /// (used by the held-transaction batch path; the decorated handler is correct because
+        /// <see cref="RelationalSendMessageCommandBatch.SkipRetry"/> keeps the retry decorator out of
+        /// the caller's transaction).</param>
+        /// <param name="sendBatchHandlerAsync">Registered async handler for <see cref="SendMessageCommandBatch"/>.</param>
         /// <param name="validator">External-transaction validator (runs at the API boundary).</param>
         /// <param name="sentMessageFactory">Factory for the <see cref="ISentMessage"/> returned to callers.</param>
         /// <param name="ownMessageFactory">Same <see cref="IMessageFactory"/> instance retained for the
@@ -80,6 +87,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             AddStandardMessageHeaders addStandardMessageHeaders,
             ICommandHandlerWithOutput<SendMessageCommand, long> sendHandler,
             ICommandHandlerWithOutputAsync<SendMessageCommand, long> sendHandlerAsync,
+            ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages> sendBatchHandler,
+            ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages> sendBatchHandlerAsync,
             ExternalTransactionValidator validator,
             ISentMessageFactory sentMessageFactory,
             IMessageFactory ownMessageFactory)
@@ -88,11 +97,15 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
         {
             Guard.NotNull(() => sendHandler, sendHandler);
             Guard.NotNull(() => sendHandlerAsync, sendHandlerAsync);
+            Guard.NotNull(() => sendBatchHandler, sendBatchHandler);
+            Guard.NotNull(() => sendBatchHandlerAsync, sendBatchHandlerAsync);
             Guard.NotNull(() => validator, validator);
             Guard.NotNull(() => sentMessageFactory, sentMessageFactory);
             Guard.NotNull(() => ownMessageFactory, ownMessageFactory);
             _sendHandler = sendHandler;
             _sendHandlerAsync = sendHandlerAsync;
+            _sendBatchHandler = sendBatchHandler;
+            _sendBatchHandlerAsync = sendBatchHandlerAsync;
             _validator = validator;
             _sentMessageFactory = sentMessageFactory;
             _messageFactory = ownMessageFactory;
@@ -123,24 +136,11 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             List<QueueMessage<TMessage, IAdditionalMessageData>> messages, DbTransaction transaction)
         {
             Guard.NotNull(() => messages, messages);
-            _validator.Validate(transaction);   // ONCE, before the loop (CONTEXT-4 Decision 4)
+            _validator.Validate(transaction);   // ONCE, at the boundary (CONTEXT-4 Decision 4)
             GuardNpgsqlTransaction(transaction);
-
-            var rc = new List<IQueueOutputMessage>(messages.Count);
-            foreach (var m in messages)         // sequential — DbTransaction is not thread-safe
-            {
-                try
-                {
-                    rc.Add(SendOne(m.Message, m.MessageData ?? new AdditionalMessageData(), transaction));
-                }
-                catch (Exception error)
-                {
-                    rc.Add(new QueueOutputMessage(
-                        _sentMessageFactory.Create(null, (m.MessageData ?? new AdditionalMessageData()).CorrelationId),
-                        error));
-                }
-            }
-            return new QueueOutputMessages(rc);
+            // True multi-row insert inside the caller's transaction: one batch command, not a
+            // SendOne loop. Exceptions propagate — the caller owns the rollback (PROJECT goal 3).
+            return DispatchBatch(messages, transaction);
         }
 
         /// <inheritdoc />
@@ -150,26 +150,48 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             Guard.NotNull(() => messages, messages);
             _validator.Validate(transaction);
             GuardNpgsqlTransaction(transaction);
-
-            var rc = new List<IQueueOutputMessage>(messages.Count);
-            foreach (var m in messages)
-            {
-                try
-                {
-                    rc.Add(await SendOneAsync(m.Message,
-                        m.MessageData ?? new AdditionalMessageData(), transaction).ConfigureAwait(false));
-                }
-                catch (Exception error)
-                {
-                    rc.Add(new QueueOutputMessage(
-                        _sentMessageFactory.Create(null, (m.MessageData ?? new AdditionalMessageData()).CorrelationId),
-                        error));
-                }
-            }
-            return new QueueOutputMessages(rc);
+            return await DispatchBatchAsync(messages, transaction).ConfigureAwait(false);
         }
 
         // ----- private dispatch helpers -----
+
+        /// <summary>
+        /// Builds a single <see cref="RelationalSendMessageCommandBatch"/> carrying the caller's
+        /// transaction and dispatches it to the batch handler. Internal (not private) so the
+        /// build-and-dispatch behavior is unit-testable with a substitute <see cref="DbTransaction"/>;
+        /// the <see cref="GuardNpgsqlTransaction"/> cast guard is covered separately because
+        /// <see cref="Npgsql.NpgsqlTransaction"/> cannot be substituted without a live connection.
+        /// </summary>
+        internal IQueueOutputMessages DispatchBatch(
+            List<QueueMessage<TMessage, IAdditionalMessageData>> messages, DbTransaction transaction)
+        {
+            var cmd = new RelationalSendMessageCommandBatch(BuildBatchMessages(messages), transaction);
+            return _sendBatchHandler.Handle(cmd);
+        }
+
+        /// <summary>
+        /// Async counterpart to <see cref="DispatchBatch"/>.
+        /// </summary>
+        internal async Task<IQueueOutputMessages> DispatchBatchAsync(
+            List<QueueMessage<TMessage, IAdditionalMessageData>> messages, DbTransaction transaction)
+        {
+            var cmd = new RelationalSendMessageCommandBatch(BuildBatchMessages(messages), transaction);
+            return await _sendBatchHandlerAsync.HandleAsync(cmd).ConfigureAwait(false);
+        }
+
+        private List<QueueMessage<IMessage, IAdditionalMessageData>> BuildBatchMessages(
+            List<QueueMessage<TMessage, IAdditionalMessageData>> messages)
+        {
+            var imsgs = new List<QueueMessage<IMessage, IAdditionalMessageData>>(messages.Count);
+            foreach (var m in messages)
+            {
+                var data = m.MessageData ?? new AdditionalMessageData();
+                var additionalHeaders = _generateMessageHeaders.HeaderSetup(data);
+                var imsg = _messageFactory.Create(m.Message, additionalHeaders);
+                imsgs.Add(new QueueMessage<IMessage, IAdditionalMessageData>(imsg, data));
+            }
+            return imsgs;
+        }
 
         private IQueueOutputMessage SendOne(TMessage message, IAdditionalMessageData data, DbTransaction transaction)
         {

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSqlRelationalProducerQueue.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSqlRelationalProducerQueue.cs
@@ -138,6 +138,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             Guard.NotNull(() => messages, messages);
             _validator.Validate(transaction);   // ONCE, at the boundary (CONTEXT-4 Decision 4)
             GuardNpgsqlTransaction(transaction);
+            if (messages.Count == 0)
+                return new QueueOutputMessages(new List<IQueueOutputMessage>());
             // True multi-row insert inside the caller's transaction: one batch command, not a
             // SendOne loop. Exceptions propagate — the caller owns the rollback (PROJECT goal 3).
             return DispatchBatch(messages, transaction);
@@ -150,6 +152,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             Guard.NotNull(() => messages, messages);
             _validator.Validate(transaction);
             GuardNpgsqlTransaction(transaction);
+            if (messages.Count == 0)
+                return new QueueOutputMessages(new List<IQueueOutputMessage>());
             return await DispatchBatchAsync(messages, transaction).ConfigureAwait(false);
         }
 

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Inbox/SqlServerInboxBatchSendTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Inbox/SqlServerInboxBatchSendTests.cs
@@ -96,6 +96,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Inbox
                 }
 
                 // Nothing was committed: neither the queue rows nor the business rows are visible.
+                // Rollback is synchronous, so the first poll already observes 0 (no lag to wait out).
                 AssertQueueRowCount(qc, 0);
                 AssertBusinessRowCountStaysAt(ConnectionInfo.ConnectionString, businessTable, 0);
             }
@@ -157,13 +158,21 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Inbox
             {
                 try
                 {
+                    // The multi-row body insert succeeds; the per-message meta insert then hits the
+                    // dropped MetaData table and the batch handler throws. The held-transaction path
+                    // performs no table-existence pre-check, so the throw originates at the insert and
+                    // propagates out of Send (no swallow into per-message results).
                     producer.RelationalProducer.Send(BuildBatch(3), transaction);
                 }
                 catch
                 {
                     threw = true;
                 }
-                transaction.Rollback();
+                finally
+                {
+                    // Roll back defensively; never let a rollback error mask the assertion below.
+                    try { transaction.Rollback(); } catch { /* already in the error path */ }
+                }
             }
 
             Assert.IsTrue(threw, "Held-transaction batch send must throw on a DB failure, not swallow it.");

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Inbox/SqlServerInboxBatchSendTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Inbox/SqlServerInboxBatchSendTests.cs
@@ -214,12 +214,15 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Inbox
         // ----- Producer resolution + capability cast (mirrors the outbox base) -----
         private sealed class ProducerScope : System.IDisposable
         {
+            private int _disposed;
+
             public QueueContainer<SqlServerMessageQueueInit> Creator { get; init; }
             public IProducerQueue<FakeMessage> Producer { get; init; }
             public IRelationalProducerQueue<FakeMessage> RelationalProducer { get; init; }
 
             public void Dispose()
             {
+                if (System.Threading.Interlocked.Exchange(ref _disposed, 1) != 0) return;
                 Producer?.Dispose();
                 Creator?.Dispose();
             }

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Inbox/SqlServerInboxBatchSendTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Inbox/SqlServerInboxBatchSendTests.cs
@@ -1,0 +1,280 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Collections.Generic;
+using System.Data;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.Messages;
+using DotNetWorkQueue.Transport.RelationalDatabase;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using Microsoft.Data.SqlClient;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Inbox
+{
+    /// <summary>
+    /// Integration tests for the SqlServer inbox held-transaction batch send (#167): a true
+    /// multi-row insert performed inside the caller's transaction. Proves commit/rollback
+    /// visibility, that the caller's connection is left open and usable, that a real DB failure
+    /// throws (rather than being swallowed into per-message results), and that one result id is
+    /// returned per message.
+    /// </summary>
+    [TestClass]
+    public class SqlServerInboxBatchSendTests : SqlServerInboxIntegrationTestBase
+    {
+        [TestMethod]
+        public void SendBatch_Commit_AllRowsVisible()
+        {
+            const int batchSize = 5;
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+            var businessTable = NewBusinessTableName();
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            CreateBusinessTable(ConnectionInfo.ConnectionString, businessTable);
+            try
+            {
+                using var producer = CreateRelationalProducer(qc);
+                using var conn = new SqlConnection(ConnectionInfo.ConnectionString);
+                conn.Open();
+
+                using (var transaction = conn.BeginTransaction())
+                {
+                    var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
+                    Assert.IsFalse(result.HasErrors, "batch send reported errors");
+                    for (var i = 0; i < batchSize; i++)
+                        InsertBusinessRowOnInboxTransaction(transaction, businessTable, i, $"row{i}");
+                    transaction.Commit();
+                }
+
+                AssertQueueRowCount(qc, batchSize);
+                AssertBusinessRowCountFromSeparateConnection(ConnectionInfo.ConnectionString, businessTable, batchSize);
+            }
+            finally
+            {
+                DropBusinessTable(ConnectionInfo.ConnectionString, businessTable);
+            }
+        }
+
+        [TestMethod]
+        public void SendBatch_Rollback_NoRowsVisible()
+        {
+            const int batchSize = 5;
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+            var businessTable = NewBusinessTableName();
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            CreateBusinessTable(ConnectionInfo.ConnectionString, businessTable);
+            try
+            {
+                using var producer = CreateRelationalProducer(qc);
+                using var conn = new SqlConnection(ConnectionInfo.ConnectionString);
+                conn.Open();
+
+                using (var transaction = conn.BeginTransaction())
+                {
+                    var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
+                    Assert.IsFalse(result.HasErrors, "batch send reported errors");
+                    for (var i = 0; i < batchSize; i++)
+                        InsertBusinessRowOnInboxTransaction(transaction, businessTable, i, $"row{i}");
+                    transaction.Rollback();
+                }
+
+                // Nothing was committed: neither the queue rows nor the business rows are visible.
+                AssertQueueRowCount(qc, 0);
+                AssertBusinessRowCountStaysAt(ConnectionInfo.ConnectionString, businessTable, 0);
+            }
+            finally
+            {
+                DropBusinessTable(ConnectionInfo.ConnectionString, businessTable);
+            }
+        }
+
+        [TestMethod]
+        public void SendBatch_ConnectionStillOpenAndUsable()
+        {
+            const int batchSize = 3;
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            using var producer = CreateRelationalProducer(qc);
+            using var conn = new SqlConnection(ConnectionInfo.ConnectionString);
+            conn.Open();
+
+            using (var transaction = conn.BeginTransaction())
+            {
+                var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
+                Assert.IsFalse(result.HasErrors, "batch send reported errors");
+
+                // The batch path must not close/dispose the caller's connection or transaction.
+                Assert.AreEqual(ConnectionState.Open, conn.State, "caller connection must remain open");
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.Transaction = transaction;
+                    cmd.CommandText = "SELECT 1";
+                    Assert.AreEqual(1, (int)cmd.ExecuteScalar(), "connection must still be usable after send");
+                }
+
+                transaction.Commit();
+            }
+
+            AssertQueueRowCount(qc, batchSize);
+        }
+
+        [TestMethod]
+        public void SendBatch_ForcedFailure_Throws()
+        {
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            using var producer = CreateRelationalProducer(qc);
+
+            // Drop the MetaData table so the per-message meta insert inside the batch path fails with
+            // a real SQL error. The held-transaction path must propagate it (throw) rather than
+            // swallow it into per-message results — the caller owns the rollback.
+            DropMetaDataTable(qc);
+
+            using var conn = new SqlConnection(ConnectionInfo.ConnectionString);
+            conn.Open();
+
+            var threw = false;
+            using (var transaction = conn.BeginTransaction())
+            {
+                try
+                {
+                    producer.RelationalProducer.Send(BuildBatch(3), transaction);
+                }
+                catch
+                {
+                    threw = true;
+                }
+                transaction.Rollback();
+            }
+
+            Assert.IsTrue(threw, "Held-transaction batch send must throw on a DB failure, not swallow it.");
+        }
+
+        [TestMethod]
+        public void SendBatch_ResultIds_OnePerMessage()
+        {
+            const int batchSize = 4;
+            var qc = new QueueConnection(NewQueueName(), ConnectionInfo.ConnectionString);
+
+            using var queue = CreateQueue(qc, enableHoldTransaction: true);
+            using var producer = CreateRelationalProducer(qc);
+            using var conn = new SqlConnection(ConnectionInfo.ConnectionString);
+            conn.Open();
+
+            using (var transaction = conn.BeginTransaction())
+            {
+                var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
+                Assert.IsFalse(result.HasErrors, "batch send reported errors");
+                Assert.AreEqual(batchSize, result.Count, "one result per message");
+
+                var ids = new HashSet<long>();
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.IsTrue(result[i].SentMessage.MessageId.HasValue, "each result must carry a message id");
+                    var id = (long)result[i].SentMessage.MessageId.Id.Value;
+                    Assert.IsTrue(id > 0, "message id must be a positive value");
+                    ids.Add(id);
+                }
+                Assert.AreEqual(batchSize, ids.Count, "message ids must be distinct");
+
+                transaction.Commit();
+            }
+
+            AssertQueueRowCount(qc, batchSize);
+        }
+
+        // ----- Producer resolution + capability cast (mirrors the outbox base) -----
+        private sealed class ProducerScope : System.IDisposable
+        {
+            public QueueContainer<SqlServerMessageQueueInit> Creator { get; init; }
+            public IProducerQueue<FakeMessage> Producer { get; init; }
+            public IRelationalProducerQueue<FakeMessage> RelationalProducer { get; init; }
+
+            public void Dispose()
+            {
+                Producer?.Dispose();
+                Creator?.Dispose();
+            }
+        }
+
+        private static ProducerScope CreateRelationalProducer(QueueConnection queueConnection)
+        {
+            var creator = new QueueContainer<SqlServerMessageQueueInit>();
+            var producer = creator.CreateProducer<FakeMessage>(queueConnection);
+            Assert.IsInstanceOfType(producer, typeof(IRelationalProducerQueue<FakeMessage>),
+                "SqlServer producer must implement IRelationalProducerQueue<T> (#167 inbox batch path)");
+            return new ProducerScope
+            {
+                Creator = creator,
+                Producer = producer,
+                RelationalProducer = (IRelationalProducerQueue<FakeMessage>)producer
+            };
+        }
+
+        // ----- Batch builder -----
+        private static List<QueueMessage<FakeMessage, IAdditionalMessageData>> BuildBatch(int count)
+        {
+            var list = new List<QueueMessage<FakeMessage, IAdditionalMessageData>>(count);
+            for (var i = 0; i < count; i++)
+                list.Add(new QueueMessage<FakeMessage, IAdditionalMessageData>(
+                    GenerateMessage.Create<FakeMessage>(), null));
+            return list;
+        }
+
+        // ----- Queue MetaData row count (polling, NOT snapshot — CLAUDE.md lesson) -----
+        private static int CountQueueMessages(QueueConnection queueConnection)
+        {
+            var info = new SqlConnectionInformation(queueConnection);
+            var helper = new SqlServerTableNameHelper(info);
+            using var conn = new SqlConnection(queueConnection.Connection);
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT COUNT(*) FROM {helper.MetaDataName}";
+            return (int)cmd.ExecuteScalar();
+        }
+
+        private static void AssertQueueRowCount(QueueConnection queueConnection, int expected, int timeoutMs = 5000)
+        {
+            var deadline = System.DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            int actual = -1;
+            while (System.DateTime.UtcNow < deadline)
+            {
+                actual = CountQueueMessages(queueConnection);
+                if (actual == expected) return;
+                System.Threading.Thread.Sleep(100);
+            }
+            Assert.AreEqual(expected, actual,
+                $"Queue row count did not converge to {expected} within {timeoutMs}ms (last observed: {actual}).");
+        }
+
+        private static void DropMetaDataTable(QueueConnection queueConnection)
+        {
+            var info = new SqlConnectionInformation(queueConnection);
+            var helper = new SqlServerTableNameHelper(info);
+            using var conn = new SqlConnection(queueConnection.Connection);
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"IF OBJECT_ID('{helper.MetaDataName}', 'U') IS NOT NULL DROP TABLE {helper.MetaDataName}";
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/SqlServerRelationalProducerQueueTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/SqlServerRelationalProducerQueueTests.cs
@@ -50,12 +50,21 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             ICommandHandlerWithOutputAsync<SendMessageCommand, long> asyncHandler = null,
             ExternalTransactionValidator validator = null,
             ISentMessageFactory sentFactory = null,
-            IMessageFactory messageFactory = null)
+            IMessageFactory messageFactory = null,
+            ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages> syncBatchHandler = null,
+            ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages> asyncBatchHandler = null)
         {
             syncHandler ??= Substitute.For<ICommandHandlerWithOutput<SendMessageCommand, long>>();
             syncHandler.Handle(Arg.Any<SendMessageCommand>()).Returns(42L);
             asyncHandler ??= Substitute.For<ICommandHandlerWithOutputAsync<SendMessageCommand, long>>();
             asyncHandler.HandleAsync(Arg.Any<SendMessageCommand>()).Returns(Task.FromResult(42L));
+
+            syncBatchHandler ??= Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            syncBatchHandler.Handle(Arg.Any<SendMessageCommandBatch>())
+                .Returns(new QueueOutputMessages(new List<IQueueOutputMessage>()));
+            asyncBatchHandler ??= Substitute.For<ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages>>();
+            asyncBatchHandler.HandleAsync(Arg.Any<SendMessageCommandBatch>())
+                .Returns(Task.FromResult(new QueueOutputMessages(new List<IQueueOutputMessage>())));
 
             if (validator == null)
             {
@@ -94,7 +103,16 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
                 Substitute.For<ILogger>(),
                 generateHeaders,
                 addStandardHeaders,
-                syncHandler, asyncHandler, validator, sentFactory, messageFactory);
+                syncHandler, asyncHandler, syncBatchHandler, asyncBatchHandler,
+                validator, sentFactory, messageFactory);
+        }
+
+        private static List<QueueMessage<TestMessage, IAdditionalMessageData>> BuildBatch(int count)
+        {
+            var list = new List<QueueMessage<TestMessage, IAdditionalMessageData>>(count);
+            for (var i = 0; i < count; i++)
+                list.Add(new QueueMessage<TestMessage, IAdditionalMessageData>(new TestMessage(), null));
+            return list;
         }
 
         // Helper: build a non-SqlTransaction DbTransaction for guard/validator tests.
@@ -196,6 +214,97 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             // Assert it was called exactly once across the 3-message batch.
             try { sut.Send(msgs, transaction); } catch (InvalidOperationException) { /* expected */ }
             extractor.Received(1).Extract(Arg.Any<DbConnection>());
+        }
+
+        // ----- Held-transaction batch dispatch (#167) -----
+        //
+        // GuardSqlTransaction requires a concrete SqlTransaction (sealed, no public ctor — cannot be
+        // substituted), so the full public override cannot be driven past the guard in a unit test.
+        // The build-and-dispatch seam (DispatchBatch/DispatchBatchAsync, internal via InternalsVisibleTo)
+        // is exercised directly with a substitute DbTransaction to prove producer behavior. The
+        // handler-side "reuse caller connection, attach Transaction, never commit/rollback" guarantees
+        // need a real transaction and are covered by the SQL Server inbox integration tests (PLAN-3.1).
+
+        [TestMethod]
+        public void SendBatch_DispatchesBatchCommand_NotPerMessageSend()
+        {
+            var batch = Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            batch.Handle(Arg.Any<SendMessageCommandBatch>())
+                .Returns(new QueueOutputMessages(new List<IQueueOutputMessage>()));
+            var single = Substitute.For<ICommandHandlerWithOutput<SendMessageCommand, long>>();
+
+            var sut = BuildSut(syncHandler: single, syncBatchHandler: batch);
+            sut.DispatchBatch(BuildBatch(3), BuildNonSqlTransaction());
+
+            batch.Received(1).Handle(Arg.Any<SendMessageCommandBatch>());
+            single.DidNotReceive().Handle(Arg.Any<SendMessageCommand>()); // not a SendOne loop
+        }
+
+        [TestMethod]
+        public void SendBatch_BatchHandlerReceivesExternalTransaction()
+        {
+            SendMessageCommandBatch captured = null;
+            var batch = Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            batch.Handle(Arg.Do<SendMessageCommandBatch>(c => captured = c))
+                .Returns(new QueueOutputMessages(new List<IQueueOutputMessage>()));
+
+            var sut = BuildSut(syncBatchHandler: batch);
+            var transaction = BuildNonSqlTransaction();
+            sut.DispatchBatch(BuildBatch(2), transaction);
+
+            Assert.IsInstanceOfType(captured, typeof(RelationalSendMessageCommandBatch));
+            Assert.AreSame(transaction, ((RelationalSendMessageCommandBatch)captured).ExternalTransaction);
+            Assert.AreEqual(2, captured.Messages.Count);
+        }
+
+        [TestMethod]
+        public void SendBatch_NeverCallsCommitRollbackOnCallerTransaction()
+        {
+            var sut = BuildSut();
+            var transaction = BuildNonSqlTransaction();
+            sut.DispatchBatch(BuildBatch(2), transaction);
+
+            // The producer dispatches; it must never commit or roll back the caller's transaction.
+            transaction.DidNotReceive().Commit();
+            transaction.DidNotReceive().Rollback();
+        }
+
+        [TestMethod]
+        public async Task SendBatchAsync_DispatchesBatchCommandAsync()
+        {
+            var batch = Substitute.For<ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages>>();
+            batch.HandleAsync(Arg.Any<SendMessageCommandBatch>())
+                .Returns(Task.FromResult(new QueueOutputMessages(new List<IQueueOutputMessage>())));
+
+            var sut = BuildSut(asyncBatchHandler: batch);
+            await sut.DispatchBatchAsync(BuildBatch(3), BuildNonSqlTransaction());
+
+            await batch.Received(1).HandleAsync(Arg.Any<SendMessageCommandBatch>());
+        }
+
+        [TestMethod]
+        public void SendBatch_ForwardsBatchHandlerException()
+        {
+            var batch = Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            batch.When(b => b.Handle(Arg.Any<SendMessageCommandBatch>()))
+                .Do(_ => throw new InvalidOperationException("boom"));
+
+            var sut = BuildSut(syncBatchHandler: batch);
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
+                () => sut.DispatchBatch(BuildBatch(2), BuildNonSqlTransaction()));
+            StringAssert.Contains(ex.Message, "boom"); // propagated, not swallowed into per-message results
+        }
+
+        [TestMethod]
+        public void SendBatch_NonSqlTransaction_ThrowsAndDoesNotDispatch()
+        {
+            // The cast guard fires before any dispatch, so the batch handler is never invoked.
+            var batch = Substitute.For<ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages>>();
+            var sut = BuildSut(syncBatchHandler: batch);
+
+            Assert.ThrowsExactly<InvalidOperationException>(
+                () => sut.Send(BuildBatch(2), BuildNonSqlTransaction()));
+            batch.DidNotReceive().Handle(Arg.Any<SendMessageCommandBatch>());
         }
 
         // ----- DI smoke test (PROJECT.md §Success Criteria #3) -----

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandBatchHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandBatchHandler.cs
@@ -26,6 +26,7 @@ using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Messages;
 using DotNetWorkQueue.Serialization;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
@@ -95,6 +96,11 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
 
             BatchSendValidation.GuardNoScheduledJobs(messages, _jobSchedulerMetaData);
 
+            // Inbox (held-transaction) batch path: when the caller supplied a transaction, reuse
+            // its connection/transaction instead of opening our own (and never commit it).
+            if (command is RelationalSendMessageCommandBatch rel && rel.ExternalTransaction != null)
+                return HandleExternalTransaction(rel);
+
             var options = _options.Value;
             var batchSizer = new SendBatchSize(SendMessageBatch.SafeMaxBatchSize,
                 options.BatchSize > 0 ? options.BatchSize : (int?)null);
@@ -134,6 +140,34 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                     }
                 }
             }
+            return new QueueOutputMessages(results.ToList());
+        }
+
+        /// <summary>
+        /// Inbox (held-transaction) batch path. Runs the same multi-row body insert and per-message
+        /// meta/status rows as <see cref="Handle"/>, but on the caller-supplied connection and
+        /// transaction. The caller owns the commit/rollback, so this method opens nothing, commits
+        /// nothing, and wraps nothing — any failure propagates so the caller can roll back.
+        /// </summary>
+        private QueueOutputMessages HandleExternalTransaction(RelationalSendMessageCommandBatch rel)
+        {
+            var sqlTransaction = (SqlTransaction)rel.ExternalTransaction;
+            var sqlConn = (SqlConnection)sqlTransaction.Connection;
+
+            var messages = rel.Messages;
+            var options = _options.Value;
+            var batchSizer = new SendBatchSize(SendMessageBatch.SafeMaxBatchSize,
+                options.BatchSize > 0 ? options.BatchSize : (int?)null);
+
+            var results = new IQueueOutputMessage[messages.Count];
+            var globalIndex = 0;
+            foreach (var chunk in messages.Partition(batchSizer.BatchSize(messages.Count)))
+            {
+                ProcessChunk(sqlConn, sqlTransaction, chunk, options, results, ref globalIndex);
+            }
+
+            // Caller owns the transaction lifecycle — deliberately no Commit/Rollback/Dispose/Close
+            // and no try/catch wrapper (failures propagate so the caller can roll back).
             return new QueueOutputMessages(results.ToList());
         }
 

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
@@ -27,6 +27,7 @@ using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Messages;
 using DotNetWorkQueue.Serialization;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
@@ -87,6 +88,11 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
 
             BatchSendValidation.GuardNoScheduledJobs(messages, _jobSchedulerMetaData);
 
+            // Inbox (held-transaction) batch path: when the caller supplied a transaction, reuse
+            // its connection/transaction instead of opening our own (and never commit it).
+            if (command is RelationalSendMessageCommandBatch rel && rel.ExternalTransaction != null)
+                return await HandleExternalTransactionAsync(rel).ConfigureAwait(false);
+
             var options = _options.Value;
             var batchSizer = new SendBatchSize(SendMessageBatch.SafeMaxBatchSize,
                 options.BatchSize > 0 ? options.BatchSize : (int?)null);
@@ -127,6 +133,35 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                     }
                 }
             }
+            return new QueueOutputMessages(results.ToList());
+        }
+
+        /// <summary>
+        /// Inbox (held-transaction) batch path. Runs the same multi-row body insert and per-message
+        /// meta/status rows as <see cref="HandleAsync"/>, but on the caller-supplied connection and
+        /// transaction. The caller owns the commit/rollback, so this method opens nothing, commits
+        /// nothing, and wraps nothing — any failure propagates so the caller can roll back.
+        /// </summary>
+        private async Task<QueueOutputMessages> HandleExternalTransactionAsync(RelationalSendMessageCommandBatch rel)
+        {
+            var sqlTransaction = (SqlTransaction)rel.ExternalTransaction;
+            var sqlConn = (SqlConnection)sqlTransaction.Connection;
+
+            var messages = rel.Messages;
+            var options = _options.Value;
+            var batchSizer = new SendBatchSize(SendMessageBatch.SafeMaxBatchSize,
+                options.BatchSize > 0 ? options.BatchSize : (int?)null);
+
+            var results = new IQueueOutputMessage[messages.Count];
+            var globalIndex = 0;
+            foreach (var chunk in messages.Partition(batchSizer.BatchSize(messages.Count)))
+            {
+                globalIndex = await ProcessChunkAsync(sqlConn, sqlTransaction, chunk, options, results, globalIndex)
+                    .ConfigureAwait(false);
+            }
+
+            // Caller owns the transaction lifecycle — deliberately no Commit/Rollback/Dispose/Close
+            // and no try/catch wrapper (failures propagate so the caller can roll back).
             return new QueueOutputMessages(results.ToList());
         }
 

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerRelationalProducerQueue.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerRelationalProducerQueue.cs
@@ -51,6 +51,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
     {
         private readonly ICommandHandlerWithOutput<SendMessageCommand, long> _sendHandler;
         private readonly ICommandHandlerWithOutputAsync<SendMessageCommand, long> _sendHandlerAsync;
+        private readonly ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages> _sendBatchHandler;
+        private readonly ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages> _sendBatchHandlerAsync;
         private readonly ExternalTransactionValidator _validator;
         private readonly ISentMessageFactory _sentMessageFactory;
         private readonly IMessageFactory _messageFactory;
@@ -67,6 +69,11 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         /// <param name="addStandardMessageHeaders">Standard header populator.</param>
         /// <param name="sendHandler">Registered sync handler for <see cref="SendMessageCommand"/>.</param>
         /// <param name="sendHandlerAsync">Registered async handler for <see cref="SendMessageCommand"/>.</param>
+        /// <param name="sendBatchHandler">Registered sync handler for <see cref="SendMessageCommandBatch"/>
+        /// (used by the held-transaction batch path; the decorated handler is correct because
+        /// <see cref="RelationalSendMessageCommandBatch.SkipRetry"/> keeps the retry decorator out of
+        /// the caller's transaction).</param>
+        /// <param name="sendBatchHandlerAsync">Registered async handler for <see cref="SendMessageCommandBatch"/>.</param>
         /// <param name="validator">External-transaction validator (runs at the API boundary).</param>
         /// <param name="sentMessageFactory">Factory for the <see cref="ISentMessage"/> returned to callers.</param>
         /// <param name="ownMessageFactory">Same <see cref="IMessageFactory"/> instance retained for the
@@ -80,6 +87,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             AddStandardMessageHeaders addStandardMessageHeaders,
             ICommandHandlerWithOutput<SendMessageCommand, long> sendHandler,
             ICommandHandlerWithOutputAsync<SendMessageCommand, long> sendHandlerAsync,
+            ICommandHandlerWithOutput<SendMessageCommandBatch, QueueOutputMessages> sendBatchHandler,
+            ICommandHandlerWithOutputAsync<SendMessageCommandBatch, QueueOutputMessages> sendBatchHandlerAsync,
             ExternalTransactionValidator validator,
             ISentMessageFactory sentMessageFactory,
             IMessageFactory ownMessageFactory)
@@ -88,11 +97,15 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         {
             Guard.NotNull(() => sendHandler, sendHandler);
             Guard.NotNull(() => sendHandlerAsync, sendHandlerAsync);
+            Guard.NotNull(() => sendBatchHandler, sendBatchHandler);
+            Guard.NotNull(() => sendBatchHandlerAsync, sendBatchHandlerAsync);
             Guard.NotNull(() => validator, validator);
             Guard.NotNull(() => sentMessageFactory, sentMessageFactory);
             Guard.NotNull(() => ownMessageFactory, ownMessageFactory);
             _sendHandler = sendHandler;
             _sendHandlerAsync = sendHandlerAsync;
+            _sendBatchHandler = sendBatchHandler;
+            _sendBatchHandlerAsync = sendBatchHandlerAsync;
             _validator = validator;
             _sentMessageFactory = sentMessageFactory;
             _messageFactory = ownMessageFactory;
@@ -123,24 +136,11 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             List<QueueMessage<TMessage, IAdditionalMessageData>> messages, DbTransaction transaction)
         {
             Guard.NotNull(() => messages, messages);
-            _validator.Validate(transaction);  // ONCE, before the loop (CONTEXT-3 Decision 3)
+            _validator.Validate(transaction);  // ONCE, at the boundary (CONTEXT-3 Decision 3)
             GuardSqlTransaction(transaction);
-
-            var rc = new List<IQueueOutputMessage>(messages.Count);
-            foreach (var m in messages)  // sequential — DbTransaction is not thread-safe
-            {
-                try
-                {
-                    rc.Add(SendOne(m.Message, m.MessageData ?? new AdditionalMessageData(), transaction));
-                }
-                catch (Exception error)
-                {
-                    rc.Add(new QueueOutputMessage(
-                        _sentMessageFactory.Create(null, (m.MessageData ?? new AdditionalMessageData()).CorrelationId),
-                        error));
-                }
-            }
-            return new QueueOutputMessages(rc);
+            // True multi-row insert inside the caller's transaction: one batch command, not a
+            // SendOne loop. Exceptions propagate — the caller owns the rollback (PROJECT goal 3).
+            return DispatchBatch(messages, transaction);
         }
 
         /// <inheritdoc />
@@ -150,26 +150,48 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             Guard.NotNull(() => messages, messages);
             _validator.Validate(transaction);
             GuardSqlTransaction(transaction);
-
-            var rc = new List<IQueueOutputMessage>(messages.Count);
-            foreach (var m in messages)
-            {
-                try
-                {
-                    rc.Add(await SendOneAsync(m.Message,
-                        m.MessageData ?? new AdditionalMessageData(), transaction).ConfigureAwait(false));
-                }
-                catch (Exception error)
-                {
-                    rc.Add(new QueueOutputMessage(
-                        _sentMessageFactory.Create(null, (m.MessageData ?? new AdditionalMessageData()).CorrelationId),
-                        error));
-                }
-            }
-            return new QueueOutputMessages(rc);
+            return await DispatchBatchAsync(messages, transaction).ConfigureAwait(false);
         }
 
         // ----- private dispatch helpers -----
+
+        /// <summary>
+        /// Builds a single <see cref="RelationalSendMessageCommandBatch"/> carrying the caller's
+        /// transaction and dispatches it to the batch handler. Internal (not private) so the
+        /// build-and-dispatch behavior is unit-testable with a substitute <see cref="DbTransaction"/>;
+        /// the <see cref="GuardSqlTransaction"/> cast guard is covered separately because
+        /// <see cref="Microsoft.Data.SqlClient.SqlTransaction"/> is sealed and cannot be substituted.
+        /// </summary>
+        internal IQueueOutputMessages DispatchBatch(
+            List<QueueMessage<TMessage, IAdditionalMessageData>> messages, DbTransaction transaction)
+        {
+            var cmd = new RelationalSendMessageCommandBatch(BuildBatchMessages(messages), transaction);
+            return _sendBatchHandler.Handle(cmd);
+        }
+
+        /// <summary>
+        /// Async counterpart to <see cref="DispatchBatch"/>.
+        /// </summary>
+        internal async Task<IQueueOutputMessages> DispatchBatchAsync(
+            List<QueueMessage<TMessage, IAdditionalMessageData>> messages, DbTransaction transaction)
+        {
+            var cmd = new RelationalSendMessageCommandBatch(BuildBatchMessages(messages), transaction);
+            return await _sendBatchHandlerAsync.HandleAsync(cmd).ConfigureAwait(false);
+        }
+
+        private List<QueueMessage<IMessage, IAdditionalMessageData>> BuildBatchMessages(
+            List<QueueMessage<TMessage, IAdditionalMessageData>> messages)
+        {
+            var imsgs = new List<QueueMessage<IMessage, IAdditionalMessageData>>(messages.Count);
+            foreach (var m in messages)
+            {
+                var data = m.MessageData ?? new AdditionalMessageData();
+                var additionalHeaders = _generateMessageHeaders.HeaderSetup(data);
+                var imsg = _messageFactory.Create(m.Message, additionalHeaders);
+                imsgs.Add(new QueueMessage<IMessage, IAdditionalMessageData>(imsg, data));
+            }
+            return imsgs;
+        }
 
         private IQueueOutputMessage SendOne(TMessage message, IAdditionalMessageData data, DbTransaction transaction)
         {

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerRelationalProducerQueue.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerRelationalProducerQueue.cs
@@ -138,6 +138,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             Guard.NotNull(() => messages, messages);
             _validator.Validate(transaction);  // ONCE, at the boundary (CONTEXT-3 Decision 3)
             GuardSqlTransaction(transaction);
+            if (messages.Count == 0)
+                return new QueueOutputMessages(new List<IQueueOutputMessage>());
             // True multi-row insert inside the caller's transaction: one batch command, not a
             // SendOne loop. Exceptions propagate — the caller owns the rollback (PROJECT goal 3).
             return DispatchBatch(messages, transaction);
@@ -150,6 +152,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             Guard.NotNull(() => messages, messages);
             _validator.Validate(transaction);
             GuardSqlTransaction(transaction);
+            if (messages.Count == 0)
+                return new QueueOutputMessages(new List<IQueueOutputMessage>());
             return await DispatchBatchAsync(messages, transaction).ConfigureAwait(false);
         }
 

--- a/docs/outbox-pattern.md
+++ b/docs/outbox-pattern.md
@@ -150,18 +150,32 @@ var batch = new[]
     new OrderCreatedEvent { OrderId = 43, Status = "Pending" }
 };
 
-var results = relationalProducer.Send(batch, transaction);
-
-if (results.HasErrors)
-    throw new InvalidOperationException("One or more batch enqueues failed.");
-
-transaction.Commit();
+try
+{
+    relationalProducer.Send(batch, transaction);
+    transaction.Commit();
+}
+catch
+{
+    transaction.Rollback();
+    throw;
+}
 ```
 
-The batch path runs each enqueue inside the supplied transaction. A rollback after a partially
-successful batch rolls back every queue row written so far, including the successful ones — the
-all-or-nothing guarantee holds for the whole batch, not per message. `SendAsync(batch, transaction)`
-is the async equivalent.
+The batch path performs a true multi-row insert inside the supplied transaction (one insert per
+chunk, not one round trip per message). Because the caller owns the transaction, the path is
+fail-fast: on any failure it **throws** so you can roll back — it does not report per-message
+errors. (Catch the exception and call `transaction.Rollback()`, as above.) The all-or-nothing
+guarantee holds for the whole batch. `SendAsync(batch, transaction)` is the async equivalent.
+
+> The caller-supplied-transaction batch overload is implemented for **SQL Server** and
+> **PostgreSQL**. Other transports throw `InvalidOperationException` (SQLite is single-writer, so
+> holding a transaction open across a batch is non-viable — use the standalone `Send(List<T>)`
+> outbox path there instead).
+>
+> Note: this throw-on-failure behavior is specific to the caller-transaction batch path
+> (since 0.9.42). The standalone `Send(List<T>)` path still reports per-message results via
+> `IQueueOutputMessages.HasErrors`.
 
 ## Reference
 

--- a/docs/outbox-pattern.md
+++ b/docs/outbox-pattern.md
@@ -162,11 +162,12 @@ catch
 }
 ```
 
-The batch path performs a true multi-row insert inside the supplied transaction (one insert per
-chunk, not one round trip per message). Because the caller owns the transaction, the path is
-fail-fast: on any failure it **throws** so you can roll back — it does not report per-message
-errors. (Catch the exception and call `transaction.Rollback()`, as above.) The all-or-nothing
-guarantee holds for the whole batch. `SendAsync(batch, transaction)` is the async equivalent.
+The batch path performs a true multi-row **body** insert inside the supplied transaction for each
+chunk; the per-message metadata (and status) rows are still written one per message afterward, all
+on the same transaction. Because the caller owns the transaction, the path is fail-fast: on any
+failure it **throws** so you can roll back — it does not report per-message errors. (Catch the
+exception and call `transaction.Rollback()`, as above.) The all-or-nothing guarantee holds for the
+whole batch. `SendAsync(batch, transaction)` is the async equivalent.
 
 > The caller-supplied-transaction batch overload is implemented for **SQL Server** and
 > **PostgreSQL**. Other transports throw `InvalidOperationException` (SQLite is single-writer, so


### PR DESCRIPTION
## Summary

Follow-up to #162. Gives the **inbox held-transaction** batch send path
(`Send(List<...>, DbTransaction)` with `EnableHoldTransactionUntilMessageCommitted`) a
true multi-row insert **inside the caller's transaction**, for **SQL Server and
PostgreSQL**. Previously this path looped single-row `SendOne` per message; now it
dispatches a single `RelationalSendMessageCommandBatch` to the batch handler, which
reuses the caller's connection/transaction.

Closes #167.

## What changed

- **Handlers (SQL Server + PostgreSQL, sync + async):** fork on
  `RelationalSendMessageCommandBatch.ExternalTransaction`. When set, `HandleExternalTransaction[Async]`
  reuses the caller's `SqlConnection`/`SqlTransaction` (resp. `NpgsqlConnection`/`NpgsqlTransaction`)
  via the existing `ProcessChunk`/`ProcessChunkAsync` — no `Open`/`BeginTransaction`/`Commit`/`Rollback`/
  `Dispose`/`Close` and no catch wrapper. The fork sits **after** `GuardNoScheduledJobs`, so scheduled-job
  batches are still rejected on this path. The standalone/outbox batch path is unchanged.
- **Producers (`SqlServerRelationalProducerQueue`, `PostgreSqlRelationalProducerQueue`):** the
  `SendWithExternalTransactionBatch[Async]` overrides validate once at the boundary, then dispatch a
  single `RelationalSendMessageCommandBatch` instead of looping `SendOne`. Build-and-dispatch is
  factored into an `internal DispatchBatch`/`DispatchBatchAsync` seam (testability — see below).
  `SendOne`/`SendOneAsync` remain for the single-message overrides.

## Behavior change

On the **held-transaction batch path only**, a failure now **throws** (the caller owns the
transaction's all-or-nothing semantics and the rollback) instead of being swallowed into per-message
results. The standalone `Send(List<...>)` path is unchanged (still reports `HasErrors`).

## Scope / non-goals

- **SQLite is excluded by design** — its single-writer model makes holding a transaction open across a
  batch non-viable (see #149). `Send(batch, transaction)` throws `InvalidOperationException` on
  transports that don't override it (the base default), i.e. everything except SQL Server + PostgreSQL.
- No public API surface changes. No DI registration changes — SimpleInjector auto-resolves the new
  producer ctor params, and `RelationalSendMessageCommandBatch.SkipRetry` keeps the retry decorator out
  of the caller's transaction.

## Testing

- **Unit (26 pass, run locally):** producer dispatches one batch command (not a `SendOne` loop), the
  command carries the caller's transaction, the producer never commits/rolls back the caller's
  transaction, async dispatch, exception propagation, and a non-Sql/Npgsql transaction throws without
  dispatching. (`SqlTransaction`/`NpgsqlTransaction` are sealed/unmockable, so dispatch is tested
  through the `internal DispatchBatch` seam; the cast guard is covered by the non-Sql/Npgsql tests.)
- **Integration (run on Jenkins / local `connectionstring.txt`):** new `SqlServerInboxBatchSendTests`
  and `PostgreSqlInboxBatchSendTests` — commit → rows visible, rollback → rows absent, caller connection
  still open & usable after the call, forced failure throws (MetaData table dropped → meta insert fails),
  one distinct positive id per message, and (PG) a multi-chunk batch (`BatchSize=2`, 5 messages → 3
  chunks) asserting recovered ids are strictly increasing in caller input order across chunks within one
  external transaction.

## Changelog

`0.9.42` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added held-transaction batch send for caller-managed transactions in SQL Server and PostgreSQL.
  * Batch send now performs multi-row inserts and returns one output result per message, including distinct positive message ids.
* **Bug Fixes**
  * Batch sends now fail fast: errors throw instead of being hidden as per-item results.
  * Caller-owned connections/transactions remain usable after `Send`; rollback prevents both inbox and related business rows from appearing.
  * In multi-chunk batches, returned message ids increase in the same order as input messages.
* **Documentation**
  * Updated async batch/outbox guidance with correct try/catch rollback + transport support details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->