### PR TITLE
Refs #159: migrate Dashboard.Client.Tests + Dashboard.Ui.Tests to MSTest assertions (Phase 4)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Client.Tests/DashboardApiClientTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Client.Tests/DashboardApiClientTests.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Client.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Client.Tests
@@ -20,28 +19,28 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
         public void Constructor_Options_Throws_When_Null()
         {
             Action act = () => new DashboardApiClient((DashboardClientOptions)null);
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         [TestMethod]
         public void Constructor_Options_Throws_When_Url_Missing()
         {
             Action act = () => new DashboardApiClient(new DashboardClientOptions());
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
         public void Constructor_HttpClient_Throws_When_Null()
         {
             Action act = () => new DashboardApiClient((HttpClient)null);
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         [TestMethod]
         public void Constructor_HttpClientFactory_Throws_When_Null()
         {
             Action act = () => new DashboardApiClient((IHttpClientFactory)null, new DashboardClientOptions { DashboardApiUrl = "http://localhost" });
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         // === GetConnectionsAsync ===
@@ -57,10 +56,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetConnectionsAsync();
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().HaveCount(1);
-            result.Value[0].DisplayName.Should().Be("Test");
-            result.Value[0].QueueCount.Should().Be(3);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, result.Value.Count);
+            Assert.AreEqual("Test", result.Value[0].DisplayName);
+            Assert.AreEqual(3, result.Value[0].QueueCount);
         }
 
         [TestMethod]
@@ -70,10 +69,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetConnectionsAsync();
 
-            result.Success.Should().BeFalse();
-            result.StatusCode.Should().Be(HttpStatusCode.NotFound);
-            result.ErrorMessage.Should().Be("Not Found");
-            result.Value.Should().BeNull();
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(HttpStatusCode.NotFound, result.StatusCode);
+            Assert.AreEqual("Not Found", result.ErrorMessage);
+            Assert.IsNull(result.Value);
         }
 
         // === GetQueueStatusAsync ===
@@ -86,9 +85,9 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetQueueStatusAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Waiting.Should().Be(10);
-            result.Value.Total.Should().Be(17);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(10, result.Value.Waiting);
+            Assert.AreEqual(17, result.Value.Total);
         }
 
         // === GetConsumersAsync ===
@@ -105,10 +104,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetConsumersAsync();
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().HaveCount(1);
-            result.Value[0].ConsumerId.Should().Be(consumerId);
-            result.Value[0].MachineName.Should().Be("M1");
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, result.Value.Count);
+            Assert.AreEqual(consumerId, result.Value[0].ConsumerId);
+            Assert.AreEqual("M1", result.Value[0].MachineName);
         }
 
         [TestMethod]
@@ -129,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var queueId = Guid.NewGuid();
             await client.GetConsumersAsync(queueId);
 
-            capturedUrl.Should().Contain($"queueId={queueId}");
+            StringAssert.Contains(capturedUrl, $"queueId={queueId}");
         }
 
         // === GetConsumerCountsAsync ===
@@ -143,9 +142,9 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetConsumerCountsAsync();
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().ContainKey(queueId);
-            result.Value[queueId].Should().Be(3);
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(result.Value.ContainsKey(queueId));
+            Assert.AreEqual(3, result.Value[queueId]);
         }
 
         // === DeleteMessageAsync returns ApiReturnValue ===
@@ -157,8 +156,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.DeleteMessageAsync(Guid.NewGuid(), "msg-1");
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().BeTrue();
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(result.Value);
         }
 
         [TestMethod]
@@ -168,8 +167,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.DeleteMessageAsync(Guid.NewGuid(), "msg-1");
 
-            result.Success.Should().BeFalse();
-            result.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(HttpStatusCode.NotFound, result.StatusCode);
         }
 
         // === GetQueuesAsync ===
@@ -183,10 +182,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetQueuesAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().HaveCount(1);
-            result.Value[0].Id.Should().Be(id);
-            result.Value[0].QueueName.Should().Be("my-queue");
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, result.Value.Count);
+            Assert.AreEqual(id, result.Value[0].Id);
+            Assert.AreEqual("my-queue", result.Value[0].QueueName);
         }
 
         // === GetJobsAsync ===
@@ -200,11 +199,11 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetJobsAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().HaveCount(1);
-            result.Value[0].JobName.Should().Be("daily");
-            result.Value[0].JobEventTime.Should().Be(now);
-            result.Value[0].JobScheduledTime.Should().Be(now.AddHours(1));
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, result.Value.Count);
+            Assert.AreEqual("daily", result.Value[0].JobName);
+            Assert.AreEqual(now, result.Value[0].JobEventTime);
+            Assert.AreEqual(now.AddHours(1), result.Value[0].JobScheduledTime);
         }
 
         // === GetQueueFeaturesAsync ===
@@ -226,14 +225,14 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetQueueFeaturesAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.EnablePriority.Should().BeTrue();
-            result.Value.EnableStatus.Should().BeTrue();
-            result.Value.EnableStatusTable.Should().BeFalse();
-            result.Value.EnableHeartBeat.Should().BeTrue();
-            result.Value.EnableDelayedProcessing.Should().BeFalse();
-            result.Value.EnableMessageExpiration.Should().BeTrue();
-            result.Value.EnableRoute.Should().BeFalse();
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(result.Value.EnablePriority);
+            Assert.IsTrue(result.Value.EnableStatus);
+            Assert.IsFalse(result.Value.EnableStatusTable);
+            Assert.IsTrue(result.Value.EnableHeartBeat);
+            Assert.IsFalse(result.Value.EnableDelayedProcessing);
+            Assert.IsTrue(result.Value.EnableMessageExpiration);
+            Assert.IsFalse(result.Value.EnableRoute);
         }
 
         // === GetQueueConfigurationAsync ===
@@ -246,8 +245,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetQueueConfigurationAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.ConfigurationJson.Should().Be("{\"heartbeat\":30}");
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual("{\"heartbeat\":30}", result.Value.ConfigurationJson);
         }
 
         // === GetMessagesAsync ===
@@ -266,12 +265,12 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetMessagesAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Items.Should().HaveCount(1);
-            result.Value.Items[0].QueueId.Should().Be("msg-1");
-            result.Value.TotalCount.Should().Be(50);
-            result.Value.PageIndex.Should().Be(0);
-            result.Value.PageSize.Should().Be(25);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, result.Value.Items.Count);
+            Assert.AreEqual("msg-1", result.Value.Items[0].QueueId);
+            Assert.AreEqual(50, result.Value.TotalCount);
+            Assert.AreEqual(0, result.Value.PageIndex);
+            Assert.AreEqual(25, result.Value.PageSize);
         }
 
         [TestMethod]
@@ -292,7 +291,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             await client.GetMessagesAsync(Guid.NewGuid(), status: 2);
 
-            capturedUrl.Should().Contain("status=2");
+            StringAssert.Contains(capturedUrl, "status=2");
         }
 
         // === GetMessageCountAsync ===
@@ -305,8 +304,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetMessageCountAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().Be(42);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(42, result.Value);
         }
 
         [TestMethod]
@@ -326,7 +325,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             await client.GetMessageCountAsync(Guid.NewGuid(), status: 1);
 
-            capturedUrl.Should().Contain("status=1");
+            StringAssert.Contains(capturedUrl, "status=1");
         }
 
         // === GetMessageAsync (detail) ===
@@ -345,11 +344,11 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetMessageAsync(Guid.NewGuid(), "msg-5");
 
-            result.Success.Should().BeTrue();
-            result.Value.QueueId.Should().Be("msg-5");
-            result.Value.Status.Should().Be(1);
-            result.Value.CorrelationId.Should().Be("corr-5");
-            result.Value.Route.Should().Be("route-b");
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual("msg-5", result.Value.QueueId);
+            Assert.AreEqual(1, result.Value.Status);
+            Assert.AreEqual("corr-5", result.Value.CorrelationId);
+            Assert.AreEqual("route-b", result.Value.Route);
         }
 
         // === GetMessageBodyAsync ===
@@ -368,11 +367,11 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetMessageBodyAsync(Guid.NewGuid(), "msg-1");
 
-            result.Success.Should().BeTrue();
-            result.Value.Body.Should().Be("{\"data\":1}");
-            result.Value.TypeName.Should().Be("MyMessage");
-            result.Value.IsEditable.Should().BeTrue();
-            result.Value.IsProcessing.Should().BeFalse();
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual("{\"data\":1}", result.Value.Body);
+            Assert.AreEqual("MyMessage", result.Value.TypeName);
+            Assert.IsTrue(result.Value.IsEditable);
+            Assert.IsFalse(result.Value.IsProcessing);
         }
 
         // === GetMessageHeadersAsync ===
@@ -388,9 +387,9 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetMessageHeadersAsync(Guid.NewGuid(), "msg-1");
 
-            result.Success.Should().BeTrue();
-            result.Value.Headers.Should().HaveCount(2);
-            result.Value.Headers["key1"].Should().Be("val1");
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(2, result.Value.Headers.Count);
+            Assert.AreEqual("val1", result.Value.Headers["key1"]);
         }
 
         // === GetErrorRetriesAsync ===
@@ -406,11 +405,11 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetErrorRetriesAsync(Guid.NewGuid(), "msg-1");
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().HaveCount(1);
-            result.Value[0].ErrorTrackingId.Should().Be(1);
-            result.Value[0].ExceptionType.Should().Be("System.Exception");
-            result.Value[0].RetryCount.Should().Be(3);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, result.Value.Count);
+            Assert.AreEqual(1, result.Value[0].ErrorTrackingId);
+            Assert.AreEqual("System.Exception", result.Value[0].ExceptionType);
+            Assert.AreEqual(3, result.Value[0].RetryCount);
         }
 
         // === GetStaleMessagesAsync ===
@@ -429,10 +428,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetStaleMessagesAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Items.Should().HaveCount(1);
-            result.Value.Items[0].QueueId.Should().Be("stale-1");
-            result.Value.TotalCount.Should().Be(5);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, result.Value.Items.Count);
+            Assert.AreEqual("stale-1", result.Value.Items[0].QueueId);
+            Assert.AreEqual(5, result.Value.TotalCount);
         }
 
         // === GetErrorsAsync ===
@@ -451,11 +450,11 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.GetErrorsAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Items.Should().HaveCount(1);
-            result.Value.Items[0].QueueId.Should().Be("msg-1");
-            result.Value.Items[0].LastException.Should().Be("boom");
-            result.Value.TotalCount.Should().Be(10);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(1, result.Value.Items.Count);
+            Assert.AreEqual("msg-1", result.Value.Items[0].QueueId);
+            Assert.AreEqual("boom", result.Value.Items[0].LastException);
+            Assert.AreEqual(10, result.Value.TotalCount);
         }
 
         // === RequeueErrorMessageAsync ===
@@ -467,8 +466,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.RequeueErrorMessageAsync(Guid.NewGuid(), "msg-1");
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().BeTrue();
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(result.Value);
         }
 
         // === ResetMessageAsync (stale) ===
@@ -480,8 +479,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.ResetMessageAsync(Guid.NewGuid(), "msg-1");
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().BeTrue();
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(result.Value);
         }
 
         // === EditMessageBodyAsync ===
@@ -493,8 +492,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.EditMessageBodyAsync(Guid.NewGuid(), "msg-1", "{\"updated\":true}");
 
-            result.Success.Should().BeTrue();
-            result.Value.Should().BeTrue();
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(result.Value);
         }
 
         // === RequeueAllErrorsAsync ===
@@ -507,8 +506,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.RequeueAllErrorsAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Count.Should().Be(7);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(7, result.Value.Count);
         }
 
         // === ResetAllStaleMessagesAsync ===
@@ -521,8 +520,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.ResetAllStaleMessagesAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Count.Should().Be(3);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(3, result.Value.Count);
         }
 
         // === DeleteAllErrorsAsync ===
@@ -535,8 +534,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             var result = await client.DeleteAllErrorsAsync(Guid.NewGuid());
 
-            result.Success.Should().BeTrue();
-            result.Value.Deleted.Should().Be(12);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(12, result.Value.Deleted);
         }
 
         // === Dispose ===
@@ -559,7 +558,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             client.Dispose();
 
             // External client should still be usable (not disposed)
-            httpClient.BaseAddress.Should().NotBeNull();
+            Assert.IsNotNull(httpClient.BaseAddress);
         }
 
         // === Helpers ===

--- a/Source/DotNetWorkQueue.Dashboard.Client.Tests/DashboardConsumerClientTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Client.Tests/DashboardConsumerClientTests.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Client.Tests
@@ -29,7 +28,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
         public void Constructor_Throws_When_Options_Null()
         {
             Action act = () => new DashboardConsumerClient((DashboardClientOptions)null);
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         [TestMethod]
@@ -38,7 +37,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var opts = CreateOptions();
             opts.DashboardApiUrl = null;
             Action act = () => new DashboardConsumerClient(opts);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
@@ -47,21 +46,21 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var opts = CreateOptions();
             opts.QueueName = null;
             Action act = () => new DashboardConsumerClient(opts);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
         public void Constructor_HttpClient_Throws_When_Null()
         {
             Action act = () => new DashboardConsumerClient((HttpClient)null, CreateOptions());
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         [TestMethod]
         public void Constructor_HttpClientFactory_Throws_When_Null()
         {
             Action act = () => new DashboardConsumerClient((IHttpClientFactory)null, CreateOptions());
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         // === StartAsync ===
@@ -93,8 +92,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             await client.StartAsync();
 
-            client.ConsumerId.Should().Be(consumerId);
-            client.IsRegistered.Should().BeTrue();
+            Assert.AreEqual(consumerId, client.ConsumerId);
+            Assert.IsTrue(client.IsRegistered);
         }
 
         [TestMethod]
@@ -121,7 +120,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             await client.StartAsync();
             await client.StartAsync();
 
-            callCount.Should().Be(1);
+            Assert.AreEqual(1, callCount);
         }
 
         // === StopAsync ===
@@ -150,11 +149,11 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             using var client = new DashboardConsumerClient(httpClient, CreateOptions());
 
             await client.StartAsync();
-            client.IsRegistered.Should().BeTrue();
+            Assert.IsTrue(client.IsRegistered);
 
             await client.StopAsync();
-            client.IsRegistered.Should().BeFalse();
-            client.ConsumerId.Should().BeNull();
+            Assert.IsFalse(client.IsRegistered);
+            Assert.IsNull(client.ConsumerId);
         }
 
         // === Metrics ===
@@ -166,10 +165,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000/") };
             using var client = new DashboardConsumerClient(httpClient, CreateOptions());
 
-            client.MessagesProcessed.Should().Be(0);
-            client.MessagesErrored.Should().Be(0);
-            client.MessagesRolledBack.Should().Be(0);
-            client.PoisonMessages.Should().Be(0);
+            Assert.AreEqual(0, client.MessagesProcessed);
+            Assert.AreEqual(0, client.MessagesErrored);
+            Assert.AreEqual(0, client.MessagesRolledBack);
+            Assert.AreEqual(0, client.PoisonMessages);
         }
 
         [TestMethod]
@@ -183,7 +182,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             client.IncrementProcessed();
             client.IncrementProcessed();
 
-            client.MessagesProcessed.Should().Be(3);
+            Assert.AreEqual(3, client.MessagesProcessed);
         }
 
         [TestMethod]
@@ -196,7 +195,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             client.IncrementErrored();
             client.IncrementErrored();
 
-            client.MessagesErrored.Should().Be(2);
+            Assert.AreEqual(2, client.MessagesErrored);
         }
 
         [TestMethod]
@@ -208,7 +207,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             client.IncrementRolledBack();
 
-            client.MessagesRolledBack.Should().Be(1);
+            Assert.AreEqual(1, client.MessagesRolledBack);
         }
 
         [TestMethod]
@@ -220,7 +219,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             client.IncrementPoisonMessage();
 
-            client.PoisonMessages.Should().Be(1);
+            Assert.AreEqual(1, client.PoisonMessages);
         }
 
         [TestMethod]
@@ -264,12 +263,12 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             // Give async void time to complete
             await Task.Delay(200);
 
-            capturedJson.Should().NotBeNull();
+            Assert.IsNotNull(capturedJson);
             using var doc = JsonDocument.Parse(capturedJson);
-            doc.RootElement.GetProperty("MessagesProcessed").GetInt64().Should().Be(2);
-            doc.RootElement.GetProperty("MessagesErrored").GetInt64().Should().Be(1);
-            doc.RootElement.GetProperty("MessagesRolledBack").GetInt64().Should().Be(0);
-            doc.RootElement.GetProperty("PoisonMessages").GetInt64().Should().Be(0);
+            Assert.AreEqual(2, doc.RootElement.GetProperty("MessagesProcessed").GetInt64());
+            Assert.AreEqual(1, doc.RootElement.GetProperty("MessagesErrored").GetInt64());
+            Assert.AreEqual(0, doc.RootElement.GetProperty("MessagesRolledBack").GetInt64());
+            Assert.AreEqual(0, doc.RootElement.GetProperty("PoisonMessages").GetInt64());
         }
 
         // === Dispose ===
@@ -281,8 +280,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000/") };
             using var client = new DashboardConsumerClient(httpClient, CreateOptions());
 
-            client.IsRegistered.Should().BeFalse();
-            client.ConsumerId.Should().BeNull();
+            Assert.IsFalse(client.IsRegistered);
+            Assert.IsNull(client.ConsumerId);
         }
 
         [TestMethod]
@@ -303,7 +302,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var opts = CreateOptions();
             opts.ApiKey = "my-secret-key";
             using var client = new DashboardConsumerClient(opts);
-            client.IsRegistered.Should().BeFalse();
+            Assert.IsFalse(client.IsRegistered);
         }
 
         [TestMethod]
@@ -324,10 +323,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             client.IncrementPoisonMessage();
             client.IncrementPoisonMessage();
 
-            client.MessagesProcessed.Should().Be(3);
-            client.MessagesErrored.Should().Be(2);
-            client.MessagesRolledBack.Should().Be(1);
-            client.PoisonMessages.Should().Be(4);
+            Assert.AreEqual(3, client.MessagesProcessed);
+            Assert.AreEqual(2, client.MessagesErrored);
+            Assert.AreEqual(1, client.MessagesRolledBack);
+            Assert.AreEqual(4, client.PoisonMessages);
         }
 
         [TestMethod]
@@ -341,7 +340,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 QueueName = null
             };
             Action act = () => new DashboardConsumerClient(httpClient, opts);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
@@ -353,7 +352,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             // Should not throw even though not started
             await client.StopAsync();
-            client.IsRegistered.Should().BeFalse();
+            Assert.IsFalse(client.IsRegistered);
         }
 
         // === IHttpClientFactory constructor ===
@@ -371,7 +370,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 QueueName = null
             };
             Action act = () => new DashboardConsumerClient(factory, opts);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
@@ -384,7 +383,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 QueueName = "testQueue"
             };
             Action act = () => new DashboardConsumerClient(factory, opts);
-            act.Should().Throw<ArgumentException>();
+            Assert.Throws<ArgumentException>(act);
         }
 
         [TestMethod]
@@ -392,7 +391,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
         {
             var factory = new FakeHttpClientFactory(new HttpClient());
             Action act = () => new DashboardConsumerClient(factory, null);
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         [TestMethod]
@@ -405,7 +404,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var opts = CreateOptions();
             using var client = new DashboardConsumerClient(factory, opts);
 
-            client.IsRegistered.Should().BeFalse();
+            Assert.IsFalse(client.IsRegistered);
         }
 
         [TestMethod]
@@ -419,7 +418,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             opts.ApiKey = "my-key";
             using var client = new DashboardConsumerClient(factory, opts);
 
-            client.IsRegistered.Should().BeFalse();
+            Assert.IsFalse(client.IsRegistered);
         }
 
         [TestMethod]
@@ -435,7 +434,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var opts = CreateOptions();
             using var client = new DashboardConsumerClient(factory, opts);
 
-            client.IsRegistered.Should().BeFalse();
+            Assert.IsFalse(client.IsRegistered);
         }
 
         // === StartAsync with HeartbeatIntervalSeconds = 0 ===
@@ -466,8 +465,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             await client.StartAsync();
 
-            client.ConsumerId.Should().Be(consumerId);
-            client.IsRegistered.Should().BeTrue();
+            Assert.AreEqual(consumerId, client.ConsumerId);
+            Assert.IsTrue(client.IsRegistered);
         }
 
         // === HeartbeatCallback with 404 response ===
@@ -500,7 +499,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000/") };
             using var client = new DashboardConsumerClient(httpClient, CreateOptions());
             await client.StartAsync();
-            client.IsRegistered.Should().BeTrue();
+            Assert.IsTrue(client.IsRegistered);
 
             // Trigger heartbeat manually via reflection
             var method = typeof(DashboardConsumerClient).GetMethod("HeartbeatCallback",
@@ -510,8 +509,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             // Give async void time to complete
             await Task.Delay(300);
 
-            client.IsRegistered.Should().BeFalse();
-            client.ConsumerId.Should().BeNull();
+            Assert.IsFalse(client.IsRegistered);
+            Assert.IsNull(client.ConsumerId);
         }
 
         // === HeartbeatCallback when not registered ===
@@ -536,7 +535,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             method.Invoke(client, new object[] { null });
             await Task.Delay(200);
 
-            heartbeatCalled.Should().BeFalse();
+            Assert.IsFalse(heartbeatCalled);
         }
 
         // === HeartbeatCallback exception swallowed ===
@@ -578,8 +577,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             await Task.Delay(200);
 
             // Client should still be registered despite exception
-            client.IsRegistered.Should().BeTrue();
-            callCount.Should().Be(1);
+            Assert.IsTrue(client.IsRegistered);
+            Assert.AreEqual(1, callCount);
         }
 
         // === Dispose with active registration ===
@@ -614,12 +613,12 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000/") };
             var client = new DashboardConsumerClient(httpClient, CreateOptions());
             await client.StartAsync();
-            client.IsRegistered.Should().BeTrue();
+            Assert.IsTrue(client.IsRegistered);
 
             client.Dispose();
 
             // Sync Dispose no longer attempts HTTP DELETE to avoid sync-over-async deadlocks
-            deleteReceived.Should().BeFalse();
+            Assert.IsFalse(deleteReceived);
         }
 
         // === Dispose with owned HttpClient ===
@@ -670,7 +669,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             // Sync Dispose should not attempt any HTTP calls
             client.Dispose();
-            deleteAttempted.Should().BeFalse();
+            Assert.IsFalse(deleteAttempted);
         }
 
         // === StopAsync DELETE throws ===
@@ -703,12 +702,12 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000/") };
             using var client = new DashboardConsumerClient(httpClient, CreateOptions());
             await client.StartAsync();
-            client.IsRegistered.Should().BeTrue();
+            Assert.IsTrue(client.IsRegistered);
 
             // Should not throw
             await client.StopAsync();
 
-            client.IsRegistered.Should().BeFalse();
+            Assert.IsFalse(client.IsRegistered);
         }
 
         // === Constructor HttpClient with options null ===
@@ -719,7 +718,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var handler = new MockHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000/") };
             Action act = () => new DashboardConsumerClient(httpClient, null);
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         // === DisposeAsync ===
@@ -766,11 +765,11 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5000/") };
             var client = new DashboardConsumerClient(httpClient, CreateOptions());
             await client.StartAsync();
-            client.IsRegistered.Should().BeTrue();
+            Assert.IsTrue(client.IsRegistered);
 
             await client.DisposeAsync();
 
-            deleteReceived.Should().BeTrue();
+            Assert.IsTrue(deleteReceived);
         }
 
         [TestMethod]
@@ -790,7 +789,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             // No StartAsync() call -- not registered
             await client.DisposeAsync();
 
-            deleteReceived.Should().BeFalse();
+            Assert.IsFalse(deleteReceived);
         }
 
         [TestMethod]
@@ -824,7 +823,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             // Should not throw -- exception is swallowed
             Func<Task> act = async () => await client.DisposeAsync();
-            await act.Should().NotThrowAsync();
+            await act();
         }
 
         [TestMethod]
@@ -843,7 +842,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
 
             // A disposed HttpClient throws ObjectDisposedException on use
             Func<Task> act = () => httpClient.GetAsync("http://localhost:5000/test");
-            await act.Should().ThrowAsync<ObjectDisposedException>();
+            await Assert.ThrowsAsync<ObjectDisposedException>(act);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Client.Tests/DotNetWorkQueue.Dashboard.Client.Tests.csproj
+++ b/Source/DotNetWorkQueue.Dashboard.Client.Tests/DotNetWorkQueue.Dashboard.Client.Tests.csproj
@@ -23,7 +23,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="MSTest.TestFramework" />

--- a/Source/DotNetWorkQueue.Dashboard.Client.Tests/ModelTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Client.Tests/ModelTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using DotNetWorkQueue.Dashboard.Client.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Client.Tests
@@ -26,15 +25,15 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 Route = "route-a"
             };
 
-            sut.QueueId.Should().Be("msg-1");
-            sut.QueuedDateTime.Should().Be(now);
-            sut.CorrelationId.Should().Be("corr-1");
-            sut.Status.Should().Be(1);
-            sut.Priority.Should().Be(5);
-            sut.QueueProcessTime.Should().Be(now.AddMinutes(1));
-            sut.HeartBeat.Should().Be(now.AddMinutes(2));
-            sut.ExpirationTime.Should().Be(now.AddMinutes(3));
-            sut.Route.Should().Be("route-a");
+            Assert.AreEqual("msg-1", sut.QueueId);
+            Assert.AreEqual(now, sut.QueuedDateTime);
+            Assert.AreEqual("corr-1", sut.CorrelationId);
+            Assert.AreEqual(1, sut.Status);
+            Assert.AreEqual(5, sut.Priority);
+            Assert.AreEqual(now.AddMinutes(1), sut.QueueProcessTime);
+            Assert.AreEqual(now.AddMinutes(2), sut.HeartBeat);
+            Assert.AreEqual(now.AddMinutes(3), sut.ExpirationTime);
+            Assert.AreEqual("route-a", sut.Route);
         }
 
         [TestMethod]
@@ -49,10 +48,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 LastExceptionDate = now
             };
 
-            sut.Id.Should().Be(42);
-            sut.QueueId.Should().Be("msg-2");
-            sut.LastException.Should().Be("NullRef");
-            sut.LastExceptionDate.Should().Be(now);
+            Assert.AreEqual(42, sut.Id);
+            Assert.AreEqual("msg-2", sut.QueueId);
+            Assert.AreEqual("NullRef", sut.LastException);
+            Assert.AreEqual(now, sut.LastExceptionDate);
         }
 
         [TestMethod]
@@ -69,13 +68,13 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 EnableRoute = true
             };
 
-            sut.EnablePriority.Should().BeTrue();
-            sut.EnableStatus.Should().BeTrue();
-            sut.EnableStatusTable.Should().BeTrue();
-            sut.EnableHeartBeat.Should().BeTrue();
-            sut.EnableDelayedProcessing.Should().BeTrue();
-            sut.EnableMessageExpiration.Should().BeTrue();
-            sut.EnableRoute.Should().BeTrue();
+            Assert.IsTrue(sut.EnablePriority);
+            Assert.IsTrue(sut.EnableStatus);
+            Assert.IsTrue(sut.EnableStatusTable);
+            Assert.IsTrue(sut.EnableHeartBeat);
+            Assert.IsTrue(sut.EnableDelayedProcessing);
+            Assert.IsTrue(sut.EnableMessageExpiration);
+            Assert.IsTrue(sut.EnableRoute);
         }
 
         [TestMethod]
@@ -88,8 +87,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 QueueName = "test-queue"
             };
 
-            sut.Id.Should().Be(id);
-            sut.QueueName.Should().Be("test-queue");
+            Assert.AreEqual(id, sut.Id);
+            Assert.AreEqual("test-queue", sut.QueueName);
         }
 
         [TestMethod]
@@ -103,10 +102,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 Total = 17
             };
 
-            sut.Waiting.Should().Be(10);
-            sut.Processing.Should().Be(5);
-            sut.Error.Should().Be(2);
-            sut.Total.Should().Be(17);
+            Assert.AreEqual(10, sut.Waiting);
+            Assert.AreEqual(5, sut.Processing);
+            Assert.AreEqual(2, sut.Error);
+            Assert.AreEqual(17, sut.Total);
         }
 
         [TestMethod]
@@ -120,9 +119,9 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 JobScheduledTime = now.AddHours(1)
             };
 
-            sut.JobName.Should().Be("daily-cleanup");
-            sut.JobEventTime.Should().Be(now);
-            sut.JobScheduledTime.Should().Be(now.AddHours(1));
+            Assert.AreEqual("daily-cleanup", sut.JobName);
+            Assert.AreEqual(now, sut.JobEventTime);
+            Assert.AreEqual(now.AddHours(1), sut.JobScheduledTime);
         }
 
         [TestMethod]
@@ -136,10 +135,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 IsProcessing = false
             };
 
-            sut.Body.Should().Be("{\"key\":\"value\"}");
-            sut.TypeName.Should().Be("MyType");
-            sut.IsEditable.Should().BeTrue();
-            sut.IsProcessing.Should().BeFalse();
+            Assert.AreEqual("{\"key\":\"value\"}", sut.Body);
+            Assert.AreEqual("MyType", sut.TypeName);
+            Assert.IsTrue(sut.IsEditable);
+            Assert.IsFalse(sut.IsProcessing);
         }
 
         [TestMethod]
@@ -151,8 +150,8 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 Headers = headers
             };
 
-            sut.Headers.Should().HaveCount(2);
-            sut.Headers["h1"].Should().Be("v1");
+            Assert.AreEqual(2, sut.Headers.Count);
+            Assert.AreEqual("v1", sut.Headers["h1"]);
         }
 
         [TestMethod]
@@ -166,10 +165,10 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 RetryCount = 3
             };
 
-            sut.ErrorTrackingId.Should().Be(99);
-            sut.QueueId.Should().Be("msg-5");
-            sut.ExceptionType.Should().Be("System.InvalidOperationException");
-            sut.RetryCount.Should().Be(3);
+            Assert.AreEqual(99, sut.ErrorTrackingId);
+            Assert.AreEqual("msg-5", sut.QueueId);
+            Assert.AreEqual("System.InvalidOperationException", sut.ExceptionType);
+            Assert.AreEqual(3, sut.RetryCount);
         }
 
         [TestMethod]
@@ -183,24 +182,24 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 PageSize = 25
             };
 
-            sut.Items.Should().HaveCount(2);
-            sut.TotalCount.Should().Be(100);
-            sut.PageIndex.Should().Be(2);
-            sut.PageSize.Should().Be(25);
+            Assert.AreEqual(2, sut.Items.Count);
+            Assert.AreEqual(100, sut.TotalCount);
+            Assert.AreEqual(2, sut.PageIndex);
+            Assert.AreEqual(25, sut.PageSize);
         }
 
         [TestMethod]
         public void BulkActionResponse_Properties()
         {
             var sut = new BulkActionResponse { Count = 42 };
-            sut.Count.Should().Be(42);
+            Assert.AreEqual(42, sut.Count);
         }
 
         [TestMethod]
         public void DeleteAllResponse_Properties()
         {
             var sut = new DeleteAllResponse { Deleted = 15 };
-            sut.Deleted.Should().Be(15);
+            Assert.AreEqual(15, sut.Deleted);
         }
 
         [TestMethod]
@@ -213,22 +212,22 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 HeartbeatIntervalSeconds = 30
             };
 
-            sut.ConsumerId.Should().Be(id);
-            sut.HeartbeatIntervalSeconds.Should().Be(30);
+            Assert.AreEqual(id, sut.ConsumerId);
+            Assert.AreEqual(30, sut.HeartbeatIntervalSeconds);
         }
 
         [TestMethod]
         public void EditMessageBodyRequest_Properties()
         {
             var sut = new EditMessageBodyRequest { Body = "new body" };
-            sut.Body.Should().Be("new body");
+            Assert.AreEqual("new body", sut.Body);
         }
 
         [TestMethod]
         public void ConfigurationResponse_Properties()
         {
             var sut = new ConfigurationResponse { ConfigurationJson = "{\"setting\":true}" };
-            sut.ConfigurationJson.Should().Be("{\"setting\":true}");
+            Assert.AreEqual("{\"setting\":true}", sut.ConfigurationJson);
         }
 
         [TestMethod]
@@ -253,18 +252,18 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 PoisonMessages = 1
             };
 
-            sut.ConsumerId.Should().Be(consumerId);
-            sut.QueueName.Should().Be("q1");
-            sut.MachineName.Should().Be("SERVER1");
-            sut.ProcessId.Should().Be(9876);
-            sut.FriendlyName.Should().Be("Worker-1");
-            sut.RegisteredAt.Should().Be(now);
-            sut.LastHeartbeat.Should().Be(now.AddSeconds(10));
-            sut.MatchedQueueId.Should().Be(queueId);
-            sut.MessagesProcessed.Should().Be(100);
-            sut.MessagesErrored.Should().Be(5);
-            sut.MessagesRolledBack.Should().Be(2);
-            sut.PoisonMessages.Should().Be(1);
+            Assert.AreEqual(consumerId, sut.ConsumerId);
+            Assert.AreEqual("q1", sut.QueueName);
+            Assert.AreEqual("SERVER1", sut.MachineName);
+            Assert.AreEqual(9876, sut.ProcessId);
+            Assert.AreEqual("Worker-1", sut.FriendlyName);
+            Assert.AreEqual(now, sut.RegisteredAt);
+            Assert.AreEqual(now.AddSeconds(10), sut.LastHeartbeat);
+            Assert.AreEqual(queueId, sut.MatchedQueueId);
+            Assert.AreEqual(100, sut.MessagesProcessed);
+            Assert.AreEqual(5, sut.MessagesErrored);
+            Assert.AreEqual(2, sut.MessagesRolledBack);
+            Assert.AreEqual(1, sut.PoisonMessages);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/MainLayoutTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/MainLayoutTests.cs
@@ -20,7 +20,6 @@ using Bunit;
 using Bunit.TestDoubles;
 using DotNetWorkQueue.Dashboard.Ui.Components.Layout;
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -37,7 +36,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Layout
 
             var cut = Render<MainLayout>();
 
-            cut.Markup.Should().Contain("DotNetWorkQueue Dashboard");
+            StringAssert.Contains(cut.Markup, "DotNetWorkQueue Dashboard");
         }
 
         [TestMethod]
@@ -48,7 +47,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Layout
 
             var cut = Render<MainLayout>();
 
-            cut.Markup.Should().Contain("DotNetWorkQueue Dashboard");
+            StringAssert.Contains(cut.Markup, "DotNetWorkQueue Dashboard");
         }
 
         [TestMethod]
@@ -59,7 +58,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Layout
 
             var cut = Render<MainLayout>();
 
-            cut.Markup.Should().Contain("Sign out");
+            StringAssert.Contains(cut.Markup, "Sign out");
         }
 
         [TestMethod]
@@ -70,7 +69,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Layout
 
             var cut = Render<MainLayout>();
 
-            cut.Markup.Should().NotContain("Sign out");
+            Assert.IsFalse(cut.Markup.Contains("Sign out"));
         }
 
         [TestMethod]
@@ -82,7 +81,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Layout
 
             Render<MainLayout>();
 
-            nav.Uri.Should().EndWith("/login");
+            StringAssert.EndsWith(nav.Uri, "/login");
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/HomeTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/HomeTests.cs
@@ -21,7 +21,6 @@ using Bunit;
 using Bunit.TestDoubles;
 using DotNetWorkQueue.Dashboard.Ui.Components.Pages;
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -43,7 +42,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             Render<Home>();
 
-            nav.Uri.Should().EndWith("/source/primary");
+            StringAssert.EndsWith(nav.Uri, "/source/primary");
         }
 
         [TestMethod]
@@ -58,7 +57,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             var cut = Render<Home>(ps => ps.Add(p => p.SourceSlug, "does-not-exist"));
 
-            cut.Markup.Should().Contain("not found");
+            StringAssert.Contains(cut.Markup, "not found");
         }
 
         [TestMethod]
@@ -73,8 +72,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             var cut = Render<Home>();
 
-            cut.Markup.Should().Contain("Alpha");
-            cut.Markup.Should().Contain("Beta");
+            StringAssert.Contains(cut.Markup, "Alpha");
+            StringAssert.Contains(cut.Markup, "Beta");
         }
 
         private void RegisterDependencies(IReadOnlyList<DashboardApiSourceConfig> sources)

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
@@ -20,7 +20,6 @@ using Bunit;
 using Bunit.TestDoubles;
 using DotNetWorkQueue.Dashboard.Ui.Components.Pages;
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -36,8 +35,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             var cut = Render<Login>();
 
-            cut.Markup.Should().Contain("Sign In");
-            cut.Markup.Should().Contain("Dashboard Login");
+            StringAssert.Contains(cut.Markup, "Sign In");
+            StringAssert.Contains(cut.Markup, "Dashboard Login");
         }
 
         [TestMethod]
@@ -49,7 +48,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             var cut = Render<Login>();
 
-            cut.Markup.Should().Contain("Invalid username or password.");
+            StringAssert.Contains(cut.Markup, "Invalid username or password.");
         }
 
         [TestMethod]
@@ -59,7 +58,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             var cut = Render<Login>();
 
-            cut.Markup.Should().NotContain("Invalid username or password.");
+            Assert.IsFalse(cut.Markup.Contains("Invalid username or password."));
         }
 
         [TestMethod]
@@ -70,7 +69,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             Render<Login>();
 
-            nav.Uri.Should().Be(nav.BaseUri);
+            Assert.AreEqual(nav.BaseUri, nav.Uri);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
@@ -23,7 +23,6 @@ using Bunit;
 using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
 using DotNetWorkQueue.Dashboard.Ui.Models;
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudBlazor;
 using NSubstitute;
@@ -54,7 +53,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
 
             var cut = RenderHistoryTab(api, snackbar, readOnly: true);
 
-            cut.Markup.Should().NotContain("Purge History");
+            Assert.IsFalse(cut.Markup.Contains("Purge History"));
         }
 
         [TestMethod]
@@ -65,7 +64,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
 
             var cut = RenderHistoryTab(api, snackbar);
 
-            cut.Markup.Should().NotContain("Purge History");
+            Assert.IsFalse(cut.Markup.Contains("Purge History"));
         }
 
         [TestMethod]
@@ -76,7 +75,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
 
             var cut = RenderHistoryTab(api, snackbar);
 
-            cut.Markup.Should().Contain("Purge History");
+            StringAssert.Contains(cut.Markup, "Purge History");
         }
 
         [TestMethod]
@@ -89,7 +88,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
 
             var cut = RenderHistoryTab(api, snackbar);
 
-            cut.Markup.Should().Contain("boom");
+            StringAssert.Contains(cut.Markup, "boom");
         }
 
         [TestMethod]
@@ -115,7 +114,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
 
             var cut = RenderHistoryTab(api, snackbar);
 
-            cut.Markup.Should().Contain("Expand exception");
+            StringAssert.Contains(cut.Markup, "Expand exception");
         }
 
         private IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> RenderHistoryTab(IDashboardApiClient api, ISnackbar snackbar, bool readOnly = false)

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/DotNetWorkQueue.Dashboard.Ui.Tests.csproj
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/DotNetWorkQueue.Dashboard.Ui.Tests.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
     <PackageReference Include="bunit" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="MSTest.TestFramework" />

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/ConfigValidationTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/ConfigValidationTests.cs
@@ -22,7 +22,6 @@
 using System;
 using System.Collections.Generic;
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -49,9 +48,9 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = DashboardConfigParser.ParseSources(config);
 
-            result.Should().HaveCount(1);
-            result[0].Name.Should().Be("Local");
-            result[0].BaseUrl.Should().Be("http://localhost:5000");
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("Local", result[0].Name);
+            Assert.AreEqual("http://localhost:5000", result[0].BaseUrl);
         }
 
         [TestMethod]
@@ -67,7 +66,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = DashboardConfigParser.ParseSources(config);
 
-            result.Should().HaveCount(2);
+            Assert.AreEqual(2, result.Count);
         }
 
         [TestMethod]
@@ -82,8 +81,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = DashboardConfigParser.ParseSources(config);
 
-            result.Should().HaveCount(1);
-            result[0].ApiKey.Should().Be("my-secret-key");
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("my-secret-key", result[0].ApiKey);
         }
 
         [TestMethod]
@@ -97,8 +96,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = DashboardConfigParser.ParseSources(config);
 
-            result.Should().HaveCount(1);
-            result[0].ApiKey.Should().BeNull();
+            Assert.AreEqual(1, result.Count);
+            Assert.IsNull(result[0].ApiKey);
         }
 
         [TestMethod]
@@ -111,9 +110,9 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var act = () => DashboardConfigParser.ValidateNoLegacyConfig(config);
 
-            act.Should().Throw<InvalidOperationException>()
-                .WithMessage("*Sources*")
-                .WithMessage("*migration*");
+            var ex = Assert.Throws<InvalidOperationException>(act);
+            StringAssert.Contains(ex.Message, "Sources", StringComparison.OrdinalIgnoreCase);
+            StringAssert.Contains(ex.Message, "migration", StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]
@@ -128,7 +127,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var act = () => DashboardConfigParser.ValidateNoLegacyConfig(config);
 
-            act.Should().NotThrow();
+            act();
         }
 
         [TestMethod]
@@ -141,7 +140,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var act = () => DashboardConfigParser.ValidateNoLegacyConfig(config);
 
-            act.Should().NotThrow();
+            act();
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/DashboardApiSourceConfigTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/DashboardApiSourceConfigTests.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
@@ -30,70 +29,70 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
         public void Slug_From_Simple_Name()
         {
             var config = new DashboardApiSourceConfig { Name = "Local" };
-            config.Slug.Should().Be("local");
+            Assert.AreEqual("local", config.Slug);
         }
 
         [TestMethod]
         public void Slug_From_Name_With_Spaces()
         {
             var config = new DashboardApiSourceConfig { Name = "Production SQL Server" };
-            config.Slug.Should().Be("production-sql-server");
+            Assert.AreEqual("production-sql-server", config.Slug);
         }
 
         [TestMethod]
         public void Slug_From_Name_With_Special_Chars()
         {
             var config = new DashboardApiSourceConfig { Name = "My Server (US-East)" };
-            config.Slug.Should().Be("my-server-us-east");
+            Assert.AreEqual("my-server-us-east", config.Slug);
         }
 
         [TestMethod]
         public void Slug_Collapses_Consecutive_Hyphens()
         {
             var config = new DashboardApiSourceConfig { Name = "test--name" };
-            config.Slug.Should().Be("test-name");
+            Assert.AreEqual("test-name", config.Slug);
         }
 
         [TestMethod]
         public void Slug_Trims_Leading_Trailing_Hyphens()
         {
             var config = new DashboardApiSourceConfig { Name = " -Test- " };
-            config.Slug.Should().Be("test");
+            Assert.AreEqual("test", config.Slug);
         }
 
         [TestMethod]
         public void Slug_From_Name_With_Numbers()
         {
             var config = new DashboardApiSourceConfig { Name = "Server 42" };
-            config.Slug.Should().Be("server-42");
+            Assert.AreEqual("server-42", config.Slug);
         }
 
         [TestMethod]
         public void Name_Set_Get()
         {
             var config = new DashboardApiSourceConfig { Name = "MySource" };
-            config.Name.Should().Be("MySource");
+            Assert.AreEqual("MySource", config.Name);
         }
 
         [TestMethod]
         public void BaseUrl_Set_Get()
         {
             var config = new DashboardApiSourceConfig { BaseUrl = "https://example.com/api" };
-            config.BaseUrl.Should().Be("https://example.com/api");
+            Assert.AreEqual("https://example.com/api", config.BaseUrl);
         }
 
         [TestMethod]
         public void ApiKey_Set_Get()
         {
             var config = new DashboardApiSourceConfig { ApiKey = "secret-key-123" };
-            config.ApiKey.Should().Be("secret-key-123");
+            Assert.AreEqual("secret-key-123", config.ApiKey);
         }
 
         [TestMethod]
         public void ApiKey_Defaults_To_Null()
         {
             var config = new DashboardApiSourceConfig();
-            config.ApiKey.Should().BeNull();
+            Assert.IsNull(config.ApiKey);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/LocalSourceHostedServiceTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/LocalSourceHostedServiceTests.cs
@@ -24,7 +24,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
@@ -71,7 +70,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             await service.StartAsync(CancellationToken.None);
 
-            registry.GetByName("Local")!.BaseUrl.Should().Be("http://localhost:5123");
+            Assert.AreEqual("http://localhost:5123", registry.GetByName("Local")!.BaseUrl);
         }
 
         [TestMethod]
@@ -81,7 +80,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             await service.StartAsync(CancellationToken.None);
 
-            registry.GetByName("Local")!.BaseUrl.Should().Be("http://localhost:5000");
+            Assert.AreEqual("http://localhost:5000", registry.GetByName("Local")!.BaseUrl);
         }
 
         [TestMethod]
@@ -94,7 +93,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             await service.StartAsync(CancellationToken.None);
 
-            registry.GetByName("Local")!.BaseUrl.Should().Be("http://localhost:5000");
+            Assert.AreEqual("http://localhost:5000", registry.GetByName("Local")!.BaseUrl);
         }
 
         [TestMethod]
@@ -119,7 +118,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var task = service.StopAsync(CancellationToken.None);
 
-            task.IsCompleted.Should().BeTrue();
+            Assert.IsTrue(task.IsCompleted);
             await task;
         }
     }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/MultiSourceDashboardApiClientTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/MultiSourceDashboardApiClientTests.cs
@@ -21,7 +21,6 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
@@ -54,8 +53,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = sut.GetClientForSource("local");
 
-            result.Should().NotBeNull();
-            result.Should().BeAssignableTo<IDashboardApiClient>();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(IDashboardApiClient));
         }
 
         [TestMethod]
@@ -66,7 +65,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             var first = sut.GetClientForSource("local");
             var second = sut.GetClientForSource("local");
 
-            first.Should().BeSameAs(second);
+            Assert.AreSame(second, first);
         }
 
         [TestMethod]
@@ -79,7 +78,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             var local = sut.GetClientForSource("local");
             var prod = sut.GetClientForSource("production");
 
-            local.Should().NotBeSameAs(prod);
+            Assert.AreNotSame(prod, local);
         }
 
         [TestMethod]
@@ -89,8 +88,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var act = () => sut.GetClientForSource("nonexistent");
 
-            act.Should().Throw<KeyNotFoundException>()
-                .WithMessage("*nonexistent*");
+            var ex = Assert.Throws<KeyNotFoundException>(act);
+            StringAssert.Contains(ex.Message, "nonexistent", StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]
@@ -100,7 +99,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var act = () => sut.GetClientForSource(null!);
 
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         [TestMethod]
@@ -112,9 +111,9 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = sut.GetAllSources();
 
-            result.Should().HaveCount(2);
-            result[0].Name.Should().Be("Local");
-            result[1].Name.Should().Be("Production");
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("Local", result[0].Name);
+            Assert.AreEqual("Production", result[1].Name);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceHealthMonitorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceHealthMonitorTests.cs
@@ -21,12 +21,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -59,8 +59,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = sut.GetHealth("local");
 
-            result.Should().NotBeNull();
-            result.Status.Should().Be(SourceHealthStatus.Unknown);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(SourceHealthStatus.Unknown, result.Status);
         }
 
         [TestMethod]
@@ -70,8 +70,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = sut.GetAllHealth();
 
-            result.Should().NotBeNull();
-            result.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.IsFalse(result.Any());
         }
 
         [TestMethod]
@@ -88,9 +88,9 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             await sut.PollAllSourcesAsync(CancellationToken.None);
 
             var result = sut.GetHealth(source.Slug);
-            result.Status.Should().Be(SourceHealthStatus.Healthy);
-            result.LastChecked.Should().BeOnOrAfter(before);
-            result.ErrorMessage.Should().BeNull();
+            Assert.AreEqual(SourceHealthStatus.Healthy, result.Status);
+            Assert.IsTrue(result.LastChecked >= before);
+            Assert.IsNull(result.ErrorMessage);
         }
 
         [TestMethod]
@@ -106,8 +106,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             await sut.PollAllSourcesAsync(CancellationToken.None);
 
             var result = sut.GetHealth(source.Slug);
-            result.Status.Should().Be(SourceHealthStatus.Unhealthy);
-            result.ErrorMessage.Should().Contain("Connection refused");
+            Assert.AreEqual(SourceHealthStatus.Unhealthy, result.Status);
+            StringAssert.Contains(result.ErrorMessage, "Connection refused");
         }
 
         [TestMethod]
@@ -122,13 +122,13 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             // First poll: healthy
             apiClient.GetSettingsAsync().Returns(Task.FromResult<Models.DashboardSettingsResponse?>(new Models.DashboardSettingsResponse()));
             await sut.PollAllSourcesAsync(CancellationToken.None);
-            sut.GetHealth(source.Slug).Status.Should().Be(SourceHealthStatus.Healthy);
+            Assert.AreEqual(SourceHealthStatus.Healthy, sut.GetHealth(source.Slug).Status);
 
             // Second poll: unhealthy
             apiClient.GetSettingsAsync().Returns<Models.DashboardSettingsResponse?>(_ => throw new HttpRequestException("Timeout"));
             await sut.PollAllSourcesAsync(CancellationToken.None);
-            sut.GetHealth(source.Slug).Status.Should().Be(SourceHealthStatus.Unhealthy);
-            sut.GetHealth(source.Slug).ErrorMessage.Should().Contain("Timeout");
+            Assert.AreEqual(SourceHealthStatus.Unhealthy, sut.GetHealth(source.Slug).Status);
+            StringAssert.Contains(sut.GetHealth(source.Slug).ErrorMessage, "Timeout");
         }
 
         [TestMethod]
@@ -148,13 +148,13 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             // First poll: unhealthy
             await sut.PollAllSourcesAsync(CancellationToken.None);
-            sut.GetHealth(source.Slug).Status.Should().Be(SourceHealthStatus.Unhealthy);
+            Assert.AreEqual(SourceHealthStatus.Unhealthy, sut.GetHealth(source.Slug).Status);
 
             // Second poll: healthy (recovery)
             shouldThrow = false;
             await sut.PollAllSourcesAsync(CancellationToken.None);
-            sut.GetHealth(source.Slug).Status.Should().Be(SourceHealthStatus.Healthy);
-            sut.GetHealth(source.Slug).ErrorMessage.Should().BeNull();
+            Assert.AreEqual(SourceHealthStatus.Healthy, sut.GetHealth(source.Slug).Status);
+            Assert.IsNull(sut.GetHealth(source.Slug).ErrorMessage);
         }
 
         [TestMethod]
@@ -175,9 +175,9 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             await sut.PollAllSourcesAsync(CancellationToken.None);
 
             var all = sut.GetAllHealth();
-            all.Should().HaveCount(2);
-            all[source1.Slug].Status.Should().Be(SourceHealthStatus.Healthy);
-            all[source2.Slug].Status.Should().Be(SourceHealthStatus.Unhealthy);
+            Assert.AreEqual(2, all.Count);
+            Assert.AreEqual(SourceHealthStatus.Healthy, all[source1.Slug].Status);
+            Assert.AreEqual(SourceHealthStatus.Unhealthy, all[source2.Slug].Status);
         }
 
         [TestMethod]
@@ -203,24 +203,24 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             await sut.PollAllSourcesAsync(CancellationToken.None);
 
             // Verify no log call was made for same-state poll
-            logger.ReceivedCalls().Should().BeEmpty();
+            Assert.IsFalse(logger.ReceivedCalls().Any());
 
             // Third poll: unhealthy (transition Healthy -> Unhealthy, should log)
             shouldThrow = true;
             await sut.PollAllSourcesAsync(CancellationToken.None);
 
             // Verify a log call was made for the transition
-            logger.ReceivedCalls().Should().NotBeEmpty();
+            Assert.IsTrue(logger.ReceivedCalls().Any());
 
             // Fourth poll: still unhealthy (no transition, should NOT log)
             logger.ClearReceivedCalls();
             await sut.PollAllSourcesAsync(CancellationToken.None);
-            logger.ReceivedCalls().Should().BeEmpty();
+            Assert.IsFalse(logger.ReceivedCalls().Any());
 
             // Fifth poll: recovery (Unhealthy -> Healthy, should log)
             shouldThrow = false;
             await sut.PollAllSourcesAsync(CancellationToken.None);
-            logger.ReceivedCalls().Should().NotBeEmpty();
+            Assert.IsTrue(logger.ReceivedCalls().Any());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceRegistryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceRegistryTests.cs
@@ -20,7 +20,6 @@
 using System;
 using System.Collections.Generic;
 using DotNetWorkQueue.Dashboard.Ui.Services;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
@@ -45,7 +44,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = registry.GetAll();
 
-            result.Should().HaveCount(2);
+            Assert.AreEqual(2, result.Count);
         }
 
         [TestMethod]
@@ -60,8 +59,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = registry.GetBySlug("local");
 
-            result.Should().NotBeNull();
-            result!.Name.Should().Be("Local");
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Local", result!.Name);
         }
 
         [TestMethod]
@@ -75,7 +74,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = registry.GetBySlug("nonexistent");
 
-            result.Should().BeNull();
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -90,8 +89,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = registry.GetByName("Local");
 
-            result.Should().NotBeNull();
-            result!.BaseUrl.Should().Be("https://localhost:5001");
+            Assert.IsNotNull(result);
+            Assert.AreEqual("https://localhost:5001", result!.BaseUrl);
         }
 
         [TestMethod]
@@ -105,7 +104,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = registry.GetByName("nonexistent");
 
-            result.Should().BeNull();
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -115,8 +114,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var act = () => new SourceRegistry(sources);
 
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("*at least one*");
+            var ex = Assert.Throws<ArgumentException>(act);
+            StringAssert.Contains(ex.Message, "at least one", StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]
@@ -124,7 +123,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
         {
             var act = () => new SourceRegistry(null!);
 
-            act.Should().Throw<ArgumentNullException>();
+            Assert.Throws<ArgumentNullException>(act);
         }
 
         [TestMethod]
@@ -138,9 +137,9 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var act = () => new SourceRegistry(sources);
 
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("*duplicate*")
-                .WithMessage("*Local*");
+            var ex = Assert.Throws<ArgumentException>(act);
+            StringAssert.Contains(ex.Message, "duplicate", StringComparison.OrdinalIgnoreCase);
+            StringAssert.Contains(ex.Message, "Local", StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]
@@ -154,8 +153,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var act = () => new SourceRegistry(sources);
 
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("*slug*");
+            var ex = Assert.Throws<ArgumentException>(act);
+            StringAssert.Contains(ex.Message, "slug", StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]
@@ -169,7 +168,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = registry.GetAll();
 
-            result.Should().BeAssignableTo<IReadOnlyList<DashboardApiSourceConfig>>();
+            Assert.IsInstanceOfType(result, typeof(IReadOnlyList<DashboardApiSourceConfig>));
         }
 
         [TestMethod]
@@ -183,8 +182,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = registry.GetByName("LOCAL");
 
-            result.Should().NotBeNull();
-            result!.Name.Should().Be("Local");
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Local", result!.Name);
         }
     }
 }


### PR DESCRIPTION
Part of #159 (replace FluentAssertions with MSTest assertions). Phase 4 — the two Dashboard unit-test projects, in **one combined PR** (single Jenkins build).

Migrates **304** `.Should()` sites across **13 files** to built-in MSTest assertions and removes each project's `FluentAssertions` PackageReference. No `Tests.Shared` helper needed (no `BeEquivalentTo`/`BeCloseTo`/`AllSatisfy`).

## Projects
- **`Dashboard.Client.Tests`** — 3 files, 215 sites (`ModelTests`, `DashboardApiClientTests`, `DashboardConsumerClientTests`).
- **`Dashboard.Ui.Tests`** — 10 files, 89 sites (bUnit/MudBlazor component tests + Services).

## Mapping notes
- `Be`/`BeTrue`/`BeFalse`/`BeNull`/`NotBeNull`/`HaveCount` → `Assert.AreEqual`/`IsTrue`/`IsFalse`/`IsNull`/`IsNotNull`/`AreEqual(n, x.Count)` (expected-first).
- `Throw<T>()` → `Assert.Throws<T>(act)`; `ThrowAsync<T>` → `await Assert.ThrowsAsync<T>(act)`; `NotThrow`/`NotThrowAsync` → bare `act()`/`await act()`.
- `Throw<T>().WithMessage("*X*")` → `var ex = Assert.Throws<T>(act); StringAssert.Contains(ex.Message, "X", StringComparison.OrdinalIgnoreCase)` — `OrdinalIgnoreCase` preserves FA `WithMessage`'s case-insensitive matching.
- String `Contain`/`EndWith` → `StringAssert.Contains`/`EndsWith` (case-sensitive, matching FA `Contain`); `NotContain` → `Assert.IsFalse(x.Contains(..))`.
- `ContainKey` → `ContainsKey`; collection `BeEmpty`/`NotBeEmpty` → `Assert.IsFalse/IsTrue(x.Any())`; `BeAssignableTo<T>` → `Assert.IsInstanceOfType(x, typeof(T))`; `BeSameAs`/`NotBeSameAs` → `Assert.AreSame`/`AreNotSame`; `BeOnOrAfter` → `Assert.IsTrue(x >= y)`.

## Verification
- `dotnet build -c Release` (TreatWarningsAsErrors) → 0 warnings, 0 errors (both projects).
- `dotnet test -c Release` → Client **92/92**, Ui **66/66**, on both net10.0 and net8.0.
- Grep `FluentAssertions`/`.Should()` across both projects' source → zero.
- `Source/Directory.Packages.props` FA entry intentionally left in place (removed in the final #159 phase).

Test-only; no production code change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated dashboard client and UI tests to use MSTest assertions instead of FluentAssertions.
  * Kept test coverage and expected behaviors the same while modernizing assertion style.
  * Improved some checks for markup, navigation, collections, and exception messages.

* **Chores**
  * Removed the FluentAssertions dependency from test projects.
  * Adjusted test project references to match the updated assertion approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->