### PR TITLE
Refs #159: migrate SQLite.Tests + Memory.Integration.Tests + IntegrationTests.Shared to MSTest (Phase 3 PR B)

### DIFF
--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/DotNetWorkQueue.IntegrationTests.Shared.csproj
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/DotNetWorkQueue.IntegrationTests.Shared.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="MSTest.TestAdapter" />

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/JobScheduler/JobSchedulerTestsShared.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/JobScheduler/JobSchedulerTestsShared.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Interceptors;
-using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -270,7 +269,7 @@ namespace DotNetWorkQueue.IntegrationTests.Shared.JobScheduler
             long nonFatal, long inQueueCount, ICreationScope scope)
         {
             Assert.AreEqual(0, enqueued);
-            error.Should().BeNull("no errors should occur");
+            Assert.IsNull(error, "no errors should occur");
             Assert.AreEqual(1, nonFatal);
             verify(queueConnection, inQueueCount, scope);
         }

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/LoggerShared.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/LoggerShared.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -36,9 +35,8 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
                 using (var textReader = new StreamReader(fileStream))
                 {
                     var errors = textReader.ReadToEnd();
-                    errors.Should()
-                        .NotBeNullOrWhiteSpace(
-                            $"errors should have occurred, however no errors where found for queue {queueName}");
+                    Assert.IsFalse(string.IsNullOrWhiteSpace(errors),
+                        $"errors should have occurred, however no errors where found for queue {queueName}");
                 }
             }
             else
@@ -58,8 +56,8 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
                 using (var textReader = new StreamReader(fileStream))
                 {
                     var errors = textReader.ReadToEnd();
-                    errors.Should()
-                        .BeEmpty("No errors should have occurred, however the following errors where found {0}", errors);
+                    Assert.AreEqual(string.Empty, errors,
+                        $"No errors should have occurred, however the following errors where found {errors}");
                 }
             }
         }

--- a/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Cancellation/MessageCancellationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Cancellation/MessageCancellationTests.cs
@@ -22,7 +22,6 @@ using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.IntegrationTests.Shared;
 using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Cancellation
@@ -86,7 +85,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Cancellation
                                 }, null);
 
                                 // Wait for handler to start
-                                handlerStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("handler should start");
+                                Assert.IsTrue(handlerStarted.Wait(TimeSpan.FromSeconds(10)), "handler should start");
 
                                 // Give the tracker a moment to register
                                 Thread.Sleep(100);
@@ -104,7 +103,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Cancellation
                                 // by checking the handler's observation
 
                                 // Wait for handler to complete (it will timeout after 10s or get cancelled)
-                                handlerCompleted.Wait(TimeSpan.FromSeconds(15)).Should().BeTrue("handler should complete");
+                                Assert.IsTrue(handlerCompleted.Wait(TimeSpan.FromSeconds(15)), "handler should complete");
                             }
                         }
 
@@ -160,12 +159,12 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Cancellation
                                     handlerCompleted.Set();
                                 }, null);
 
-                                handlerCompleted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("handler should complete");
+                                Assert.IsTrue(handlerCompleted.Wait(TimeSpan.FromSeconds(10)), "handler should complete");
                             }
                         }
 
-                        tokenWasAvailable.Should().BeTrue("MessageCancellation should be set on workerNotification");
-                        tokenCanBeCanceled.Should().BeTrue("The cancellation token should be cancelable");
+                        Assert.IsTrue(tokenWasAvailable, "MessageCancellation should be set on workerNotification");
+                        Assert.IsTrue(tokenCanBeCanceled, "The cancellation token should be cancelable");
                     }
                 }
             }

--- a/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Consumer/ConsumerRollBack.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Consumer/ConsumerRollBack.cs
@@ -4,7 +4,6 @@ using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.IntegrationTests.Shared;
 using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Consumer
@@ -75,13 +74,13 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Consumer
                                         allDone.Set();
                                 }, new ConsumerQueueNotifications());
 
-                                allDone.Wait(TimeSpan.FromSeconds(30)).Should().BeTrue(
+                                Assert.IsTrue(allDone.Wait(TimeSpan.FromSeconds(30)),
                                     "consumer should process remaining messages after errors");
                             }
                         }
 
-                        processedCount.Should().Be(3, "3 messages should be processed successfully");
-                        errorCount.Should().Be(2, "2 messages should have thrown errors");
+                        Assert.AreEqual(3, processedCount, "3 messages should be processed successfully");
+                        Assert.AreEqual(2, errorCount, "2 messages should have thrown errors");
                     }
                 }
             }
@@ -136,13 +135,13 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Consumer
                                 }, new ConsumerQueueNotifications());
 
                                 // Wait for first message then stop
-                                firstMessageProcessed.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue(
+                                Assert.IsTrue(firstMessageProcessed.Wait(TimeSpan.FromSeconds(10)),
                                     "at least one message should be processed");
                             }
                             // Consumer disposed -- no crash
                         }
 
-                        processedCount.Should().BeGreaterThanOrEqualTo(1,
+                        Assert.IsTrue(processedCount >= 1,
                             "at least one message should have been processed before stop");
                     }
                 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Dashboard/DashboardQueries.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Dashboard/DashboardQueries.cs
@@ -26,7 +26,6 @@ using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
@@ -124,10 +123,10 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardStatusCountsQuery())
                     .GetAwaiter().GetResult();
 
-                result.Waiting.Should().Be(5);
-                result.Processing.Should().Be(0);
-                result.Error.Should().Be(0);
-                result.Total.Should().Be(5);
+                Assert.AreEqual(5, result.Waiting);
+                Assert.AreEqual(0, result.Processing);
+                Assert.AreEqual(0, result.Error);
+                Assert.AreEqual(5, result.Total);
             });
         }
 
@@ -143,10 +142,10 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardStatusCountsQuery())
                     .GetAwaiter().GetResult();
 
-                result.Waiting.Should().Be(3);
-                result.Processing.Should().Be(2);
-                result.Error.Should().Be(0);
-                result.Total.Should().Be(5);
+                Assert.AreEqual(3, result.Waiting);
+                Assert.AreEqual(2, result.Processing);
+                Assert.AreEqual(0, result.Error);
+                Assert.AreEqual(5, result.Total);
             });
         }
 
@@ -160,7 +159,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessageCountQuery(null))
                     .GetAwaiter().GetResult();
 
-                result.Should().Be(5);
+                Assert.AreEqual(5, result);
             });
         }
 
@@ -174,7 +173,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessageCountQuery(0))
                     .GetAwaiter().GetResult();
 
-                result.Should().Be(3);
+                Assert.AreEqual(3, result);
             });
         }
 
@@ -188,7 +187,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessageCountQuery(1))
                     .GetAwaiter().GetResult();
 
-                result.Should().Be(2);
+                Assert.AreEqual(2, result);
             });
         }
 
@@ -202,7 +201,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessageCountQuery(2))
                     .GetAwaiter().GetResult();
 
-                result.Should().Be(0);
+                Assert.AreEqual(0, result);
             });
         }
 
@@ -222,11 +221,11 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
 
-                result.Should().HaveCount(3);
+                Assert.AreEqual(3, result.Count);
                 foreach (var msg in result)
                 {
-                    msg.QueueId.Should().NotBeNullOrEmpty();
-                    msg.Status.Should().Be(0);
+                    Assert.IsFalse(string.IsNullOrEmpty(msg.QueueId));
+                    Assert.AreEqual(0, msg.Status);
                 }
             });
         }
@@ -243,10 +242,10 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessagesQuery(0, 100, 0))
                     .GetAwaiter().GetResult();
 
-                result.Should().HaveCount(2);
+                Assert.AreEqual(2, result.Count);
                 foreach (var msg in result)
                 {
-                    msg.Status.Should().Be(0);
+                    Assert.AreEqual(0, msg.Status);
                 }
             });
         }
@@ -263,8 +262,8 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessagesQuery(0, 100, 1))
                     .GetAwaiter().GetResult();
 
-                result.Should().HaveCount(1);
-                result[0].Status.Should().Be(1);
+                Assert.AreEqual(1, result.Count);
+                Assert.AreEqual(1, result[0].Status);
             });
         }
 
@@ -280,7 +279,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessagesQuery(0, 100, 2))
                     .GetAwaiter().GetResult();
 
-                result.Should().BeEmpty();
+                Assert.AreEqual(0, result.Count);
             });
         }
 
@@ -301,7 +300,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var messages = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
-                messages.Should().HaveCount(1);
+                Assert.AreEqual(1, messages.Count);
 
                 var detailHandler =
                     container
@@ -311,11 +310,11 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                     .HandleAsync(new GetDashboardMessageDetailQuery(messages[0].QueueId))
                     .GetAwaiter().GetResult();
 
-                detail.Should().NotBeNull();
-                detail.QueueId.Should().Be(messages[0].QueueId);
-                detail.Status.Should().Be(0);
-                detail.QueuedDateTime.Should().NotBeNull();
-                detail.CorrelationId.Should().NotBeNullOrEmpty();
+                Assert.IsNotNull(detail);
+                Assert.AreEqual(messages[0].QueueId, detail.QueueId);
+                Assert.AreEqual(0, detail.Status);
+                Assert.IsNotNull(detail.QueuedDateTime);
+                Assert.IsFalse(string.IsNullOrEmpty(detail.CorrelationId));
             });
         }
 
@@ -332,7 +331,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                     .HandleAsync(new GetDashboardMessageDetailQuery(Guid.NewGuid().ToString()))
                     .GetAwaiter().GetResult();
 
-                result.Should().BeNull();
+                Assert.IsNull(result);
             });
         }
 
@@ -348,7 +347,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var messages = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
-                messages.Should().HaveCount(1);
+                Assert.AreEqual(1, messages.Count);
 
                 var bodyHandler =
                     container
@@ -358,9 +357,9 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                     .HandleAsync(new GetDashboardMessageBodyQuery(messages[0].QueueId))
                     .GetAwaiter().GetResult();
 
-                body.Should().NotBeNull();
-                body.Body.Should().NotBeNullOrEmpty();
-                body.Headers.Should().NotBeNullOrEmpty();
+                Assert.IsNotNull(body);
+                Assert.IsTrue(body.Body != null && body.Body.Length > 0);
+                Assert.IsTrue(body.Headers != null && body.Headers.Length > 0);
             });
         }
 
@@ -376,7 +375,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var messages = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
-                messages.Should().HaveCount(1);
+                Assert.AreEqual(1, messages.Count);
 
                 var headerHandler =
                     container
@@ -386,8 +385,8 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                     .HandleAsync(new GetDashboardMessageHeadersQuery(messages[0].QueueId))
                     .GetAwaiter().GetResult();
 
-                headers.Should().NotBeNull();
-                headers.Headers.Should().NotBeNullOrEmpty();
+                Assert.IsNotNull(headers);
+                Assert.IsTrue(headers.Headers != null && headers.Headers.Length > 0);
             });
         }
 
@@ -407,7 +406,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardJobsQuery())
                     .GetAwaiter().GetResult();
 
-                result.Should().BeEmpty();
+                Assert.AreEqual(0, result.Count);
             });
         }
 
@@ -428,7 +427,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var messages = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
-                messages.Should().HaveCount(1);
+                Assert.AreEqual(1, messages.Count);
 
                 var deleteHandler =
                     container
@@ -437,7 +436,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var deleted = deleteHandler.Handle(
                     new DashboardDeleteMessageCommand(messages[0].QueueId));
 
-                deleted.Should().Be(1);
+                Assert.AreEqual(1, deleted);
 
                 // Verify message is gone
                 var countHandler =
@@ -446,8 +445,8 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                             DashboardStatusCounts>>();
                 var counts = countHandler.HandleAsync(new GetDashboardStatusCountsQuery())
                     .GetAwaiter().GetResult();
-                counts.Waiting.Should().Be(0);
-                counts.Total.Should().Be(0);
+                Assert.AreEqual(0, counts.Waiting);
+                Assert.AreEqual(0, counts.Total);
             });
         }
 
@@ -463,7 +462,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.Handle(
                     new DashboardDeleteMessageCommand(Guid.NewGuid().ToString()));
 
-                result.Should().Be(0);
+                Assert.AreEqual(0, result);
             });
         }
 
@@ -480,7 +479,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var processing = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, 1))
                     .GetAwaiter().GetResult();
-                processing.Should().HaveCount(1);
+                Assert.AreEqual(1, processing.Count);
 
                 var deleteHandler =
                     container
@@ -489,7 +488,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var deleted = deleteHandler.Handle(
                     new DashboardDeleteMessageCommand(processing[0].QueueId));
 
-                deleted.Should().Be(1);
+                Assert.AreEqual(1, deleted);
 
                 // Verify processing count is now 0
                 var countHandler =
@@ -498,9 +497,9 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                             DashboardStatusCounts>>();
                 var counts = countHandler.HandleAsync(new GetDashboardStatusCountsQuery())
                     .GetAwaiter().GetResult();
-                counts.Processing.Should().Be(0);
-                counts.Waiting.Should().Be(1);
-                counts.Total.Should().Be(1);
+                Assert.AreEqual(0, counts.Processing);
+                Assert.AreEqual(1, counts.Waiting);
+                Assert.AreEqual(1, counts.Total);
             });
         }
 
@@ -520,7 +519,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardStaleMessagesQuery(60, 0, 100))
                     .GetAwaiter().GetResult();
 
-                result.Should().BeEmpty();
+                Assert.AreEqual(0, result.Count);
             });
         }
 
@@ -536,7 +535,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardErrorMessagesQuery(0, 100))
                     .GetAwaiter().GetResult();
 
-                result.Should().BeEmpty();
+                Assert.AreEqual(0, result.Count);
             });
         }
 
@@ -551,7 +550,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardErrorMessageCountQuery())
                     .GetAwaiter().GetResult();
 
-                result.Should().Be(0);
+                Assert.AreEqual(0, result);
             });
         }
 
@@ -568,7 +567,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                     .HandleAsync(new GetDashboardErrorRetriesQuery(Guid.NewGuid().ToString()))
                     .GetAwaiter().GetResult();
 
-                result.Should().BeEmpty();
+                Assert.AreEqual(0, result.Count);
             });
         }
 
@@ -583,7 +582,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardConfigurationQuery())
                     .GetAwaiter().GetResult();
 
-                result.Should().BeNull();
+                Assert.IsNull(result);
             });
         }
 
@@ -598,7 +597,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                             DashboardDeleteAllErrorMessagesCommand, long>>();
                 var result = handler.Handle(new DashboardDeleteAllErrorMessagesCommand());
 
-                result.Should().Be(0);
+                Assert.AreEqual(0, result);
             });
         }
 
@@ -614,7 +613,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.Handle(
                     new DashboardRequeueErrorMessageCommand(Guid.NewGuid().ToString()));
 
-                result.Should().Be(0);
+                Assert.AreEqual(0, result);
             });
         }
 
@@ -630,7 +629,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.Handle(
                     new DashboardResetStaleMessageCommand(Guid.NewGuid().ToString()));
 
-                result.Should().Be(0);
+                Assert.AreEqual(0, result);
             });
         }
 
@@ -649,7 +648,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                         new byte[] { 1, 2, 3 },
                         new byte[] { 4, 5, 6 }));
 
-                result.Should().Be(0);
+                Assert.AreEqual(0, result);
             });
         }
 

--- a/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/DotNetWorkQueue.Transport.Memory.Integration.Tests.csproj
+++ b/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/DotNetWorkQueue.Transport.Memory.Integration.Tests.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
-<PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="MSTest.TestFramework" />

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
@@ -6,7 +6,6 @@ using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler;
 using NSubstitute;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic.CommandHandler

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/DotNetWorkQueue.Transport.SQLite.Tests.csproj
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/DotNetWorkQueue.Transport.SQLite.Tests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
 <PackageReference Include="CompareNETObjects" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="MSTest.TestFramework" />


### PR DESCRIPTION
Part of #159 (replace FluentAssertions with MSTest assertions). Phase 3, PR B of 2 — the three mechanical/trivial projects.

## Projects
- **`Transport.SQLite.Tests`** — 0 `.Should()` sites; removes a dead `using FluentAssertions;` + the `FluentAssertions` PackageReference.
- **`Transport.Memory.Integration.Tests`** — 64 sites across `MessageCancellationTests.cs`, `ConsumerRollBack.cs`, `DashboardQueries.cs`; removes FA ref.
- **`DotNetWorkQueue.IntegrationTests.Shared`** — 3 sites (`LoggerShared.cs`, `JobScheduler/JobSchedulerTestsShared.cs`); removes FA ref. This project is `ProjectReference`d by 13 integration test projects, all of which own their own FA ref, so removing it here is safe — validated by a full-solution build.

## Mapping notes
- `NotBeNullOrEmpty()` split by receiver type: string → `Assert.IsFalse(string.IsNullOrEmpty(x))`; `byte[]` → `Assert.IsTrue(x != null && x.Length > 0)`.
- `bool.Wait(...).Should().BeTrue(reason)` → `Assert.IsTrue(Wait(...), reason)`; `BeGreaterThanOrEqualTo(1)` → `Assert.IsTrue(x >= 1)`.
- FA composite-format reason `BeEmpty("...{0}", errors)` → `Assert.AreEqual(string.Empty, errors, $"...{errors}")` (MSTest has no format-args overload).

## Verification
- Full-solution `dotnet build Source/DotNetWorkQueue.sln -c Release` → **0 errors** (proves the 13 IntegrationTests.Shared consumers still compile).
- `dotnet test` → SQLite.Tests **146/146**, Memory.Integration.Tests **57/57**.
- Grep for `FluentAssertions`/`.Should()` across all three projects → zero.
- `Source/Directory.Packages.props` FA entry intentionally left in place (removed in the final #159 phase).

Test-only; no production code change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized test assertions across the suite to use built-in testing checks.
  * Removed an unused test dependency from multiple test projects.
  * Updated one test project to use a different comparison utility for assertions.
  * Kept test coverage and behavior verification intact while simplifying the test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->