### PR TITLE
Phase 2 (#159): migrate DotNetWorkQueue.Tests to MSTest assertions

### DIFF
--- a/Source/DotNetWorkQueue.Tests/DotNetWorkQueue.Tests.csproj
+++ b/Source/DotNetWorkQueue.Tests/DotNetWorkQueue.Tests.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
-<PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="MSTest.TestFramework" />

--- a/Source/DotNetWorkQueue.Tests/IoC/ContainerWrapperTests.cs
+++ b/Source/DotNetWorkQueue.Tests/IoC/ContainerWrapperTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.IoC;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SimpleInjector;
 
@@ -32,7 +31,7 @@ namespace DotNetWorkQueue.Tests.IoC
         {
             using (var wrapper = new ContainerWrapper(new Container()))
             {
-                wrapper.IsDisposed.Should().BeFalse();
+                Assert.IsFalse(wrapper.IsDisposed);
             }
         }
 
@@ -41,7 +40,7 @@ namespace DotNetWorkQueue.Tests.IoC
         {
             var wrapper = new ContainerWrapper(new Container());
             wrapper.Dispose();
-            wrapper.IsDisposed.Should().BeTrue();
+            Assert.IsTrue(wrapper.IsDisposed);
         }
 
         [TestMethod]
@@ -50,7 +49,7 @@ namespace DotNetWorkQueue.Tests.IoC
             var wrapper = new ContainerWrapper(new Container());
             wrapper.Dispose();
             wrapper.Dispose(); // Second call should not throw
-            wrapper.IsDisposed.Should().BeTrue();
+            Assert.IsTrue(wrapper.IsDisposed);
         }
 
         [TestMethod]
@@ -60,7 +59,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(container))
             {
                 object inner = wrapper.Container;
-                inner.Should().BeSameAs(container);
+                Assert.AreSame(container, inner);
             }
         }
 
@@ -69,7 +68,7 @@ namespace DotNetWorkQueue.Tests.IoC
         {
             using (var wrapper = new ContainerWrapper(new Container()))
             {
-                wrapper.IsVerifying.Should().BeFalse();
+                Assert.IsFalse(wrapper.IsVerifying);
             }
         }
 
@@ -78,7 +77,7 @@ namespace DotNetWorkQueue.Tests.IoC
         {
             using (var wrapper = new ContainerWrapper(new Container()))
             {
-                wrapper.TypesThatCanBeSuppressed.Should().BeEmpty();
+                Assert.AreEqual(0, wrapper.TypesThatCanBeSuppressed.Count);
             }
         }
 
@@ -90,7 +89,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 var result = wrapper.Register<ITestService, TestServiceImpl>(LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -101,7 +100,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 wrapper.Register<ITestService, TestServiceImpl>(LifeStyles.Transient);
                 var instance = wrapper.GetInstance<ITestService>();
-                instance.Should().BeOfType<TestServiceImpl>();
+                Assert.AreEqual(typeof(TestServiceImpl), instance.GetType());
             }
         }
 
@@ -111,7 +110,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 var result = wrapper.Register<TestServiceImpl>(LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -121,7 +120,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 var result = wrapper.Register<ITestService>(() => new TestServiceImpl(), LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -132,7 +131,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 wrapper.Register<ITestService>(() => new TestServiceImpl(), LifeStyles.Transient);
                 var instance = wrapper.GetInstance<ITestService>();
-                instance.Should().BeOfType<TestServiceImpl>();
+                Assert.AreEqual(typeof(TestServiceImpl), instance.GetType());
             }
         }
 
@@ -142,7 +141,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 var result = wrapper.Register(typeof(ITestService), () => new TestServiceImpl(), LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -152,7 +151,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 var result = wrapper.Register(typeof(ITestService), typeof(TestServiceImpl), LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -163,7 +162,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 wrapper.Register(typeof(ITestService), typeof(TestServiceImpl), LifeStyles.Transient);
                 var instance = wrapper.GetInstance(typeof(ITestService));
-                instance.Should().BeOfType<TestServiceImpl>();
+                Assert.AreEqual(typeof(TestServiceImpl), instance.GetType());
             }
         }
 
@@ -174,7 +173,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 var result = wrapper.Register(typeof(IGenericService<>),
                     new[] { typeof(StringServiceImpl) }, LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -185,7 +184,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 var result = wrapper.RegisterConditional(typeof(ITestService), typeof(TestServiceImpl),
                     LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -195,7 +194,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 var result = wrapper.RegisterConditional<ITestService, TestServiceImpl>(LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -206,7 +205,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 var instance = new TestServiceImpl();
                 var result = wrapper.RegisterNonScopedSingleton(instance);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -218,7 +217,7 @@ namespace DotNetWorkQueue.Tests.IoC
                 var instance = new TestServiceImpl();
                 wrapper.RegisterNonScopedSingleton(instance);
                 var resolved = wrapper.GetInstance<TestServiceImpl>();
-                resolved.Should().BeSameAs(instance);
+                Assert.AreSame(instance, resolved);
             }
         }
 
@@ -228,7 +227,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 var result = wrapper.RegisterCollection<ITestService>(new[] { typeof(TestServiceImpl) });
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -242,7 +241,7 @@ namespace DotNetWorkQueue.Tests.IoC
                 wrapper.Register<ITestService, TestServiceImpl>(LifeStyles.Singleton);
                 var instance1 = wrapper.GetInstance<ITestService>();
                 var instance2 = wrapper.GetInstance<ITestService>();
-                instance1.Should().BeSameAs(instance2);
+                Assert.AreSame(instance2, instance1);
             }
         }
 
@@ -254,7 +253,7 @@ namespace DotNetWorkQueue.Tests.IoC
                 wrapper.Register<ITestService, TestServiceImpl>(LifeStyles.Transient);
                 var instance1 = wrapper.GetInstance<ITestService>();
                 var instance2 = wrapper.GetInstance<ITestService>();
-                instance1.Should().NotBeSameAs(instance2);
+                Assert.AreNotSame(instance2, instance1);
             }
         }
 
@@ -266,7 +265,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 Action act = () => wrapper.Register<ITestService, TestServiceImpl>((LifeStyles)99);
-                act.Should().Throw<DotNetWorkQueueException>();
+                Assert.Throws<DotNetWorkQueueException>(act);
             }
         }
 
@@ -279,7 +278,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 Action act = () => wrapper.SuppressDiagnosticWarning(null,
                     DiagnosticTypes.DisposableTransientComponent, "test");
-                act.Should().Throw<ArgumentNullException>();
+                Assert.Throws<ArgumentNullException>(act);
             }
         }
 
@@ -290,7 +289,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 var result = wrapper.SuppressDiagnosticWarning(typeof(ITestService),
                     DiagnosticTypes.DisposableTransientComponent, "test");
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -302,7 +301,7 @@ namespace DotNetWorkQueue.Tests.IoC
                 wrapper.AddTypeThatNeedsWarningSuppression(typeof(ITestService));
                 var result = wrapper.SuppressDiagnosticWarning(typeof(ITestService),
                     DiagnosticTypes.DisposableTransientComponent, "test");
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -316,7 +315,7 @@ namespace DotNetWorkQueue.Tests.IoC
 
                 Action act = () => wrapper.SuppressDiagnosticWarning(typeof(ITestService),
                     DiagnosticTypes.DisposableTransientComponent, "test reason");
-                act.Should().NotThrow();
+                act();
             }
         }
 
@@ -328,7 +327,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 wrapper.AddTypeThatNeedsWarningSuppression(typeof(ITestService));
-                wrapper.TypesThatCanBeSuppressed.Should().Contain(typeof(ITestService));
+                Assert.IsTrue(wrapper.TypesThatCanBeSuppressed.Contains(typeof(ITestService)));
             }
         }
 
@@ -339,7 +338,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 wrapper.AddTypeThatNeedsWarningSuppression(typeof(ITestService));
                 wrapper.AddTypeThatNeedsWarningSuppression(typeof(ITestService));
-                wrapper.TypesThatCanBeSuppressed.Should().HaveCount(1);
+                Assert.AreEqual(1, wrapper.TypesThatCanBeSuppressed.Count);
             }
         }
 
@@ -353,7 +352,7 @@ namespace DotNetWorkQueue.Tests.IoC
                 wrapper.Register<ITestService, TestServiceImpl>(LifeStyles.Transient);
                 var result = wrapper.RegisterDecorator(typeof(ITestService), typeof(TestServiceDecorator),
                     LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -364,7 +363,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 wrapper.Register<ITestService, TestServiceImpl>(LifeStyles.Transient);
                 var result = wrapper.RegisterDecorator<ITestService, TestServiceDecorator>(LifeStyles.Transient);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 
@@ -377,7 +376,7 @@ namespace DotNetWorkQueue.Tests.IoC
                 wrapper.RegisterDecorator<ITestService, TestServiceDecorator>(LifeStyles.Transient);
 
                 var instance = wrapper.GetInstance<ITestService>();
-                instance.Should().BeOfType<TestServiceDecorator>();
+                Assert.AreEqual(typeof(TestServiceDecorator), instance.GetType());
             }
         }
 
@@ -390,7 +389,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 var result = wrapper.Register(typeof(IGenericService<>), LifeStyles.Transient,
                     typeof(GenericServiceImpl<>).Assembly);
-                result.Should().BeSameAs(wrapper);
+                Assert.AreSame(wrapper, result);
             }
         }
 

--- a/Source/DotNetWorkQueue.Tests/JobScheduler/JobScheduleTests.cs
+++ b/Source/DotNetWorkQueue.Tests/JobScheduler/JobScheduleTests.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using System;
 using DotNetWorkQueue.JobScheduler;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Tests.JobScheduler
@@ -34,42 +33,42 @@ namespace DotNetWorkQueue.Tests.JobScheduler
         public void Constructor_InvalidFieldCount_1Field_Throws()
         {
             Action act = () => new JobSchedule("invalid", GetNow);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
         public void Constructor_InvalidFieldCount_4Fields_Throws()
         {
             Action act = () => new JobSchedule("* * * *", GetNow);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
         public void Constructor_InvalidFieldCount_7Fields_Throws()
         {
             Action act = () => new JobSchedule("* * * * * * *", GetNow);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
         public void Constructor_SchyntaxFormat_Throws()
         {
             Action act = () => new JobSchedule("second(*%3)", GetNow);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
         public void Constructor_InvalidCronSyntax_5Field_Throws()
         {
             Action act = () => new JobSchedule("99 99 99 99 99", GetNow);
-            act.Should().Throw<Cronos.CronFormatException>();
+            Assert.Throws<Cronos.CronFormatException>(act);
         }
 
         [TestMethod]
         public void Constructor_InvalidCronSyntax_6Field_Throws()
         {
             Action act = () => new JobSchedule("99 99 99 99 99 99", GetNow);
-            act.Should().Throw<Cronos.CronFormatException>();
+            Assert.Throws<Cronos.CronFormatException>(act);
         }
 
         // --- Valid construction ---

--- a/Source/DotNetWorkQueue.Tests/Messages/StandardHeadersTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Messages/StandardHeadersTests.cs
@@ -1,6 +1,5 @@
 using DotNetWorkQueue.Factory;
 using DotNetWorkQueue.Messages;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Tests.Messages
@@ -12,14 +11,14 @@ namespace DotNetWorkQueue.Tests.Messages
         public void MessageBodyType_Has_Correct_Name()
         {
             var sut = Create();
-            sut.MessageBodyType.Name.Should().Be("Queue-MessageBodyType");
+            Assert.AreEqual("Queue-MessageBodyType", sut.MessageBodyType.Name);
         }
 
         [TestMethod]
         public void MessageBodyType_Default_Is_Null()
         {
             var sut = Create();
-            sut.MessageBodyType.Default.Should().BeNull();
+            Assert.IsNull(sut.MessageBodyType.Default);
         }
 
         private static IStandardHeaders Create()

--- a/Source/DotNetWorkQueue.Tests/Queue/AddStandardMessageHeadersTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/AddStandardMessageHeadersTests.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using DotNetWorkQueue.Factory;
 using DotNetWorkQueue.Messages;
 using DotNetWorkQueue.Queue;
-using FluentAssertions;
 using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -37,9 +36,9 @@ namespace DotNetWorkQueue.Tests.Queue
 
             sut.AddHeaders(message, Substitute.For<IAdditionalMessageData>());
 
-            message.Headers.Should().ContainKey("Queue-MessageBodyType");
+            Assert.IsTrue(message.Headers.ContainsKey("Queue-MessageBodyType"));
             var stamped = (string)message.Headers["Queue-MessageBodyType"];
-            stamped.Should().Be($"{typeof(SimpleTestBody).FullName}, {typeof(SimpleTestBody).Assembly.GetName().Name}");
+            Assert.AreEqual($"{typeof(SimpleTestBody).FullName}, {typeof(SimpleTestBody).Assembly.GetName().Name}", stamped);
         }
 
         [TestMethod]
@@ -50,9 +49,9 @@ namespace DotNetWorkQueue.Tests.Queue
             sut.AddHeaders(message, Substitute.For<IAdditionalMessageData>());
 
             var stamped = (string)message.Headers["Queue-MessageBodyType"];
-            stamped.Should().NotContain("Version=");
-            stamped.Should().NotContain("Culture=");
-            stamped.Should().NotContain("PublicKeyToken=");
+            Assert.IsFalse(stamped.Contains("Version="));
+            Assert.IsFalse(stamped.Contains("Culture="));
+            Assert.IsFalse(stamped.Contains("PublicKeyToken="));
         }
 
         [TestMethod]
@@ -63,7 +62,7 @@ namespace DotNetWorkQueue.Tests.Queue
 
             sut.AddHeaders(message, Substitute.For<IAdditionalMessageData>());
 
-            message.Headers.Should().NotContainKey("Queue-MessageBodyType");
+            Assert.IsFalse(message.Headers.ContainsKey("Queue-MessageBodyType"));
         }
 
         [TestMethod]
@@ -73,7 +72,7 @@ namespace DotNetWorkQueue.Tests.Queue
 
             sut.AddHeaders(message, Substitute.For<IAdditionalMessageData>());
 
-            message.Headers.Should().ContainKey("Queue-FirstPossibleDeliveryDate");
+            Assert.IsTrue(message.Headers.ContainsKey("Queue-FirstPossibleDeliveryDate"));
         }
 
         private static (AddStandardMessageHeaders sut, IMessage message) CreateSut(dynamic body)

--- a/Source/DotNetWorkQueue.Tests/Queue/ConsumerMetricsNotificationTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/ConsumerMetricsNotificationTests.cs
@@ -1,6 +1,5 @@
 using System;
 using DotNetWorkQueue.Queue;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Tests.Queue
@@ -15,7 +14,7 @@ namespace DotNetWorkQueue.Tests.Queue
             var sut = new ConsumerMetricsNotification(() => count++, () => { }, () => { }, () => { });
             sut.IncrementProcessed();
             sut.IncrementProcessed();
-            count.Should().Be(2);
+            Assert.AreEqual(2, count);
         }
 
         [TestMethod]
@@ -24,7 +23,7 @@ namespace DotNetWorkQueue.Tests.Queue
             var count = 0;
             var sut = new ConsumerMetricsNotification(() => { }, () => count++, () => { }, () => { });
             sut.IncrementErrored();
-            count.Should().Be(1);
+            Assert.AreEqual(1, count);
         }
 
         [TestMethod]
@@ -33,7 +32,7 @@ namespace DotNetWorkQueue.Tests.Queue
             var count = 0;
             var sut = new ConsumerMetricsNotification(() => { }, () => { }, () => count++, () => { });
             sut.IncrementRolledBack();
-            count.Should().Be(1);
+            Assert.AreEqual(1, count);
         }
 
         [TestMethod]
@@ -42,7 +41,7 @@ namespace DotNetWorkQueue.Tests.Queue
             var count = 0;
             var sut = new ConsumerMetricsNotification(() => { }, () => { }, () => { }, () => count++);
             sut.IncrementPoisonMessage();
-            count.Should().Be(1);
+            Assert.AreEqual(1, count);
         }
 
         [TestMethod]
@@ -53,10 +52,10 @@ namespace DotNetWorkQueue.Tests.Queue
             Action act3 = () => new ConsumerMetricsNotification(() => { }, () => { }, null, () => { });
             Action act4 = () => new ConsumerMetricsNotification(() => { }, () => { }, () => { }, null);
 
-            act1.Should().Throw<ArgumentNullException>();
-            act2.Should().Throw<ArgumentNullException>();
-            act3.Should().Throw<ArgumentNullException>();
-            act4.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act1);
+            Assert.Throws<ArgumentNullException>(act2);
+            Assert.Throws<ArgumentNullException>(act3);
+            Assert.Throws<ArgumentNullException>(act4);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Tests/Queue/ConsumerQueueNotificationTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/ConsumerQueueNotificationTests.cs
@@ -1,6 +1,5 @@
 using DotNetWorkQueue.Notifications;
 using DotNetWorkQueue.Queue;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
@@ -44,7 +43,7 @@ namespace DotNetWorkQueue.Tests.Queue
 
             sut.InvokeMessageComplete(new MessageCompleteNotification(null, null, null, null));
 
-            called.Should().BeTrue();
+            Assert.IsTrue(called);
             metrics.Received(1).IncrementProcessed();
         }
 
@@ -61,7 +60,7 @@ namespace DotNetWorkQueue.Tests.Queue
 
             sut.InvokeRollback(new RollBackNotification(null, null, null, null));
 
-            called.Should().BeTrue();
+            Assert.IsTrue(called);
             metrics.Received(1).IncrementRolledBack();
         }
     }
@@ -103,7 +102,7 @@ namespace DotNetWorkQueue.Tests.Queue
 
             sut.InvokeError(new ErrorNotification(null, null, null, null));
 
-            called.Should().BeTrue();
+            Assert.IsTrue(called);
             metrics.Received(1).IncrementErrored();
         }
 
@@ -119,7 +118,7 @@ namespace DotNetWorkQueue.Tests.Queue
 
             sut.InvokePoisonMessageError(new PoisonMessageNotification(new DotNetWorkQueue.Exceptions.PoisonMessageException()));
 
-            called.Should().BeTrue();
+            Assert.IsTrue(called);
             metrics.Received(1).IncrementPoisonMessage();
         }
 

--- a/Source/DotNetWorkQueue.Tests/Queue/MessageCancellationTrackerTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/MessageCancellationTrackerTests.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using System.Threading;
 using DotNetWorkQueue.Queue;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Tests.Queue
@@ -31,7 +30,7 @@ namespace DotNetWorkQueue.Tests.Queue
         {
             var tracker = new MessageCancellationTracker();
             var token = tracker.Register("test-register-1");
-            token.CanBeCanceled.Should().BeTrue();
+            Assert.IsTrue(token.CanBeCanceled);
             tracker.Unregister("test-register-1");
         }
 
@@ -43,7 +42,7 @@ namespace DotNetWorkQueue.Tests.Queue
             var token = tracker.Register("test-link-1", workerCts.Token);
 
             workerCts.Cancel();
-            token.IsCancellationRequested.Should().BeTrue();
+            Assert.IsTrue(token.IsCancellationRequested);
             tracker.Unregister("test-link-1");
             workerCts.Dispose();
         }
@@ -55,8 +54,8 @@ namespace DotNetWorkQueue.Tests.Queue
             var token = tracker.Register("test-cancel-1");
 
             var result = tracker.Cancel("test-cancel-1");
-            result.Should().BeTrue();
-            token.IsCancellationRequested.Should().BeTrue();
+            Assert.IsTrue(result);
+            Assert.IsTrue(token.IsCancellationRequested);
             tracker.Unregister("test-cancel-1");
         }
 
@@ -64,7 +63,7 @@ namespace DotNetWorkQueue.Tests.Queue
         public void Cancel_Returns_False_For_Unknown_Id()
         {
             var tracker = new MessageCancellationTracker();
-            tracker.Cancel("nonexistent").Should().BeFalse();
+            Assert.IsFalse(tracker.Cancel("nonexistent"));
         }
 
         [TestMethod]
@@ -73,8 +72,8 @@ namespace DotNetWorkQueue.Tests.Queue
             var tracker = new MessageCancellationTracker();
             tracker.Register("test-double-cancel-1");
 
-            tracker.Cancel("test-double-cancel-1").Should().BeTrue();
-            tracker.Cancel("test-double-cancel-1").Should().BeFalse();
+            Assert.IsTrue(tracker.Cancel("test-double-cancel-1"));
+            Assert.IsFalse(tracker.Cancel("test-double-cancel-1"));
             tracker.Unregister("test-double-cancel-1");
         }
 
@@ -85,7 +84,7 @@ namespace DotNetWorkQueue.Tests.Queue
             tracker.Register("test-unregister-1");
             tracker.Unregister("test-unregister-1");
 
-            tracker.Cancel("test-unregister-1").Should().BeFalse();
+            Assert.IsFalse(tracker.Cancel("test-unregister-1"));
         }
 
         [TestMethod]
@@ -101,9 +100,9 @@ namespace DotNetWorkQueue.Tests.Queue
             var tracker = new MessageCancellationTracker();
             tracker.Register("test-processing-1");
 
-            MessageCancellationTracker.IsProcessing("test-processing-1").Should().BeTrue();
+            Assert.IsTrue(MessageCancellationTracker.IsProcessing("test-processing-1"));
             tracker.Unregister("test-processing-1");
-            MessageCancellationTracker.IsProcessing("test-processing-1").Should().BeFalse();
+            Assert.IsFalse(MessageCancellationTracker.IsProcessing("test-processing-1"));
         }
     }
 }

--- a/Source/DotNetWorkQueue.Tests/Queue/MessageHandlerCancellationDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/MessageHandlerCancellationDecoratorTests.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using DotNetWorkQueue.Queue;
-using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -47,8 +46,8 @@ namespace DotNetWorkQueue.Tests.Queue
 
             decorator.Handle(message, notification);
 
-            captured.Should().NotBeNull();
-            captured.Token.CanBeCanceled.Should().BeTrue();
+            Assert.IsNotNull(captured);
+            Assert.IsTrue(captured.Token.CanBeCanceled);
         }
 
         [TestMethod]
@@ -63,7 +62,7 @@ namespace DotNetWorkQueue.Tests.Queue
 
             decorator.Handle(message, notification);
 
-            MessageCancellationTracker.IsProcessing("unregister-success-1").Should().BeFalse();
+            Assert.IsFalse(MessageCancellationTracker.IsProcessing("unregister-success-1"));
         }
 
         [TestMethod]
@@ -79,9 +78,9 @@ namespace DotNetWorkQueue.Tests.Queue
             var notification = CreateNotification();
 
             Action act = () => decorator.Handle(message, notification);
-            act.Should().Throw<InvalidOperationException>();
+            Assert.Throws<InvalidOperationException>(act);
 
-            MessageCancellationTracker.IsProcessing("unregister-error-1").Should().BeFalse();
+            Assert.IsFalse(MessageCancellationTracker.IsProcessing("unregister-error-1"));
         }
 
         [TestMethod]
@@ -96,7 +95,7 @@ namespace DotNetWorkQueue.Tests.Queue
 
             decorator.Handle(message, notification);
 
-            notification.MessageCancellation.Should().BeOfType<MessageCancellationNoOp>();
+            Assert.AreEqual(typeof(MessageCancellationNoOp), notification.MessageCancellation.GetType());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Phase 2 of #159 — migrate `DotNetWorkQueue.Tests` to MSTest assertions

Second increment of [#159](https://github.com/blehnen/DotNetWorkQueue/issues/159). **Test-only, no production code, no version bump.** Migrates the 8 FluentAssertions-using files in the core `DotNetWorkQueue.Tests` project (76 `.Should()` sites) to built-in MSTest assertions and removes the project's FA `PackageReference`. This is the first real migration and establishes the mechanical mapping patterns the remaining phases reuse.

### Mapping patterns established
- `.Should().Be(x)` → `Assert.AreEqual(x, actual)` (expected-first)
- `.Should().BeSameAs(x)` → `Assert.AreSame(x, actual)`; `BeTrue/False`→`Assert.IsTrue/IsFalse`; `BeNull/NotBeNull`→`Assert.IsNull/IsNotNull`
- `.Should().BeOfType<T>()` → `Assert.AreEqual(typeof(T), x.GetType())` — **exact type** preserved (not `IsInstanceOfType`, which would accept subclasses)
- `act.Should().Throw<T>()` → `Assert.Throws<T>(act)` (matches T-or-derived, like FA). `.NotThrow()` → invoke `act();`. **Note:** MSTest 4.x removed `Assert.ThrowsException` — `Assert.Throws<T>` is the replacement.
- String `NotContain` → `Assert.IsFalse(str.Contains(...))`; `HashSet<T>` membership → `.Count`/`.Contains` (no `CollectionAssert`, which doesn't support non-generic-`ICollection`-less types)

### Scope & verification
- 8 test files migrated + FA `PackageReference` removed from `DotNetWorkQueue.Tests.csproj`.
- `Directory.Packages.props` left **untouched** — FluentAssertions stays there until the final-phase cleanup, since other projects still reference it.
- Release build (`-p:CI=true`, `TreatWarningsAsErrors`) clean — proves FA is fully unused.
- `dotnet test` → **905/905 pass**, identical to the pre-migration baseline (no test added/removed/renamed).
- No production assembly changed; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test suite to use the standard test assertion APIs throughout.
  * Improved consistency in validation, exception, and callback-behavior checks.
  * Removed an unused test assertion dependency from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->