### PR TITLE
Refs #159: migrate Transport.LiteDb.Tests to MSTest assertions (Phase 3 PR A)

### DIFF
--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
@@ -22,7 +22,6 @@ using DotNetWorkQueue.Transport.LiteDb.Basic;
 using DotNetWorkQueue.Transport.LiteDb.Basic.Command;
 using DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler;
 using DotNetWorkQueue.Transport.LiteDb.Schema;
-using FluentAssertions;
 using LiteDB;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -59,10 +58,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.CommandHandler
             var col = db.GetCollection<JobsTable>(tableNameHelper.JobTableName);
             var all = col.FindAll().ToList();
 
-            all.Should().HaveCount(1);
-            all[0].JobName.Should().Be("TestJob");
-            all[0].JobScheduledTime.Should().Be(scheduledTime);
-            all[0].JobEventTime.Should().Be(eventTime);
+            Assert.AreEqual(1, all.Count);
+            Assert.AreEqual("TestJob", all[0].JobName);
+            Assert.AreEqual(scheduledTime, all[0].JobScheduledTime);
+            Assert.AreEqual(eventTime, all[0].JobEventTime);
         }
 
         [TestMethod]
@@ -91,10 +90,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.CommandHandler
             handler.Handle(command);
 
             var all = col.FindAll().ToList();
-            all.Should().HaveCount(1, "existing job should be updated, not duplicated");
-            all[0].JobName.Should().Be("ExistingJob");
-            all[0].JobScheduledTime.Should().Be(newScheduled);
-            all[0].JobEventTime.Should().Be(newEvent);
+            Assert.AreEqual(1, all.Count, "existing job should be updated, not duplicated");
+            Assert.AreEqual("ExistingJob", all[0].JobName);
+            Assert.AreEqual(newScheduled, all[0].JobScheduledTime);
+            Assert.AreEqual(newEvent, all[0].JobEventTime);
         }
 
         [TestMethod]
@@ -123,15 +122,15 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.CommandHandler
             handler.Handle(command);
 
             var all = col.FindAll().OrderBy(j => j.JobName).ToList();
-            all.Should().HaveCount(2);
+            Assert.AreEqual(2, all.Count);
 
             var first = all.Single(j => j.JobName == "FirstJob");
-            first.JobScheduledTime.Should().Be(firstScheduled);
-            first.JobEventTime.Should().Be(firstEvent);
+            Assert.AreEqual(firstScheduled, first.JobScheduledTime);
+            Assert.AreEqual(firstEvent, first.JobEventTime);
 
             var second = all.Single(j => j.JobName == "SecondJob");
-            second.JobScheduledTime.Should().Be(secondScheduled);
-            second.JobEventTime.Should().Be(secondEvent);
+            Assert.AreEqual(secondScheduled, second.JobScheduledTime);
+            Assert.AreEqual(secondEvent, second.JobEventTime);
         }
 
         private static TableNameHelper CreateTableNameHelper()

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/QueryHandler/DoesJobExistQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/QueryHandler/DoesJobExistQueryHandlerTests.cs
@@ -7,7 +7,6 @@ using DotNetWorkQueue.Transport.LiteDb.Schema;
 using DotNetWorkQueue.Transport.Shared;
 using LiteDB;
 using NSubstitute;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
@@ -60,7 +59,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new DoesJobExistQuery("myJob", DateTimeOffset.UtcNow, db);
                 var result = handler.Handle(query);
 
-                result.Should().Be(QueueStatuses.NotQueued);
+                Assert.AreEqual(QueueStatuses.NotQueued, result);
             }
         }
 
@@ -86,7 +85,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new DoesJobExistQuery("myJob", DateTimeOffset.UtcNow, db);
                 var result = handler.Handle(query);
 
-                result.Should().Be(QueueStatuses.Waiting);
+                Assert.AreEqual(QueueStatuses.Waiting, result);
             }
         }
 
@@ -111,7 +110,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new DoesJobExistQuery("myJob", DateTimeOffset.UtcNow, db);
                 var result = handler.Handle(query);
 
-                result.Should().Be(QueueStatuses.Processing);
+                Assert.AreEqual(QueueStatuses.Processing, result);
             }
         }
 
@@ -141,7 +140,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new DoesJobExistQuery("myJob", scheduledTime, db);
                 var result = handler.Handle(query);
 
-                result.Should().Be(QueueStatuses.Processed);
+                Assert.AreEqual(QueueStatuses.Processed, result);
             }
         }
 
@@ -171,7 +170,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new DoesJobExistQuery("myJob", differentTime, db);
                 var result = handler.Handle(query);
 
-                result.Should().Be(QueueStatuses.NotQueued);
+                Assert.AreEqual(QueueStatuses.NotQueued, result);
             }
         }
 
@@ -186,7 +185,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new DoesJobExistQuery("myJob", DateTimeOffset.UtcNow, db);
                 var result = handler.Handle(query);
 
-                result.Should().Be(QueueStatuses.NotQueued);
+                Assert.AreEqual(QueueStatuses.NotQueued, result);
             }
         }
 
@@ -202,7 +201,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new DoesJobExistQuery("nonexistentJob", DateTimeOffset.UtcNow, db);
                 var result = handler.Handle(query);
 
-                result.Should().Be(QueueStatuses.NotQueued);
+                Assert.AreEqual(QueueStatuses.NotQueued, result);
             }
         }
 

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/QueryHandler/GetJobIdQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/QueryHandler/GetJobIdQueryHandlerTests.cs
@@ -21,7 +21,6 @@ using DotNetWorkQueue.Transport.LiteDb.Basic;
 using DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler;
 using DotNetWorkQueue.Transport.LiteDb.Schema;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
@@ -94,7 +93,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new GetJobIdQuery<int>("myJob");
                 var result = handler.Handle(query);
 
-                result.Should().Be(42);
+                Assert.AreEqual(42, result);
             }
         }
 
@@ -108,7 +107,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new GetJobIdQuery<int>("missingJob");
                 var result = handler.Handle(query);
 
-                result.Should().Be(0);
+                Assert.AreEqual(0, result);
             }
         }
 
@@ -144,7 +143,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new GetJobIdQuery<int>("jobB");
                 var result = handler.Handle(query);
 
-                result.Should().Be(2);
+                Assert.AreEqual(2, result);
             }
         }
 
@@ -168,7 +167,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
                 var query = new GetJobIdQuery<int>("notThere");
                 var result = handler.Handle(query);
 
-                result.Should().Be(0);
+                Assert.AreEqual(0, result);
             }
         }
 

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/QueryMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/QueryMessageHistoryHandlerTests.cs
@@ -21,7 +21,6 @@ using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
 using DotNetWorkQueue.Transport.LiteDb.Schema;
 using NSubstitute;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
@@ -83,8 +82,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 var record = handler.GetByQueueId("q1");
 
                 // Assert: DurationMs must be 0, NOT null
-                record.Should().NotBeNull();
-                record.DurationMs.Should().Be(0L,
+                Assert.IsNotNull(record);
+                Assert.AreEqual(0L, record.DurationMs,
                     "DurationMs=0 on a completed row must be preserved as 0, not converted to null");
             }
         }
@@ -112,8 +111,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 var record = handler.GetByQueueId("q2");
 
                 // Assert: DurationMs must be null — row never completed
-                record.Should().NotBeNull();
-                record.DurationMs.Should().BeNull(
+                Assert.IsNotNull(record);
+                Assert.IsNull(record.DurationMs,
                     "DurationMs must be null when CompletedUtc=0 (row never completed)");
             }
         }

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/WriteMessageHistoryHandlerTests.cs
@@ -4,8 +4,8 @@ using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
 using DotNetWorkQueue.Transport.LiteDb.Schema;
 using NSubstitute;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
 
 namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
 {
@@ -54,14 +54,14 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var records = col.FindAll().ToList();
-                    records.Should().HaveCount(1);
-                    records[0].QueueId.Should().Be("q1");
-                    records[0].CorrelationId.Should().Be("c1");
-                    records[0].Route.Should().Be("routeA");
-                    records[0].MessageType.Should().Be("MyType");
-                    records[0].Status.Should().Be((int)MessageHistoryStatus.Enqueued);
-                    records[0].RetryCount.Should().Be(0);
-                    records[0].EnqueuedUtc.Should().BeGreaterThan(0);
+                    Assert.AreEqual(1, records.Count);
+                    Assert.AreEqual("q1", records[0].QueueId);
+                    Assert.AreEqual("c1", records[0].CorrelationId);
+                    Assert.AreEqual("routeA", records[0].Route);
+                    Assert.AreEqual("MyType", records[0].MessageType);
+                    Assert.AreEqual((int)MessageHistoryStatus.Enqueued, records[0].Status);
+                    Assert.AreEqual(0, records[0].RetryCount);
+                    Assert.IsTrue(records[0].EnqueuedUtc > 0);
                 }
             }
         }
@@ -80,8 +80,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Body.Should().BeEquivalentTo(body);
-                    record.Headers.Should().BeEquivalentTo(headers);
+                    AssertHelper.AreEquivalent(body, record.Body);
+                    AssertHelper.AreEquivalent(headers, record.Headers);
                 }
             }
         }
@@ -98,8 +98,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Body.Should().BeNull();
-                    record.Headers.Should().BeNull();
+                    Assert.IsNull(record.Body);
+                    Assert.IsNull(record.Headers);
                 }
             }
         }
@@ -119,8 +119,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Status.Should().Be((int)MessageHistoryStatus.Processing);
-                    record.StartedUtc.Should().BeGreaterThan(0);
+                    Assert.AreEqual((int)MessageHistoryStatus.Processing, record.Status);
+                    Assert.IsTrue(record.StartedUtc > 0);
                 }
             }
         }
@@ -132,7 +132,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
             using (cm)
             {
                 Action act = () => handler.RecordProcessingStart("nonexistent");
-                act.Should().NotThrow();
+                act();
             }
         }
 
@@ -152,9 +152,9 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Status.Should().Be((int)MessageHistoryStatus.Complete);
-                    record.CompletedUtc.Should().BeGreaterThan(0);
-                    record.DurationMs.Should().BeGreaterThanOrEqualTo(0);
+                    Assert.AreEqual((int)MessageHistoryStatus.Complete, record.Status);
+                    Assert.IsTrue(record.CompletedUtc > 0);
+                    Assert.IsTrue(record.DurationMs >= 0);
                 }
             }
         }
@@ -174,7 +174,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
                     // RecordComplete should have returned early without updating
-                    record.Status.Should().Be((int)MessageHistoryStatus.Processing);
+                    Assert.AreEqual((int)MessageHistoryStatus.Processing, record.Status);
                 }
             }
         }
@@ -203,9 +203,9 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Status.Should().Be((int)MessageHistoryStatus.Complete);
-                    record.StartedUtc.Should().Be(0, "StartedUtc was manually cleared to simulate missing start");
-                    record.DurationMs.Should().Be(0, "DurationMs must be explicitly 0 when StartedUtc is not set");
+                    Assert.AreEqual((int)MessageHistoryStatus.Complete, record.Status);
+                    Assert.AreEqual(0, record.StartedUtc, "StartedUtc was manually cleared to simulate missing start");
+                    Assert.AreEqual(0, record.DurationMs, "DurationMs must be explicitly 0 when StartedUtc is not set");
                 }
             }
         }
@@ -217,7 +217,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
             using (cm)
             {
                 Action act = () => handler.RecordComplete("nonexistent");
-                act.Should().NotThrow();
+                act();
             }
         }
 
@@ -237,10 +237,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Status.Should().Be((int)MessageHistoryStatus.Error);
-                    record.ExceptionText.Should().Be("Something went wrong");
-                    record.CompletedUtc.Should().BeGreaterThan(0);
-                    record.DurationMs.Should().BeGreaterThanOrEqualTo(0);
+                    Assert.AreEqual((int)MessageHistoryStatus.Error, record.Status);
+                    Assert.AreEqual("Something went wrong", record.ExceptionText);
+                    Assert.IsTrue(record.CompletedUtc > 0);
+                    Assert.IsTrue(record.DurationMs >= 0);
                 }
             }
         }
@@ -258,9 +258,9 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Status.Should().Be((int)MessageHistoryStatus.Error);
-                    record.ExceptionText.Should().Be("Error without processing");
-                    record.DurationMs.Should().Be(0);
+                    Assert.AreEqual((int)MessageHistoryStatus.Error, record.Status);
+                    Assert.AreEqual("Error without processing", record.ExceptionText);
+                    Assert.AreEqual(0, record.DurationMs);
                 }
             }
         }
@@ -272,7 +272,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
             using (cm)
             {
                 Action act = () => handler.RecordError("nonexistent", "error");
-                act.Should().NotThrow();
+                act();
             }
         }
 
@@ -292,11 +292,11 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Status.Should().Be((int)MessageHistoryStatus.Enqueued);
-                    record.RetryCount.Should().Be(1);
-                    record.StartedUtc.Should().Be(0);
-                    record.CompletedUtc.Should().Be(0);
-                    record.DurationMs.Should().Be(0);
+                    Assert.AreEqual((int)MessageHistoryStatus.Enqueued, record.Status);
+                    Assert.AreEqual(1, record.RetryCount);
+                    Assert.AreEqual(0, record.StartedUtc);
+                    Assert.AreEqual(0, record.CompletedUtc);
+                    Assert.AreEqual(0, record.DurationMs);
                 }
             }
         }
@@ -316,7 +316,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.RetryCount.Should().Be(3);
+                    Assert.AreEqual(3, record.RetryCount);
                 }
             }
         }
@@ -328,7 +328,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
             using (cm)
             {
                 Action act = () => handler.RecordRollback("nonexistent");
-                act.Should().NotThrow();
+                act();
             }
         }
 
@@ -347,8 +347,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Status.Should().Be((int)MessageHistoryStatus.Deleted);
-                    record.CompletedUtc.Should().BeGreaterThan(0);
+                    Assert.AreEqual((int)MessageHistoryStatus.Deleted, record.Status);
+                    Assert.IsTrue(record.CompletedUtc > 0);
                 }
             }
         }
@@ -360,7 +360,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
             using (cm)
             {
                 Action act = () => handler.RecordDelete("nonexistent");
-                act.Should().NotThrow();
+                act();
             }
         }
 
@@ -379,8 +379,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Status.Should().Be((int)MessageHistoryStatus.Expired);
-                    record.CompletedUtc.Should().BeGreaterThan(0);
+                    Assert.AreEqual((int)MessageHistoryStatus.Expired, record.Status);
+                    Assert.IsTrue(record.CompletedUtc > 0);
                 }
             }
         }
@@ -392,7 +392,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
             using (cm)
             {
                 Action act = () => handler.RecordExpire("nonexistent");
-                act.Should().NotThrow();
+                act();
             }
         }
 
@@ -412,11 +412,11 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
-                    record.Status.Should().Be((int)MessageHistoryStatus.Complete);
-                    record.QueueId.Should().Be("q1");
-                    record.CorrelationId.Should().Be("c1");
-                    record.Route.Should().Be("route1");
-                    record.MessageType.Should().Be("MyMessage");
+                    Assert.AreEqual((int)MessageHistoryStatus.Complete, record.Status);
+                    Assert.AreEqual("q1", record.QueueId);
+                    Assert.AreEqual("c1", record.CorrelationId);
+                    Assert.AreEqual("route1", record.Route);
+                    Assert.AreEqual("MyMessage", record.MessageType);
                 }
             }
         }

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/DotNetWorkQueue.Transport.LiteDb.Tests.csproj
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/DotNetWorkQueue.Transport.LiteDb.Tests.csproj
@@ -8,13 +8,13 @@
     <ProjectReference Include="..\DotNetWorkQueue.Transport.LiteDB\DotNetWorkQueue.Transport.LiteDb.csproj" />
     <ProjectReference Include="..\DotNetWorkQueue.Transport.RelationalDatabase\DotNetWorkQueue.Transport.RelationalDatabase.csproj" />
     <ProjectReference Include="..\DotNetWorkQueue\DotNetWorkQueue.csproj" />
+    <ProjectReference Include="..\DotNetWorkQueue.Tests.Shared\DotNetWorkQueue.Tests.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
 <PackageReference Include="CompareNETObjects" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="MSTest.TestFramework" />


### PR DESCRIPTION
Part of #159 (replace FluentAssertions with MSTest assertions). Phase 3, PR A of 2.

Migrates **`DotNetWorkQueue.Transport.LiteDb.Tests`** (77 `.Should()` sites across 5 files) from FluentAssertions to built-in MSTest assertions and removes the project's `FluentAssertions` PackageReference. Adds a `ProjectReference` to `DotNetWorkQueue.Tests.Shared` for the one non-1:1 pattern.

## Files
- `Basic/QueryMessageHistoryHandlerTests.cs` (4)
- `Basic/QueryHandler/DoesJobExistQueryHandlerTests.cs` (7)
- `Basic/QueryHandler/GetJobIdQueryHandlerTests.cs` (4)
- `Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs` (13)
- `Basic/WriteMessageHistoryHandlerTests.cs` (49)
- csproj: +`Tests.Shared` ProjectReference, −`FluentAssertions`

## Mapping notes
- Expected-first `Assert.AreEqual`; `.Should().Be(x)`→`AreEqual`, `HaveCount(n)`→`AreEqual(n, .Count)`, `NotBeNull`/`BeNull`→`IsNotNull`/`IsNull`.
- `BeEquivalentTo(byte[])` → `AssertHelper.AreEquivalent` (order-insensitive, matches FA default).
- `BeGreaterThan(0)`/`BeGreaterThanOrEqualTo(0)` → `Assert.IsTrue(x > 0)`/`(x >= 0)`.
- `NotThrow()` → bare `act();`.

## Verification
- `dotnet build -c Release` (TreatWarningsAsErrors) → 0 warnings, 0 errors.
- `dotnet test -c Release` → **168/168 passed**.
- Project grep for `FluentAssertions`/`.Should()` → zero.
- `Source/Directory.Packages.props` FA entry intentionally left in place (removed in the final #159 phase).

Test-only; no production code change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to use the built-in test framework consistently.
  * Added broader coverage helpers for comparing complex values in history-related tests.
  * Removed an unused test dependency and adjusted test project references accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->