### PR TITLE
Phase 1 (#159): add DotNetWorkQueue.Tests.Shared assertion helper

### DIFF
--- a/Source/DotNetWorkQueue.Tests.Shared.Tests/AssertHelperTests.cs
+++ b/Source/DotNetWorkQueue.Tests.Shared.Tests/AssertHelperTests.cs
@@ -1,0 +1,162 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
+
+namespace DotNetWorkQueue.Tests.Shared.Tests
+{
+    [TestClass]
+    public class AssertHelperTests
+    {
+        #region AreClose (DateTime)
+
+        [TestMethod]
+        public void AreClose_DateTime_WithinTolerance_Passes()
+        {
+            var expected = new DateTime(2026, 1, 1, 12, 0, 0);
+            var actual = expected.AddSeconds(2);
+            var tolerance = TimeSpan.FromSeconds(5);
+
+            AssertHelper.AreClose(expected, actual, tolerance);
+        }
+
+        [TestMethod]
+        public void AreClose_DateTime_OutOfTolerance_Throws()
+        {
+            var expected = new DateTime(2026, 1, 1, 12, 0, 0);
+            var actual = expected.AddSeconds(10);
+            var tolerance = TimeSpan.FromSeconds(5);
+
+            Assert.ThrowsExactly<AssertFailedException>(() => AssertHelper.AreClose(expected, actual, tolerance));
+        }
+
+        [TestMethod]
+        public void AreClose_DateTime_DeltaExactlyEqualsTolerance_Passes()
+        {
+            var expected = new DateTime(2026, 1, 1, 12, 0, 0);
+            var tolerance = TimeSpan.FromSeconds(5);
+            var actual = expected.Add(tolerance);
+
+            AssertHelper.AreClose(expected, actual, tolerance);
+        }
+
+        #endregion
+
+        #region AreClose (DateTimeOffset)
+
+        [TestMethod]
+        public void AreClose_DateTimeOffset_WithinTolerance_Passes()
+        {
+            var expected = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+            var actual = expected.AddSeconds(2);
+            var tolerance = TimeSpan.FromSeconds(5);
+
+            AssertHelper.AreClose(expected, actual, tolerance);
+        }
+
+        [TestMethod]
+        public void AreClose_DateTimeOffset_OutOfTolerance_Throws()
+        {
+            var expected = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+            var actual = expected.AddSeconds(10);
+            var tolerance = TimeSpan.FromSeconds(5);
+
+            Assert.ThrowsExactly<AssertFailedException>(() => AssertHelper.AreClose(expected, actual, tolerance));
+        }
+
+        [TestMethod]
+        public void AreClose_DateTimeOffset_DeltaExactlyEqualsTolerance_Passes()
+        {
+            var expected = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+            var tolerance = TimeSpan.FromSeconds(5);
+            var actual = expected.Add(tolerance);
+
+            AssertHelper.AreClose(expected, actual, tolerance);
+        }
+
+        #endregion
+
+        #region AllSatisfy
+
+        [TestMethod]
+        public void AllSatisfy_AllElementsPass_DoesNotThrow()
+        {
+            var items = new List<int> { 2, 4, 6, 8 };
+
+            AssertHelper.AllSatisfy(items, item => Assert.AreEqual(0, item % 2));
+        }
+
+        [TestMethod]
+        public void AllSatisfy_OneElementFails_ThrowsAndReportsFailingIndex()
+        {
+            var items = new List<int> { 2, 4, 5, 8 };
+
+            var exception = Assert.ThrowsExactly<AssertFailedException>(
+                () => AssertHelper.AllSatisfy(items, item => Assert.AreEqual(0, item % 2)));
+
+            StringAssert.Contains(exception.Message, "index");
+            StringAssert.Contains(exception.Message, "2");
+        }
+
+        #endregion
+
+        #region AreEquivalent
+
+        [TestMethod]
+        public void AreEquivalent_EqualObjects_DoesNotThrow()
+        {
+            var expected = new[] { "one", "two", "three" };
+            var actual = new[] { "one", "two", "three" };
+
+            AssertHelper.AreEquivalent(expected, actual);
+        }
+
+        [TestMethod]
+        public void AreEquivalent_StringArray_OrderDifferent_DefaultIgnoresOrder_DoesNotThrow()
+        {
+            var expected = new[] { "one", "two", "three" };
+            var actual = new[] { "three", "one", "two" };
+
+            AssertHelper.AreEquivalent(expected, actual);
+        }
+
+        [TestMethod]
+        public void AreEquivalent_ByteArray_Unequal_Throws()
+        {
+            var expected = new byte[] { 1, 2, 3 };
+            var actual = new byte[] { 1, 2, 4 };
+
+            Assert.ThrowsExactly<AssertFailedException>(() => AssertHelper.AreEquivalent(expected, actual));
+        }
+
+        [TestMethod]
+        public void AreEquivalent_ByteArray_OrderDifferent_IgnoreCollectionOrderFalse_Throws()
+        {
+            var expected = new byte[] { 1, 2, 3 };
+            var actual = new byte[] { 3, 2, 1 };
+
+            Assert.ThrowsExactly<AssertFailedException>(
+                () => AssertHelper.AreEquivalent(expected, actual, ignoreCollectionOrder: false));
+        }
+
+        #endregion
+    }
+}

--- a/Source/DotNetWorkQueue.Tests.Shared.Tests/DotNetWorkQueue.Tests.Shared.Tests.csproj
+++ b/Source/DotNetWorkQueue.Tests.Shared.Tests/DotNetWorkQueue.Tests.Shared.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0;</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;CODE_ANALYSIS;</DefineConstants>
+    <NoWarn>1701;1702;1705;NU1701;NU1603</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;CODE_ANALYSIS;</DefineConstants>
+    <NoWarn>1701;1702;1705;NU1701;NU1603</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+    <NoWarn>1701;1702;1705;NU1701;NU1603</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0|AnyCPU'">
+    <NoWarn>1701;1702;1705;NU1701;NU1603</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="MSTest.TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotNetWorkQueue.Tests.Shared\DotNetWorkQueue.Tests.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/DotNetWorkQueue.Tests.Shared/AssertHelper.cs
+++ b/Source/DotNetWorkQueue.Tests.Shared/AssertHelper.cs
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using KellermanSoftware.CompareNetObjects;
+
+namespace DotNetWorkQueue.Tests.Shared
+{
+    /// <summary>
+    /// Shared MSTest assertion helpers covering patterns that FluentAssertions provided
+    /// but MSTest has no clean 1:1 equivalent for: close-enough date/time comparisons,
+    /// per-element collection assertions, and deep structural equivalence.
+    /// </summary>
+    public static class AssertHelper
+    {
+        /// <summary>
+        /// Asserts that <paramref name="actual"/> is within <paramref name="tolerance"/> of
+        /// <paramref name="expected"/>.
+        /// </summary>
+        /// <param name="expected">The expected date/time.</param>
+        /// <param name="actual">The actual date/time.</param>
+        /// <param name="tolerance">The maximum allowed difference between the two values.</param>
+        public static void AreClose(DateTime expected, DateTime actual, TimeSpan tolerance)
+        {
+            var delta = actual - expected;
+            if (Math.Abs(delta.Ticks) > tolerance.Ticks)
+            {
+                Assert.Fail($"Expected {actual:O} to be within {tolerance} of {expected:O}, but the difference was {delta}.");
+            }
+        }
+
+        /// <summary>
+        /// Asserts that <paramref name="actual"/> is within <paramref name="tolerance"/> of
+        /// <paramref name="expected"/>.
+        /// </summary>
+        /// <param name="expected">The expected date/time offset.</param>
+        /// <param name="actual">The actual date/time offset.</param>
+        /// <param name="tolerance">The maximum allowed difference between the two values.</param>
+        public static void AreClose(DateTimeOffset expected, DateTimeOffset actual, TimeSpan tolerance)
+        {
+            var delta = actual - expected;
+            if (Math.Abs(delta.Ticks) > tolerance.Ticks)
+            {
+                Assert.Fail($"Expected {actual:O} to be within {tolerance} of {expected:O}, but the difference was {delta}.");
+            }
+        }
+
+        /// <summary>
+        /// Asserts that <paramref name="assertion"/> succeeds for every element of
+        /// <paramref name="collection"/>. Stops and reports the first failing element.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="collection">The collection to check.</param>
+        /// <param name="assertion">The assertion to run against each element.</param>
+        public static void AllSatisfy<T>(IEnumerable<T> collection, Action<T> assertion)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (assertion == null)
+            {
+                throw new ArgumentNullException(nameof(assertion));
+            }
+
+            var index = 0;
+            foreach (var item in collection)
+            {
+                try
+                {
+                    assertion(item);
+                }
+                catch (Exception ex)
+                {
+                    Assert.Fail($"AllSatisfy failed for element at index {index} (value: {item}): {ex.Message}");
+                }
+
+                index++;
+            }
+        }
+
+        /// <summary>
+        /// Asserts that <paramref name="expected"/> and <paramref name="actual"/> are deeply,
+        /// structurally equivalent.
+        /// </summary>
+        /// <typeparam name="T">The compared type.</typeparam>
+        /// <param name="expected">The expected value.</param>
+        /// <param name="actual">The actual value.</param>
+        /// <param name="ignoreCollectionOrder">Whether collection members are compared without regard to order.</param>
+        public static void AreEquivalent<T>(T expected, T actual, bool ignoreCollectionOrder = true)
+        {
+            var compareLogic = new CompareLogic(new ComparisonConfig { IgnoreCollectionOrder = ignoreCollectionOrder });
+            var result = compareLogic.Compare(expected, actual);
+            if (!result.AreEqual)
+            {
+                Assert.Fail(result.DifferencesString);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Tests.Shared/DotNetWorkQueue.Tests.Shared.csproj
+++ b/Source/DotNetWorkQueue.Tests.Shared/DotNetWorkQueue.Tests.Shared.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0;</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="CompareNETObjects" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\DotNetWorkQueue\DotNetWorkQueue.licenseheader" Link="DotNetWorkQueue.licenseheader" />
+  </ItemGroup>
+
+</Project>

--- a/Source/DotNetWorkQueue.sln
+++ b/Source/DotNetWorkQueue.sln
@@ -81,6 +81,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetWorkQueue.Dashboard.U
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetWorkQueue.Dashboard.Ui.E2E.Tests", "DotNetWorkQueue.Dashboard.Ui.E2E.Tests\DotNetWorkQueue.Dashboard.Ui.E2E.Tests.csproj", "{DE1D3E82-3E76-4F0C-B0C0-17966E9F0DE9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetWorkQueue.Tests.Shared", "DotNetWorkQueue.Tests.Shared\DotNetWorkQueue.Tests.Shared.csproj", "{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -559,6 +561,18 @@ Global
 		{DE1D3E82-3E76-4F0C-B0C0-17966E9F0DE9}.Release|x64.Build.0 = Release|Any CPU
 		{DE1D3E82-3E76-4F0C-B0C0-17966E9F0DE9}.Release|x86.ActiveCfg = Release|Any CPU
 		{DE1D3E82-3E76-4F0C-B0C0-17966E9F0DE9}.Release|x86.Build.0 = Release|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Debug|x64.Build.0 = Debug|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Debug|x86.Build.0 = Debug|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Release|x64.ActiveCfg = Release|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Release|x64.Build.0 = Release|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Release|x86.ActiveCfg = Release|Any CPU
+		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/DotNetWorkQueue.sln
+++ b/Source/DotNetWorkQueue.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetWorkQueue.Dashboard.U
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetWorkQueue.Tests.Shared", "DotNetWorkQueue.Tests.Shared\DotNetWorkQueue.Tests.Shared.csproj", "{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetWorkQueue.Tests.Shared.Tests", "DotNetWorkQueue.Tests.Shared.Tests\DotNetWorkQueue.Tests.Shared.Tests.csproj", "{B1C5BCA4-095F-4309-9D87-98E2426A492A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -573,6 +575,18 @@ Global
 		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Release|x64.Build.0 = Release|Any CPU
 		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Release|x86.ActiveCfg = Release|Any CPU
 		{1B9D95F9-2D69-444E-B7A6-F0FDE3561F5F}.Release|x86.Build.0 = Release|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Debug|x86.Build.0 = Debug|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Release|x64.Build.0 = Release|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1C5BCA4-095F-4309-9D87-98E2426A492A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Phase 1 of #159 — FluentAssertions → MSTest migration foundation

First increment of [#159](https://github.com/blehnen/DotNetWorkQueue/issues/159) (replace FluentAssertions with built-in MSTest assertions). **Test-only, no production code, no version bump.** This phase adds the shared assertion helper that later per-project migration PRs depend on — it performs **no migration itself**.

### What's here
- **`DotNetWorkQueue.Tests.Shared`** — a plain multi-target (`net10.0;net8.0`) class library (deliberately *not* a test-SDK project, to avoid double test discovery). References only `MSTest.TestFramework` + `CompareNETObjects` (both already pinned). Exposes `AssertHelper`:
  - `AreClose(DateTime/DateTimeOffset, TimeSpan tolerance)` — for the datetime `BeCloseTo` sites.
  - `AllSatisfy<T>(IEnumerable<T>, Action<T>)` — runs an assertion per element, reports the failing index.
  - `AreEquivalent<T>(expected, actual, bool ignoreCollectionOrder = true)` — object-graph equivalence via CompareNETObjects, surfacing `DifferencesString` on mismatch.
- **`DotNetWorkQueue.Tests.Shared.Tests`** — MSTest SDK project with **12 tests** proving pass + fail paths for every helper (including tolerance boundary, `AllSatisfy` failing-index message, and a `byte[]` negative-control that proves byte-order significance is preserved when `ignoreCollectionOrder:false`). Fail paths use `Assert.ThrowsExactly<AssertFailedException>` (MSTest 4.x removed `ThrowsException`).
- Both projects registered in `DotNetWorkQueue.sln` only.

### Verification
- Builds clean on net10.0 + net8.0 under Release/`TreatWarningsAsErrors`.
- `dotnet test` → **12/12 pass** on both TFMs.
- `FluentAssertions` (6.12.2) untouched in `Directory.Packages.props`; no existing test project migrated; no production assembly changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new shared test assertions for comparing dates, validating collections, and checking object equivalence.

* **Tests**
  * Added coverage for time tolerance checks, collection validation failures, and equivalence comparisons, including order handling and error reporting.

* **Chores**
  * Added new test projects and included them in the solution for multi-target test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->