### PR TITLE
Refs #159: migrate Dashboard.Api.Integration.Tests to MSTest assertions (Phase 6)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/DotNetWorkQueue.Dashboard.Api.Integration.Tests.csproj
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/DotNetWorkQueue.Dashboard.Api.Integration.Tests.csproj
@@ -38,7 +38,6 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="MSTest.TestFramework" />
@@ -54,6 +53,7 @@
     <ProjectReference Include="..\DotNetWorkQueue.Transport.Redis\DotNetWorkQueue.Transport.Redis.csproj" />
     <ProjectReference Include="..\DotNetWorkQueue.Transport.LiteDB\DotNetWorkQueue.Transport.LiteDb.csproj" />
     <ProjectReference Include="..\DotNetWorkQueue.Transport.Memory\DotNetWorkQueue.Transport.Memory.csproj" />
+    <ProjectReference Include="..\DotNetWorkQueue.Tests.Shared\DotNetWorkQueue.Tests.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/AssemblyPathTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/AssemblyPathTests.cs
@@ -24,7 +24,6 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -86,8 +85,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
 
-            body.Body.Should().NotBeNullOrEmpty();
-            body.TypeName.Should().Contain("FakeMessage");
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
+            StringAssert.Contains(body.TypeName, "FakeMessage");
         }
 
         [TestMethod]
@@ -102,7 +101,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
 
-            body.Body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
         }
 
         [TestMethod]
@@ -118,7 +117,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
 
-            body.Body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/AuthorizationPolicyIntegrationTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/AuthorizationPolicyIntegrationTests.cs
@@ -20,7 +20,6 @@ using System.Net;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
-using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -79,7 +78,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // middleware, not a controller) and assert an unauthenticated 401 response.
             var response = await _server.Client.GetAsync("api/v1/dashboard/connections");
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
         private class NoAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/ConsumersEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/ConsumersEndpointTests.cs
@@ -8,8 +8,8 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 {
@@ -50,11 +50,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await RegisterConsumer("MACHINE1", 1234, "Worker1");
 
-            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             var registration = await response.Content.ReadFromJsonAsync<ConsumerRegistrationResponse>();
-            registration.Should().NotBeNull();
-            registration!.ConsumerId.Should().NotBeEmpty();
-            registration.HeartbeatIntervalSeconds.Should().BeGreaterThan(0);
+            Assert.IsNotNull(registration);
+            Assert.AreNotEqual(Guid.Empty, registration!.ConsumerId);
+            Assert.IsTrue(registration.HeartbeatIntervalSeconds > 0);
         }
 
         [TestMethod]
@@ -63,7 +63,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var r1 = await RegisterAndDeserialize("M1", 1000);
             var r2 = await RegisterAndDeserialize("M2", 2000);
 
-            r1.ConsumerId.Should().NotBe(r2.ConsumerId);
+            Assert.AreNotEqual(r2.ConsumerId, r1.ConsumerId);
         }
 
         // === Heartbeat ===
@@ -75,7 +75,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var response = await SendHeartbeat(registration.ConsumerId);
 
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
 
         [TestMethod]
@@ -83,7 +83,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await SendHeartbeat(Guid.NewGuid());
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var response = await SendHeartbeat(registration.ConsumerId, 100, 5, 3, 1);
 
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
 
         [TestMethod]
@@ -105,12 +105,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
 
-            consumers.Should().HaveCount(1);
+            Assert.AreEqual(1, consumers.Count);
             var c = consumers![0];
-            c.MessagesProcessed.Should().Be(250);
-            c.MessagesErrored.Should().Be(10);
-            c.MessagesRolledBack.Should().Be(7);
-            c.PoisonMessages.Should().Be(2);
+            Assert.AreEqual(250, c.MessagesProcessed);
+            Assert.AreEqual(10, c.MessagesErrored);
+            Assert.AreEqual(7, c.MessagesRolledBack);
+            Assert.AreEqual(2, c.PoisonMessages);
         }
 
         [TestMethod]
@@ -124,10 +124,10 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 "api/v1/dashboard/consumers");
 
             var c = consumers![0];
-            c.MessagesProcessed.Should().Be(500);
-            c.MessagesErrored.Should().Be(8);
-            c.MessagesRolledBack.Should().Be(4);
-            c.PoisonMessages.Should().Be(1);
+            Assert.AreEqual(500, c.MessagesProcessed);
+            Assert.AreEqual(8, c.MessagesErrored);
+            Assert.AreEqual(4, c.MessagesRolledBack);
+            Assert.AreEqual(1, c.PoisonMessages);
         }
 
         [TestMethod]
@@ -140,10 +140,10 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 "api/v1/dashboard/consumers");
 
             var c = consumers![0];
-            c.MessagesProcessed.Should().Be(0);
-            c.MessagesErrored.Should().Be(0);
-            c.MessagesRolledBack.Should().Be(0);
-            c.PoisonMessages.Should().Be(0);
+            Assert.AreEqual(0, c.MessagesProcessed);
+            Assert.AreEqual(0, c.MessagesErrored);
+            Assert.AreEqual(0, c.MessagesRolledBack);
+            Assert.AreEqual(0, c.PoisonMessages);
         }
 
         // === Unregister ===
@@ -156,7 +156,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/consumers/{registration.ConsumerId}");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
 
         [TestMethod]
@@ -165,7 +165,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/consumers/{Guid.NewGuid()}");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -178,7 +178,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            consumers.Should().BeEmpty();
+            Assert.AreEqual(0, consumers.Count);
         }
 
         // === List ===
@@ -192,7 +192,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
 
-            consumers.Should().HaveCount(2);
+            Assert.AreEqual(2, consumers.Count);
         }
 
         [TestMethod]
@@ -203,8 +203,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 $"api/v1/dashboard/consumers?queueId={_queueId}");
 
-            consumers.Should().HaveCount(1);
-            consumers![0].MatchedQueueId.Should().Be(_queueId);
+            Assert.AreEqual(1, consumers.Count);
+            Assert.AreEqual(_queueId, consumers![0].MatchedQueueId);
         }
 
         [TestMethod]
@@ -215,7 +215,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 $"api/v1/dashboard/consumers?queueId={Guid.NewGuid()}");
 
-            consumers.Should().BeEmpty();
+            Assert.AreEqual(0, consumers.Count);
         }
 
         [TestMethod]
@@ -226,14 +226,14 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
 
-            consumers.Should().HaveCount(1);
+            Assert.AreEqual(1, consumers.Count);
             var c = consumers![0];
-            c.MachineName.Should().Be("TESTMACHINE");
-            c.ProcessId.Should().Be(9876);
-            c.FriendlyName.Should().Be("MyWorker");
-            c.QueueName.Should().Be("testQueue");
-            c.RegisteredAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
-            c.LastHeartbeat.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+            Assert.AreEqual("TESTMACHINE", c.MachineName);
+            Assert.AreEqual(9876, c.ProcessId);
+            Assert.AreEqual("MyWorker", c.FriendlyName);
+            Assert.AreEqual("testQueue", c.QueueName);
+            AssertHelper.AreClose(DateTimeOffset.UtcNow, c.RegisteredAt, TimeSpan.FromSeconds(5));
+            AssertHelper.AreClose(DateTimeOffset.UtcNow, c.LastHeartbeat, TimeSpan.FromSeconds(5));
         }
 
         // === Counts ===
@@ -247,8 +247,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var counts = await _server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
 
-            counts.Should().ContainKey(_queueId);
-            counts![_queueId].Should().Be(2);
+            Assert.IsTrue(counts.ContainsKey(_queueId));
+            Assert.AreEqual(2, counts![_queueId]);
         }
 
         [TestMethod]
@@ -257,7 +257,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var counts = await _server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
 
-            counts.Should().BeEmpty();
+            Assert.AreEqual(0, counts.Count);
         }
 
         // === Full lifecycle ===
@@ -267,35 +267,35 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             // Register
             var registration = await RegisterAndDeserialize("M1", 1000, "Worker1");
-            registration.ConsumerId.Should().NotBeEmpty();
+            Assert.AreNotEqual(Guid.Empty, registration.ConsumerId);
 
             // Heartbeat with metrics
             var hbResponse = await SendHeartbeat(registration.ConsumerId, 42, 3, 2, 1);
-            hbResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, hbResponse.StatusCode);
 
             // List — verify metrics are present
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            consumers.Should().HaveCount(1);
-            consumers![0].MessagesProcessed.Should().Be(42);
-            consumers[0].MessagesErrored.Should().Be(3);
-            consumers[0].MessagesRolledBack.Should().Be(2);
-            consumers[0].PoisonMessages.Should().Be(1);
+            Assert.AreEqual(1, consumers.Count);
+            Assert.AreEqual(42, consumers![0].MessagesProcessed);
+            Assert.AreEqual(3, consumers[0].MessagesErrored);
+            Assert.AreEqual(2, consumers[0].MessagesRolledBack);
+            Assert.AreEqual(1, consumers[0].PoisonMessages);
 
             // Count
             var counts = await _server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
-            counts![_queueId].Should().Be(1);
+            Assert.AreEqual(1, counts![_queueId]);
 
             // Unregister
             var deleteResponse = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/consumers/{registration.ConsumerId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             // Verify gone
             consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            consumers.Should().BeEmpty();
+            Assert.AreEqual(0, consumers.Count);
         }
 
         // === Helpers ===

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/CorsIntegrationTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/CorsIntegrationTests.cs
@@ -19,8 +19,8 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 {
@@ -56,9 +56,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var response = await _server.Client.SendAsync(request);
 
-            response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins).Should().BeTrue(
+            Assert.IsTrue(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins),
                 "because the CORS middleware should have added the allow-origin header for the matching origin");
-            origins.Should().Contain("https://example.com");
+            Assert.IsTrue(origins.Contains("https://example.com"));
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/DashboardStartupTimingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/DashboardStartupTimingTests.cs
@@ -26,7 +26,6 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -90,12 +89,14 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // by hitting an endpoint that resolves the transport-options chain.
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().NotBeNullOrEmpty();
+            Assert.IsNotNull(connections);
+            Assert.IsTrue(connections.Count > 0);
             var connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{connectionId}/queues");
-            queues.Should().NotBeNullOrEmpty();
+            Assert.IsNotNull(queues);
+            Assert.IsTrue(queues.Count > 0);
             var queueId = queues[0].Id;
 
             // --- Phase 2: create the queue with history enabled and populate it ---
@@ -143,15 +144,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // cached EnableHistory=false at phase-1 resolution.
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/history?pageSize=100");
-            history.Should().NotBeNull();
-            history.Items.Should().HaveCountGreaterThanOrEqualTo(MessageCount,
+            Assert.IsNotNull(history);
+            Assert.IsTrue(history.Items.Count >= MessageCount,
                 "history reads must survive a stale/default options cache on the dashboard side");
 
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{queueId}/history/count");
             countResponse.EnsureSuccessStatusCode();
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/EdgeCaseTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/EdgeCaseTests.cs
@@ -25,7 +25,6 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -75,8 +74,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(5);
-            paged.TotalCount.Should().Be(5);
+            Assert.AreEqual(5, paged.Items.Count);
+            Assert.AreEqual(5, paged.TotalCount);
         }
 
         [TestMethod]
@@ -84,8 +83,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=10&pageIndex=99");
-            paged.Items.Should().BeEmpty();
-            paged.TotalCount.Should().Be(5);
+            Assert.AreEqual(0, paged.Items.Count);
+            Assert.AreEqual(5, paged.TotalCount);
         }
 
         [TestMethod]
@@ -97,11 +96,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var first = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            first.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, first.StatusCode);
 
             var second = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            second.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, second.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/EmptyQueueTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/EmptyQueueTests.cs
@@ -25,7 +25,6 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -75,9 +74,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Waiting.Should().Be(0);
-            status.Processing.Should().Be(0);
-            status.Total.Should().Be(0);
+            Assert.AreEqual(0, status.Waiting);
+            Assert.AreEqual(0, status.Processing);
+            Assert.AreEqual(0, status.Total);
         }
 
         [TestMethod]
@@ -85,8 +84,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            paged.Items.Should().BeEmpty();
-            paged.TotalCount.Should().Be(0);
+            Assert.AreEqual(0, paged.Items.Count);
+            Assert.AreEqual(0, paged.TotalCount);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/HealthEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/HealthEndpointTests.cs
@@ -21,7 +21,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -61,18 +60,18 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         public async Task Health_ReturnsOk()
         {
             var response = await _server.Client.GetAsync("api/v1/dashboard/health");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         }
 
         [TestMethod]
         public async Task Health_ResponseContainsHealthyStatus()
         {
             var response = await _server.Client.GetAsync("api/v1/dashboard/health");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
             var body = await response.Content.ReadAsStringAsync();
-            body.Should().NotBeNullOrEmpty();
-            body.Should().Contain("Healthy");
+            Assert.IsFalse(string.IsNullOrEmpty(body));
+            StringAssert.Contains(body, "Healthy");
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbEndpointTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -63,12 +62,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
+            Assert.AreEqual(1, queues.Count);
             _queueId = queues[0].Id;
         }
 
@@ -86,8 +85,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -95,8 +94,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
-            queues[0].QueueName.Should().Be(_queueName);
+            Assert.AreEqual(1, queues.Count);
+            Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
         [TestMethod]
@@ -104,7 +103,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{Guid.NewGuid()}/queues");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Status & Features ===
@@ -114,9 +113,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Waiting.Should().Be(5);
-            status.Processing.Should().Be(0);
-            status.Total.Should().Be(5);
+            Assert.AreEqual(5, status.Waiting);
+            Assert.AreEqual(0, status.Processing);
+            Assert.AreEqual(5, status.Total);
         }
 
         [TestMethod]
@@ -124,7 +123,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var features = await _server.Client.GetFromJsonAsync<QueueFeaturesResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/features");
-            features.EnableStatusTable.Should().BeTrue();
+            Assert.IsTrue(features.EnableStatusTable);
         }
 
         // === Message Listing ===
@@ -134,7 +133,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -142,8 +141,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            paged.Items.Should().HaveCount(2);
-            paged.TotalCount.Should().Be(5);
+            Assert.AreEqual(2, paged.Items.Count);
+            Assert.AreEqual(5, paged.TotalCount);
         }
 
         [TestMethod]
@@ -151,7 +150,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -159,9 +158,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -169,9 +168,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -179,7 +178,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=99");
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         // === Message Detail/Body/Headers ===
@@ -193,7 +192,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var detail = await _server.Client.GetFromJsonAsync<MessageResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            detail.QueueId.Should().Be(messageId);
+            Assert.AreEqual(messageId, detail.QueueId);
         }
 
         [TestMethod]
@@ -201,7 +200,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -213,7 +212,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
-            body.Body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
         }
 
         [TestMethod]
@@ -225,7 +224,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var headers = await _server.Client.GetFromJsonAsync<MessageHeadersResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/headers");
-            headers.Headers.Should().NotBeNull();
+            Assert.IsNotNull(headers.Headers);
         }
 
         // === Delete ===
@@ -239,12 +238,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var deleteResponse = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(4);
+            Assert.AreEqual(4, count);
         }
 
         [TestMethod]
@@ -252,7 +251,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === LiteDb-specific ===
@@ -262,7 +261,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -270,7 +269,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var jobs = await _server.Client.GetFromJsonAsync<List<JobResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/jobs");
-            jobs.Should().BeEmpty();
+            Assert.AreEqual(0, jobs.Count);
         }
 
         [TestMethod]
@@ -278,7 +277,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -286,9 +285,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
 
         [TestMethod]
@@ -296,7 +295,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/999999/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbErrorTests.cs
@@ -25,7 +25,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -89,7 +88,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Error.Should().BeGreaterThan(0);
+            Assert.IsTrue(status.Error > 0);
         }
 
         [TestMethod]
@@ -97,8 +96,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
-            paged.Items[0].LastException.Should().NotBeNullOrEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsFalse(string.IsNullOrEmpty(paged.Items[0].LastException));
         }
 
         [TestMethod]
@@ -106,13 +105,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThan(0);
+            Assert.IsTrue(result.Deleted > 0);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -120,12 +119,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbHistoryTests.cs
@@ -27,8 +27,8 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 {
@@ -86,8 +86,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -95,9 +95,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -105,7 +105,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/99999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -113,9 +113,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
     }
 
@@ -220,9 +220,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsTrue(result.Items.Count >= MessageCount);
         }
 
         [TestMethod]
@@ -231,11 +231,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=0&pageSize=2");
 
-            result.Should().NotBeNull();
-            result.Items.Should().HaveCount(2);
-            result.TotalCount.Should().BeGreaterThanOrEqualTo(MessageCount);
-            result.PageIndex.Should().Be(0);
-            result.PageSize.Should().Be(2);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Items.Count);
+            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.AreEqual(0, result.PageIndex);
+            Assert.AreEqual(2, result.PageSize);
         }
 
         [TestMethod]
@@ -244,9 +244,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=1&pageSize=2");
 
-            result.Should().NotBeNull();
-            result.Items.Should().HaveCount(2);
-            result.PageIndex.Should().Be(1);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Items.Count);
+            Assert.AreEqual(1, result.PageIndex);
         }
 
         [TestMethod]
@@ -255,9 +255,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=100&pageSize=25");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
-            result.TotalCount.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsTrue(result.TotalCount >= MessageCount);
         }
 
         [TestMethod]
@@ -267,9 +267,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Should().AllSatisfy(item => item.Status.Should().Be(2));
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
         [TestMethod]
@@ -279,8 +279,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=3&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -290,8 +290,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=1&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -299,9 +299,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -309,9 +309,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=2");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -319,9 +319,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=3");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -329,17 +329,17 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
-            history.Items.Should().NotBeEmpty();
+            Assert.IsTrue(history.Items.Count > 0);
             var recordQueueId = history.Items[0].QueueId;
 
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/{recordQueueId}");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
             var record = await response.Content.ReadFromJsonAsync<HistoryResponse>();
-            record.Should().NotBeNull();
-            record.QueueId.Should().Be(recordQueueId);
-            record.Status.Should().Be(2); // Complete
+            Assert.IsNotNull(record);
+            Assert.AreEqual(recordQueueId, record.QueueId);
+            Assert.AreEqual(2, record.Status); // Complete
         }
 
         [TestMethod]
@@ -347,7 +347,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/99999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -356,12 +356,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            result.Items.Should().NotBeEmpty();
+            Assert.IsTrue(result.Items.Count > 0);
             var record = result.Items[0];
 
-            record.QueueId.Should().NotBeNullOrEmpty();
-            record.Status.Should().Be(2); // Complete
-            record.EnqueuedUtc.Should().BeAfter(DateTime.MinValue);
+            Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
+            Assert.AreEqual(2, record.Status); // Complete
+            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
         }
 
         [TestMethod]
@@ -370,15 +370,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Purge records "older than 0 days" = purge all
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(result.Deleted >= MessageCount);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -387,15 +387,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Purge records older than 365 days - none should qualify since they were just created
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=365");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
 
             // Verify count is unchanged
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbProcessingTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -85,7 +84,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Processing.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(status.Processing >= 1);
         }
 
         [TestMethod]
@@ -93,7 +92,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -101,12 +100,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbStaleTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -88,7 +87,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -98,12 +97,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             await DashboardPollingHelper.WaitForStaleAsync(_server.Client, _queueId);
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/reset", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryEndpointTests.cs
@@ -25,7 +25,6 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -61,13 +60,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Discover connection and queue IDs
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
-            queues[0].QueueName.Should().Be(_queueName);
+            Assert.AreEqual(1, queues.Count);
+            Assert.AreEqual(_queueName, queues[0].QueueName);
             _queueId = queues[0].Id;
         }
 
@@ -85,8 +84,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -94,8 +93,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
-            queues[0].QueueName.Should().Be(_queueName);
+            Assert.AreEqual(1, queues.Count);
+            Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
         [TestMethod]
@@ -103,7 +102,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{Guid.NewGuid()}/queues");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Status & Features ===
@@ -113,9 +112,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Waiting.Should().Be(5);
-            status.Processing.Should().Be(0);
-            status.Total.Should().Be(5);
+            Assert.AreEqual(5, status.Waiting);
+            Assert.AreEqual(0, status.Processing);
+            Assert.AreEqual(5, status.Total);
         }
 
         [TestMethod]
@@ -123,7 +122,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var features = await _server.Client.GetFromJsonAsync<QueueFeaturesResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/features");
-            features.Should().NotBeNull();
+            Assert.IsNotNull(features);
         }
 
         // === Message Listing ===
@@ -133,7 +132,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -141,8 +140,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            paged.Items.Should().HaveCount(2);
-            paged.TotalCount.Should().Be(5);
+            Assert.AreEqual(2, paged.Items.Count);
+            Assert.AreEqual(5, paged.TotalCount);
         }
 
         [TestMethod]
@@ -150,7 +149,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -158,9 +157,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -168,9 +167,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -178,7 +177,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=99");
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         // === Message Detail/Body/Headers ===
@@ -192,7 +191,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var detail = await _server.Client.GetFromJsonAsync<MessageResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            detail.QueueId.Should().Be(messageId);
+            Assert.AreEqual(messageId, detail.QueueId);
         }
 
         [TestMethod]
@@ -201,7 +200,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var fakeId = Guid.NewGuid().ToString();
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{fakeId}");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -213,7 +212,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
-            body.Body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
         }
 
         [TestMethod]
@@ -225,7 +224,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var headers = await _server.Client.GetFromJsonAsync<MessageHeadersResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/headers");
-            headers.Headers.Should().NotBeNull();
+            Assert.IsNotNull(headers.Headers);
         }
 
         // === Delete ===
@@ -239,13 +238,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var deleteResponse = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             // Count should be reduced
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(4);
+            Assert.AreEqual(4, count);
         }
 
         [TestMethod]
@@ -254,7 +253,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var fakeId = Guid.NewGuid().ToString();
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{fakeId}");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Memory-specific ===
@@ -264,7 +263,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var config = await _server.Client.GetFromJsonAsync<ConfigurationResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/configuration");
-            config.ConfigurationJson.Should().BeNull();
+            Assert.IsNull(config.ConfigurationJson);
         }
 
         [TestMethod]
@@ -272,7 +271,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var jobs = await _server.Client.GetFromJsonAsync<List<JobResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/jobs");
-            jobs.Should().BeEmpty();
+            Assert.AreEqual(0, jobs.Count);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryHistoryTests.cs
@@ -28,8 +28,8 @@ using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 {
@@ -83,8 +83,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -92,9 +92,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -102,7 +102,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/99999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -110,9 +110,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
     }
 
@@ -208,9 +208,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsTrue(result.Items.Count >= MessageCount);
         }
 
         [TestMethod]
@@ -219,11 +219,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=0&pageSize=2");
 
-            result.Should().NotBeNull();
-            result.Items.Should().HaveCount(2);
-            result.TotalCount.Should().BeGreaterThanOrEqualTo(MessageCount);
-            result.PageIndex.Should().Be(0);
-            result.PageSize.Should().Be(2);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Items.Count);
+            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.AreEqual(0, result.PageIndex);
+            Assert.AreEqual(2, result.PageSize);
         }
 
         [TestMethod]
@@ -232,9 +232,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=1&pageSize=2");
 
-            result.Should().NotBeNull();
-            result.Items.Should().HaveCount(2);
-            result.PageIndex.Should().Be(1);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Items.Count);
+            Assert.AreEqual(1, result.PageIndex);
         }
 
         [TestMethod]
@@ -243,9 +243,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=100&pageSize=25");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
-            result.TotalCount.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsTrue(result.TotalCount >= MessageCount);
         }
 
         [TestMethod]
@@ -255,9 +255,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Should().AllSatisfy(item => item.Status.Should().Be(2));
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
         [TestMethod]
@@ -267,8 +267,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=3&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -278,8 +278,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=1&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -287,9 +287,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -297,9 +297,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=2");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -307,9 +307,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=3");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -317,17 +317,17 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
-            history.Items.Should().NotBeEmpty();
+            Assert.IsTrue(history.Items.Count > 0);
             var recordQueueId = history.Items[0].QueueId;
 
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/{recordQueueId}");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
             var record = await response.Content.ReadFromJsonAsync<HistoryResponse>();
-            record.Should().NotBeNull();
-            record.QueueId.Should().Be(recordQueueId);
-            record.Status.Should().Be(2); // Complete
+            Assert.IsNotNull(record);
+            Assert.AreEqual(recordQueueId, record.QueueId);
+            Assert.AreEqual(2, record.Status); // Complete
         }
 
         [TestMethod]
@@ -335,7 +335,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/99999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -344,12 +344,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            result.Items.Should().NotBeEmpty();
+            Assert.IsTrue(result.Items.Count > 0);
             var record = result.Items[0];
 
-            record.QueueId.Should().NotBeNullOrEmpty();
-            record.Status.Should().Be(2); // Complete
-            record.EnqueuedUtc.Should().BeAfter(DateTime.MinValue);
+            Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
+            Assert.AreEqual(2, record.Status); // Complete
+            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
         }
 
         [TestMethod]
@@ -358,15 +358,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Purge records "older than 0 days" = purge all
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(result.Deleted >= MessageCount);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -375,15 +375,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Purge records older than 365 days - none should qualify since they were just created
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=365");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
 
             // Verify count is unchanged
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryStatefulTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryStatefulTests.cs
@@ -25,7 +25,6 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -59,11 +58,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{connections[0].Id}/queues");
-            queues.Should().HaveCount(1);
+            Assert.AreEqual(1, queues.Count);
             _queueId = queues[0].Id;
 
             // Start blocking consumer with 2 workers — each picks up 1 message and blocks
@@ -86,9 +85,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Waiting.Should().Be(3);
-            status.Processing.Should().Be(2);
-            status.Total.Should().Be(5);
+            Assert.AreEqual(3, status.Waiting);
+            Assert.AreEqual(2, status.Processing);
+            Assert.AreEqual(5, status.Total);
         }
 
         [TestMethod]
@@ -96,9 +95,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=1");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(2);
+            Assert.AreEqual(2, count);
         }
 
         [TestMethod]
@@ -106,7 +105,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            paged.Items.Should().HaveCount(2);
+            Assert.AreEqual(2, paged.Items.Count);
         }
 
         [TestMethod]
@@ -114,7 +113,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -122,12 +121,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var detail = await _server.Client.GetFromJsonAsync<MessageResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            detail.QueueId.Should().Be(messageId);
+            Assert.AreEqual(messageId, detail.QueueId);
         }
 
         [TestMethod]
@@ -135,12 +134,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
-            body.Body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
         }
 
         [TestMethod]
@@ -148,16 +147,16 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var deleteResponse = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Total.Should().Be(4);
+            Assert.AreEqual(4, status.Total);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiQueueTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiQueueTests.cs
@@ -25,7 +25,6 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -73,12 +72,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(2);
+            Assert.AreEqual(2, queues.Count);
 
             // Assign queue IDs by matching queue names
             foreach (var q in queues)
@@ -103,8 +102,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(2);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(2, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -112,11 +111,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged1 = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId1}/messages?pageSize=100");
-            paged1.Items.Should().HaveCount(3);
+            Assert.AreEqual(3, paged1.Items.Count);
 
             var paged2 = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId2}/messages?pageSize=100");
-            paged2.Items.Should().HaveCount(2);
+            Assert.AreEqual(2, paged2.Items.Count);
         }
 
         [TestMethod]
@@ -124,11 +123,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status1 = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId1}/status");
-            status1.Waiting.Should().Be(3);
+            Assert.AreEqual(3, status1.Waiting);
 
             var status2 = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId2}/status");
-            status2.Waiting.Should().Be(2);
+            Assert.AreEqual(2, status2.Waiting);
         }
 
         [TestMethod]
@@ -136,7 +135,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/status");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiSourcePartialFailureTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiSourcePartialFailureTests.cs
@@ -26,7 +26,6 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -104,7 +103,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Verify server2 is healthy first
             var connections = await _server2.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
 
             // Dispose server2
             await _server2.DisposeAsync();
@@ -120,7 +119,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 exceptionThrown = true;
             }
 
-            exceptionThrown.Should().BeTrue("calling a disposed server should throw an exception");
+            Assert.IsTrue(exceptionThrown);
             _server2 = null; // prevent double-dispose in cleanup
         }
 
@@ -132,8 +131,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server1.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -152,7 +151,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server1.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(3);
+            Assert.AreEqual(3, paged.Items.Count);
         }
 
         [TestMethod]
@@ -162,7 +161,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             _server2 = null;
 
             var response = await _server1.Client.GetAsync("api/v1/dashboard/health");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiSourceTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiSourceTests.cs
@@ -26,7 +26,6 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -87,8 +86,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server1.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -96,8 +95,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server2.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -108,12 +107,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var connections2 = await _server2.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
 
-            connections1.Should().HaveCount(1);
-            connections2.Should().HaveCount(1);
+            Assert.AreEqual(1, connections1.Count);
+            Assert.AreEqual(1, connections2.Count);
 
             var ids1 = connections1.Select(c => c.Id).ToHashSet();
             var ids2 = connections2.Select(c => c.Id).ToHashSet();
-            ids1.Overlaps(ids2).Should().BeFalse("connection IDs from separate servers should not overlap");
+            Assert.IsFalse(ids1.Overlaps(ids2));
         }
 
         [TestMethod]
@@ -129,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server1.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(3);
+            Assert.AreEqual(3, paged.Items.Count);
         }
 
         [TestMethod]
@@ -145,7 +144,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server2.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(2);
+            Assert.AreEqual(2, paged.Items.Count);
         }
 
         [TestMethod]
@@ -167,13 +166,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Delete one message from server1
             var deleteResponse = await _server1.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{queueId1}/messages/{messageId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             // Server1 should now have 2 messages
             var countResponse1 = await _server1.Client.GetAsync(
                 $"api/v1/dashboard/queues/{queueId1}/messages/count");
             var count1 = await countResponse1.Content.ReadFromJsonAsync<long>();
-            count1.Should().Be(2);
+            Assert.AreEqual(2, count1);
 
             // Server2 should still have 2 messages (unaffected)
             var connections2 = await _server2.Client.GetFromJsonAsync<List<ConnectionResponse>>(
@@ -187,7 +186,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var countResponse2 = await _server2.Client.GetAsync(
                 $"api/v1/dashboard/queues/{queueId2}/messages/count");
             var count2 = await countResponse2.Content.ReadFromJsonAsync<long>();
-            count2.Should().Be(2);
+            Assert.AreEqual(2, count2);
         }
 
         [TestMethod]
@@ -196,8 +195,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var response1 = await _server1.Client.GetAsync("api/v1/dashboard/health");
             var response2 = await _server2.Client.GetAsync("api/v1/dashboard/health");
 
-            response1.StatusCode.Should().Be(HttpStatusCode.OK);
-            response2.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response1.StatusCode);
+            Assert.AreEqual(HttpStatusCode.OK, response2.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlEditBodyTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlEditBodyTests.cs
@@ -26,7 +26,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -90,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
 
         [TestMethod]
@@ -101,7 +100,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -116,7 +115,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [TestMethod]
@@ -129,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var content = new StringContent(
@@ -137,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlEndpointTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -64,12 +63,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
+            Assert.AreEqual(1, queues.Count);
             _queueId = queues[0].Id;
         }
 
@@ -87,8 +86,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -96,8 +95,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
-            queues[0].QueueName.Should().Be(_queueName);
+            Assert.AreEqual(1, queues.Count);
+            Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
         [TestMethod]
@@ -105,7 +104,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{Guid.NewGuid()}/queues");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Status & Features ===
@@ -115,9 +114,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Waiting.Should().Be(5);
-            status.Processing.Should().Be(0);
-            status.Total.Should().Be(5);
+            Assert.AreEqual(5, status.Waiting);
+            Assert.AreEqual(0, status.Processing);
+            Assert.AreEqual(5, status.Total);
         }
 
         [TestMethod]
@@ -125,9 +124,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var features = await _server.Client.GetFromJsonAsync<QueueFeaturesResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/features");
-            features.EnableStatus.Should().BeTrue();
-            features.EnableStatusTable.Should().BeTrue();
-            features.EnableHeartBeat.Should().BeTrue();
+            Assert.IsTrue(features.EnableStatus);
+            Assert.IsTrue(features.EnableStatusTable);
+            Assert.IsTrue(features.EnableHeartBeat);
         }
 
         // === Message Listing ===
@@ -137,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -145,8 +144,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            paged.Items.Should().HaveCount(2);
-            paged.TotalCount.Should().Be(5);
+            Assert.AreEqual(2, paged.Items.Count);
+            Assert.AreEqual(5, paged.TotalCount);
         }
 
         [TestMethod]
@@ -154,7 +153,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -162,9 +161,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -172,9 +171,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -182,7 +181,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=99");
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         // === Message Detail/Body/Headers ===
@@ -196,7 +195,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var detail = await _server.Client.GetFromJsonAsync<MessageResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            detail.QueueId.Should().Be(messageId);
+            Assert.AreEqual(messageId, detail.QueueId);
         }
 
         [TestMethod]
@@ -204,7 +203,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -216,7 +215,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
-            body.Body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
         }
 
         [TestMethod]
@@ -228,7 +227,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var headers = await _server.Client.GetFromJsonAsync<MessageHeadersResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/headers");
-            headers.Headers.Should().NotBeNull();
+            Assert.IsNotNull(headers.Headers);
         }
 
         // === Delete ===
@@ -242,12 +241,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var deleteResponse = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(4);
+            Assert.AreEqual(4, count);
         }
 
         [TestMethod]
@@ -255,7 +254,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Relational-specific ===
@@ -265,7 +264,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var config = await _server.Client.GetFromJsonAsync<ConfigurationResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/configuration");
-            config.ConfigurationJson.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(config.ConfigurationJson));
         }
 
         [TestMethod]
@@ -273,9 +272,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{_connectionId}/jobs");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var jobs = await response.Content.ReadFromJsonAsync<List<JobResponse>>();
-            jobs.Should().NotBeNull();
+            Assert.IsNotNull(jobs);
         }
 
         [TestMethod]
@@ -283,7 +282,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -291,7 +290,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -299,9 +298,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
 
         [TestMethod]
@@ -309,7 +308,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlErrorTests.cs
@@ -25,7 +25,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -90,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Error.Should().BeGreaterThan(0);
+            Assert.IsTrue(status.Error > 0);
         }
 
         [TestMethod]
@@ -98,8 +97,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
-            paged.Items[0].LastException.Should().NotBeNullOrEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsFalse(string.IsNullOrEmpty(paged.Items[0].LastException));
         }
 
         [TestMethod]
@@ -107,13 +106,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThan(0);
+            Assert.IsTrue(result.Deleted > 0);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -121,12 +120,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlHistoryEnabledTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlHistoryEnabledTests.cs
@@ -27,8 +27,8 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 {
@@ -134,9 +134,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsTrue(result.Items.Count >= MessageCount);
         }
 
         [TestMethod]
@@ -144,9 +144,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -156,9 +156,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Should().AllSatisfy(item => item.Status.Should().Be(2));
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
         [TestMethod]
@@ -167,12 +167,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            result.Items.Should().NotBeEmpty();
+            Assert.IsTrue(result.Items.Count > 0);
             var record = result.Items[0];
 
-            record.QueueId.Should().NotBeNullOrEmpty();
-            record.Status.Should().Be(2); // Complete
-            record.EnqueuedUtc.Should().BeAfter(DateTime.MinValue);
+            Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
+            Assert.AreEqual(2, record.Status); // Complete
+            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
         }
 
         [TestMethod]
@@ -181,15 +181,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Purge records older than 0 days = purge all
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(result.Deleted >= MessageCount);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlHistoryTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -82,8 +81,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -91,9 +90,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -101,7 +100,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/99999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -109,9 +108,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlProcessingTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -86,7 +85,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Processing.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(status.Processing >= 1);
         }
 
         [TestMethod]
@@ -94,7 +93,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -102,12 +101,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlStaleTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -89,7 +88,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -97,12 +96,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/reset", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisEndpointTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Redis.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -58,12 +57,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
+            Assert.AreEqual(1, queues.Count);
             _queueId = queues[0].Id;
         }
 
@@ -81,8 +80,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -90,8 +89,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
-            queues[0].QueueName.Should().Be(_queueName);
+            Assert.AreEqual(1, queues.Count);
+            Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
         [TestMethod]
@@ -99,7 +98,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{Guid.NewGuid()}/queues");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Status & Features ===
@@ -109,9 +108,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Waiting.Should().Be(5);
-            status.Processing.Should().Be(0);
-            status.Total.Should().Be(5);
+            Assert.AreEqual(5, status.Waiting);
+            Assert.AreEqual(0, status.Processing);
+            Assert.AreEqual(5, status.Total);
         }
 
         [TestMethod]
@@ -119,7 +118,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var features = await _server.Client.GetFromJsonAsync<QueueFeaturesResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/features");
-            features.Should().NotBeNull();
+            Assert.IsNotNull(features);
         }
 
         // === Message Listing ===
@@ -129,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -137,8 +136,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            paged.Items.Should().HaveCount(2);
-            paged.TotalCount.Should().Be(5);
+            Assert.AreEqual(2, paged.Items.Count);
+            Assert.AreEqual(5, paged.TotalCount);
         }
 
         [TestMethod]
@@ -146,7 +145,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -154,9 +153,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -164,9 +163,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -174,7 +173,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=99");
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         // === Message Detail/Body/Headers ===
@@ -188,7 +187,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var detail = await _server.Client.GetFromJsonAsync<MessageResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            detail.QueueId.Should().Be(messageId);
+            Assert.AreEqual(messageId, detail.QueueId);
         }
 
         [TestMethod]
@@ -196,7 +195,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/nonexistent-id-12345");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -208,7 +207,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
-            body.Body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
         }
 
         [TestMethod]
@@ -220,7 +219,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var headers = await _server.Client.GetFromJsonAsync<MessageHeadersResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/headers");
-            headers.Headers.Should().NotBeNull();
+            Assert.IsNotNull(headers.Headers);
         }
 
         // === Delete ===
@@ -234,12 +233,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var deleteResponse = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(4);
+            Assert.AreEqual(4, count);
         }
 
         [TestMethod]
@@ -247,7 +246,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/nonexistent-id-12345");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Redis-specific ===
@@ -257,7 +256,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -266,7 +265,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var jobs = await _server.Client.GetFromJsonAsync<List<JobResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/jobs");
             // Shared Redis may have leftover jobs from prior test runs
-            jobs.Should().NotBeNull();
+            Assert.IsNotNull(jobs);
         }
 
         [TestMethod]
@@ -274,7 +273,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -282,9 +281,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
 
         [TestMethod]
@@ -292,7 +291,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/nonexistent-id-12345/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisErrorTests.cs
@@ -25,7 +25,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Redis.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -84,7 +83,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Error.Should().BeGreaterThan(0);
+            Assert.IsTrue(status.Error > 0);
         }
 
         [TestMethod]
@@ -92,7 +91,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             // Redis does not store exception text, so LastException may be null
         }
 
@@ -101,13 +100,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThan(0);
+            Assert.IsTrue(result.Deleted > 0);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -115,12 +114,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisHistoryTests.cs
@@ -27,8 +27,8 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.Redis.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 {
@@ -81,8 +81,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -90,9 +90,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/nonexistent-id-12345");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -108,9 +108,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
     }
 
@@ -204,9 +204,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsTrue(result.Items.Count >= MessageCount);
         }
 
         [TestMethod]
@@ -215,11 +215,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=0&pageSize=2");
 
-            result.Should().NotBeNull();
-            result.Items.Should().HaveCount(2);
-            result.TotalCount.Should().BeGreaterThanOrEqualTo(MessageCount);
-            result.PageIndex.Should().Be(0);
-            result.PageSize.Should().Be(2);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Items.Count);
+            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.AreEqual(0, result.PageIndex);
+            Assert.AreEqual(2, result.PageSize);
         }
 
         [TestMethod]
@@ -228,9 +228,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=1&pageSize=2");
 
-            result.Should().NotBeNull();
-            result.Items.Should().HaveCount(2);
-            result.PageIndex.Should().Be(1);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Items.Count);
+            Assert.AreEqual(1, result.PageIndex);
         }
 
         [TestMethod]
@@ -239,9 +239,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=100&pageSize=25");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
-            result.TotalCount.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsTrue(result.TotalCount >= MessageCount);
         }
 
         [TestMethod]
@@ -251,9 +251,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Should().AllSatisfy(item => item.Status.Should().Be(2));
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
         [TestMethod]
@@ -263,8 +263,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=3&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -274,8 +274,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=1&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -283,9 +283,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -293,9 +293,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=2");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -303,9 +303,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=3");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -313,17 +313,17 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
-            history.Items.Should().NotBeEmpty();
+            Assert.IsTrue(history.Items.Count > 0);
             var recordQueueId = history.Items[0].QueueId;
 
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/{recordQueueId}");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
             var record = await response.Content.ReadFromJsonAsync<HistoryResponse>();
-            record.Should().NotBeNull();
-            record.QueueId.Should().Be(recordQueueId);
-            record.Status.Should().Be(2); // Complete
+            Assert.IsNotNull(record);
+            Assert.AreEqual(recordQueueId, record.QueueId);
+            Assert.AreEqual(2, record.Status); // Complete
         }
 
         [TestMethod]
@@ -331,7 +331,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/nonexistent-id-12345");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -340,12 +340,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            result.Items.Should().NotBeEmpty();
+            Assert.IsTrue(result.Items.Count > 0);
             var record = result.Items[0];
 
-            record.QueueId.Should().NotBeNullOrEmpty();
-            record.Status.Should().Be(2); // Complete
-            record.EnqueuedUtc.Should().BeAfter(DateTime.MinValue);
+            Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
+            Assert.AreEqual(2, record.Status); // Complete
+            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
         }
 
         [TestMethod]
@@ -354,15 +354,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Purge records "older than 0 days" = purge all
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(result.Deleted >= MessageCount);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -371,15 +371,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Purge records older than 365 days - none should qualify since they were just created
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=365");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
 
             // Verify count is unchanged
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisProcessingTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Redis.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -80,7 +79,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Processing.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(status.Processing >= 1);
         }
 
         [TestMethod]
@@ -88,7 +87,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -96,12 +95,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisStaleTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.Redis.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -83,7 +82,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -91,12 +90,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/reset", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerEditBodyTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerEditBodyTests.cs
@@ -26,7 +26,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -90,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
 
         [TestMethod]
@@ -101,7 +100,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -116,7 +115,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [TestMethod]
@@ -129,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var content = new StringContent(
@@ -137,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerEndpointTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -64,12 +63,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
+            Assert.AreEqual(1, queues.Count);
             _queueId = queues[0].Id;
         }
 
@@ -87,8 +86,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -96,8 +95,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
-            queues[0].QueueName.Should().Be(_queueName);
+            Assert.AreEqual(1, queues.Count);
+            Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
         [TestMethod]
@@ -105,7 +104,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{Guid.NewGuid()}/queues");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Status & Features ===
@@ -115,9 +114,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Waiting.Should().Be(5);
-            status.Processing.Should().Be(0);
-            status.Total.Should().Be(5);
+            Assert.AreEqual(5, status.Waiting);
+            Assert.AreEqual(0, status.Processing);
+            Assert.AreEqual(5, status.Total);
         }
 
         [TestMethod]
@@ -125,9 +124,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var features = await _server.Client.GetFromJsonAsync<QueueFeaturesResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/features");
-            features.EnableStatus.Should().BeTrue();
-            features.EnableStatusTable.Should().BeTrue();
-            features.EnableHeartBeat.Should().BeTrue();
+            Assert.IsTrue(features.EnableStatus);
+            Assert.IsTrue(features.EnableStatusTable);
+            Assert.IsTrue(features.EnableHeartBeat);
         }
 
         // === Message Listing ===
@@ -137,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -145,8 +144,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            paged.Items.Should().HaveCount(2);
-            paged.TotalCount.Should().Be(5);
+            Assert.AreEqual(2, paged.Items.Count);
+            Assert.AreEqual(5, paged.TotalCount);
         }
 
         [TestMethod]
@@ -154,7 +153,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -162,9 +161,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -172,9 +171,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -182,7 +181,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=99");
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         // === Message Detail/Body/Headers ===
@@ -196,7 +195,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var detail = await _server.Client.GetFromJsonAsync<MessageResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            detail.QueueId.Should().Be(messageId);
+            Assert.AreEqual(messageId, detail.QueueId);
         }
 
         [TestMethod]
@@ -204,7 +203,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -216,7 +215,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
-            body.Body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
         }
 
         [TestMethod]
@@ -228,7 +227,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var headers = await _server.Client.GetFromJsonAsync<MessageHeadersResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/headers");
-            headers.Headers.Should().NotBeNull();
+            Assert.IsNotNull(headers.Headers);
         }
 
         // === Delete ===
@@ -242,12 +241,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var deleteResponse = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(4);
+            Assert.AreEqual(4, count);
         }
 
         [TestMethod]
@@ -255,7 +254,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Relational-specific ===
@@ -265,7 +264,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var config = await _server.Client.GetFromJsonAsync<ConfigurationResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/configuration");
-            config.ConfigurationJson.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(config.ConfigurationJson));
         }
 
         [TestMethod]
@@ -273,9 +272,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{_connectionId}/jobs");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var jobs = await response.Content.ReadFromJsonAsync<List<JobResponse>>();
-            jobs.Should().NotBeNull();
+            Assert.IsNotNull(jobs);
         }
 
         [TestMethod]
@@ -283,7 +282,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -291,7 +290,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -299,9 +298,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
 
         [TestMethod]
@@ -309,7 +308,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerErrorTests.cs
@@ -25,7 +25,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -90,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Error.Should().BeGreaterThan(0);
+            Assert.IsTrue(status.Error > 0);
         }
 
         [TestMethod]
@@ -98,8 +97,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
-            paged.Items[0].LastException.Should().NotBeNullOrEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsFalse(string.IsNullOrEmpty(paged.Items[0].LastException));
         }
 
         [TestMethod]
@@ -107,13 +106,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThan(0);
+            Assert.IsTrue(result.Deleted > 0);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -121,12 +120,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerHistoryEnabledTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerHistoryEnabledTests.cs
@@ -27,8 +27,8 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 {
@@ -126,9 +126,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsTrue(result.Items.Count >= MessageCount);
         }
 
         [TestMethod]
@@ -136,9 +136,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -147,9 +147,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Should().AllSatisfy(item => item.Status.Should().Be(2));
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
         [TestMethod]
@@ -158,12 +158,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            result.Items.Should().NotBeEmpty();
+            Assert.IsTrue(result.Items.Count > 0);
             var record = result.Items[0];
 
-            record.QueueId.Should().NotBeNullOrEmpty();
-            record.Status.Should().Be(2);
-            record.EnqueuedUtc.Should().BeAfter(DateTime.MinValue);
+            Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
+            Assert.AreEqual(2, record.Status);
+            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
         }
 
         [TestMethod]
@@ -171,14 +171,14 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(result.Deleted >= MessageCount);
 
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerHistoryTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -82,8 +81,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -91,9 +90,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -101,7 +100,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/99999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -109,9 +108,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerProcessingTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -86,7 +85,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Processing.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(status.Processing >= 1);
         }
 
         [TestMethod]
@@ -94,7 +93,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -102,12 +101,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerStaleTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SqlServer.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -91,7 +90,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -99,12 +98,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/reset", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteBulkOperationsTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteBulkOperationsTests.cs
@@ -25,7 +25,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -71,9 +70,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // No stale messages -- all are Waiting
             var response = await server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/reset-all", null);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<BulkActionResponse>();
-            result.Count.Should().Be(0);
+            Assert.AreEqual(0, result.Count);
         }
 
         [TestMethod]
@@ -115,14 +114,14 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Reset all stale (resets all Processing messages)
             var response = await server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/reset-all", null);
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<BulkActionResponse>();
-            result.Count.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(result.Count >= 1);
 
             // Verify waiting count increased
             var status = await server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId}/status");
-            status.Waiting.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(status.Waiting >= 1);
         }
 
         // === Error Retries ===
@@ -165,7 +164,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // No retries for this message
             var retries = await server.Client.GetFromJsonAsync<List<ErrorRetryResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages/{messageId}/retries");
-            retries.Should().BeEmpty();
+            Assert.AreEqual(0, retries.Count);
         }
 
         [TestMethod]
@@ -208,15 +207,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Get the error message ID
             var errors = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors");
-            errors.Items.Should().NotBeEmpty();
+            Assert.IsTrue(errors.Items.Count > 0);
             var messageId = errors.Items[0].QueueId;
 
             // Check retries for this message
             var retries = await server.Client.GetFromJsonAsync<List<ErrorRetryResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages/{messageId}/retries");
-            retries.Should().NotBeEmpty();
-            retries[0].ExceptionType.Should().NotBeNullOrEmpty();
-            retries[0].RetryCount.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(retries.Count > 0);
+            Assert.IsFalse(string.IsNullOrEmpty(retries[0].ExceptionType));
+            Assert.IsTrue(retries[0].RetryCount >= 1);
         }
 
         // === Requeue single error then verify status returns to waiting ===
@@ -266,17 +265,17 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Requeue it
             var response = await server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/{messageId}/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
 
             // Verify status shows it back in Waiting
             var status = await server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId}/status");
-            status.Waiting.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(status.Waiting >= 1);
 
             // Verify error count is reduced
             var errorsAfter = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors");
-            errorsAfter.Items.Count.Should().BeLessThan(errors.Items.Count);
+            Assert.IsTrue(errorsAfter.Items.Count < errors.Items.Count);
         }
 
         // === Reset stale (single message) already tested in SqliteStaleTests,
@@ -320,7 +319,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Try to reset a Waiting message -- should return NotFound since it's not Processing
             var response = await server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/{messageId}/reset", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Cancel endpoint ===
@@ -361,7 +360,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Cancel should return 409 when no consumer is running in-process
             var response = await server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/{messageId}/cancel", null);
-            response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
         }
 
         // === Error pagination ===
@@ -406,18 +405,18 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // First page
             var page0 = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors?pageIndex=0&pageSize=2");
-            page0.Items.Should().HaveCount(2);
-            page0.TotalCount.Should().BeGreaterThanOrEqualTo(3);
+            Assert.AreEqual(2, page0.Items.Count);
+            Assert.IsTrue(page0.TotalCount >= 3);
 
             // Second page
             var page1 = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors?pageIndex=1&pageSize=2");
-            page1.Items.Should().NotBeEmpty();
-            page1.Items.Count.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(page1.Items.Count > 0);
+            Assert.IsTrue(page1.Items.Count >= 1);
 
             // Error detail fields
-            page0.Items[0].LastException.Should().NotBeNullOrEmpty();
-            page0.Items[0].QueueId.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(page0.Items[0].LastException));
+            Assert.IsFalse(string.IsNullOrEmpty(page0.Items[0].QueueId));
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteConsumerTrackingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteConsumerTrackingTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -71,19 +70,19 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var body = new { QueueName = queueName, MachineName = "SQLITEHOST", ProcessId = 5000, FriendlyName = "SqliteWorker" };
             var response = await server.Client.PostAsJsonAsync("api/v1/dashboard/consumers/register", body);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             var registration = await response.Content.ReadFromJsonAsync<ConsumerRegistrationResponse>();
-            registration.Should().NotBeNull();
-            registration!.ConsumerId.Should().NotBeEmpty();
-            registration.HeartbeatIntervalSeconds.Should().BeGreaterThan(0);
+            Assert.IsNotNull(registration);
+            Assert.AreNotEqual(Guid.Empty, registration!.ConsumerId);
+            Assert.IsTrue(registration.HeartbeatIntervalSeconds > 0);
 
             // Verify consumer appears in list and is matched to the queue
             var consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            consumers.Should().HaveCount(1);
-            consumers![0].MatchedQueueId.Should().Be(queueId);
-            consumers[0].MachineName.Should().Be("SQLITEHOST");
-            consumers[0].QueueName.Should().Be(queueName);
+            Assert.AreEqual(1, consumers.Count);
+            Assert.AreEqual(queueId, consumers![0].MatchedQueueId);
+            Assert.AreEqual("SQLITEHOST", consumers[0].MachineName);
+            Assert.AreEqual(queueName, consumers[0].QueueName);
         }
 
         // === Heartbeat updates timestamp ===
@@ -132,16 +131,16 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 PoisonMessages = 0L
             };
             var hbResponse = await server.Client.PostAsJsonAsync("api/v1/dashboard/consumers/heartbeat", hbBody);
-            hbResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, hbResponse.StatusCode);
 
             // Verify timestamp updated and metrics present
             var consumersAfter = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            consumersAfter![0].LastHeartbeat.Should().BeOnOrAfter(initialHeartbeat);
-            consumersAfter[0].MessagesProcessed.Should().Be(50);
-            consumersAfter[0].MessagesErrored.Should().Be(2);
-            consumersAfter[0].MessagesRolledBack.Should().Be(1);
-            consumersAfter[0].PoisonMessages.Should().Be(0);
+            Assert.IsTrue(consumersAfter![0].LastHeartbeat >= initialHeartbeat);
+            Assert.AreEqual(50, consumersAfter[0].MessagesProcessed);
+            Assert.AreEqual(2, consumersAfter[0].MessagesErrored);
+            Assert.AreEqual(1, consumersAfter[0].MessagesRolledBack);
+            Assert.AreEqual(0, consumersAfter[0].PoisonMessages);
         }
 
         // === List consumers filtered by queue ===
@@ -184,12 +183,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Filter by queueId should return only the 2 matched
             var filtered = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 $"api/v1/dashboard/consumers?queueId={queueId}");
-            filtered.Should().HaveCount(2);
+            Assert.AreEqual(2, filtered.Count);
 
             // All should return all 3
             var all = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            all.Should().HaveCount(3);
+            Assert.AreEqual(3, all.Count);
         }
 
         // === Unregister removes consumer ===
@@ -223,17 +222,17 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Verify registered
             var consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            consumers.Should().HaveCount(1);
+            Assert.AreEqual(1, consumers.Count);
 
             // Unregister
             var deleteResponse = await server.Client.DeleteAsync(
                 $"api/v1/dashboard/consumers/{registration!.ConsumerId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             // Verify gone
             consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            consumers.Should().BeEmpty();
+            Assert.AreEqual(0, consumers.Count);
         }
 
         // === Consumer pruning service prunes stale consumers ===
@@ -265,12 +264,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Register a consumer but do NOT send heartbeats
             var regResponse = await server.Client.PostAsJsonAsync("api/v1/dashboard/consumers/register",
                 new { QueueName = queueName, MachineName = "STALEHOST", ProcessId = 7777 });
-            regResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.AreEqual(HttpStatusCode.Created, regResponse.StatusCode);
 
             // Verify it exists
             var consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            consumers.Should().HaveCount(1);
+            Assert.AreEqual(1, consumers.Count);
 
             // Wait for the pruning service to remove it (stale threshold = 2s, prune interval = 1s)
             // Poll up to 10 seconds to account for timing
@@ -288,7 +287,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 }
             }
 
-            pruned.Should().BeTrue("Consumer should have been pruned by the ConsumerPruningService");
+            Assert.IsTrue(pruned);
         }
 
         // === Consumer tracking disabled returns appropriate responses ===
@@ -318,27 +317,27 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Register should return 404 when tracking is disabled
             var regResponse = await server.Client.PostAsJsonAsync("api/v1/dashboard/consumers/register",
                 new { QueueName = queueName, MachineName = "HOST", ProcessId = 100 });
-            regResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, regResponse.StatusCode);
 
             // Heartbeat should return 404
             var hbResponse = await server.Client.PostAsJsonAsync("api/v1/dashboard/consumers/heartbeat",
                 new { ConsumerId = Guid.NewGuid(), MessagesProcessed = 0L, MessagesErrored = 0L, MessagesRolledBack = 0L, PoisonMessages = 0L });
-            hbResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, hbResponse.StatusCode);
 
             // Unregister should return 404
             var deleteResponse = await server.Client.DeleteAsync(
                 $"api/v1/dashboard/consumers/{Guid.NewGuid()}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, deleteResponse.StatusCode);
 
             // GET consumers returns empty list (not 404)
             var consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            consumers.Should().BeEmpty();
+            Assert.AreEqual(0, consumers.Count);
 
             // GET counts returns empty dictionary
             var counts = await server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
-            counts.Should().BeEmpty();
+            Assert.AreEqual(0, counts.Count);
         }
 
         // === Consumer counts per queue ===
@@ -373,7 +372,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // No consumers initially
             var counts = await server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
-            counts.Should().BeEmpty();
+            Assert.AreEqual(0, counts.Count);
 
             // Register two
             await server.Client.PostAsJsonAsync("api/v1/dashboard/consumers/register",
@@ -383,8 +382,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             counts = await server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
-            counts.Should().ContainKey(queueId);
-            counts![queueId].Should().Be(2);
+            Assert.IsTrue(counts.ContainsKey(queueId));
+            Assert.AreEqual(2, counts![queueId]);
 
             // Unmatched queue consumer should not appear in counts
             await server.Client.PostAsJsonAsync("api/v1/dashboard/consumers/register",
@@ -392,7 +391,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             counts = await server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
-            counts![queueId].Should().Be(2); // still 2, unmatched not counted
+            Assert.AreEqual(2, counts![queueId]); // still 2, unmatched not counted
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteEditBodyTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteEditBodyTests.cs
@@ -26,7 +26,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -90,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
 
         [TestMethod]
@@ -101,7 +100,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -116,7 +115,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [TestMethod]
@@ -129,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var content = new StringContent(
@@ -137,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteEndpointTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -64,12 +63,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
+            Assert.AreEqual(1, queues.Count);
             _queueId = queues[0].Id;
         }
 
@@ -87,8 +86,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections[0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections[0].QueueCount);
         }
 
         [TestMethod]
@@ -96,8 +95,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            queues.Should().HaveCount(1);
-            queues[0].QueueName.Should().Be(_queueName);
+            Assert.AreEqual(1, queues.Count);
+            Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
         [TestMethod]
@@ -105,7 +104,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{Guid.NewGuid()}/queues");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Status & Features ===
@@ -115,9 +114,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Waiting.Should().Be(5);
-            status.Processing.Should().Be(0);
-            status.Total.Should().Be(5);
+            Assert.AreEqual(5, status.Waiting);
+            Assert.AreEqual(0, status.Processing);
+            Assert.AreEqual(5, status.Total);
         }
 
         [TestMethod]
@@ -125,9 +124,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var features = await _server.Client.GetFromJsonAsync<QueueFeaturesResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/features");
-            features.EnableStatus.Should().BeTrue();
-            features.EnableStatusTable.Should().BeTrue();
-            features.EnableHeartBeat.Should().BeTrue();
+            Assert.IsTrue(features.EnableStatus);
+            Assert.IsTrue(features.EnableStatusTable);
+            Assert.IsTrue(features.EnableHeartBeat);
         }
 
         // === Message Listing ===
@@ -137,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -145,8 +144,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            paged.Items.Should().HaveCount(2);
-            paged.TotalCount.Should().Be(5);
+            Assert.AreEqual(2, paged.Items.Count);
+            Assert.AreEqual(5, paged.TotalCount);
         }
 
         [TestMethod]
@@ -154,7 +153,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            paged.Items.Should().HaveCount(5);
+            Assert.AreEqual(5, paged.Items.Count);
         }
 
         [TestMethod]
@@ -162,9 +161,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -172,9 +171,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(5);
+            Assert.AreEqual(5, count);
         }
 
         [TestMethod]
@@ -182,7 +181,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=99");
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         // === Message Detail/Body/Headers ===
@@ -196,7 +195,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var detail = await _server.Client.GetFromJsonAsync<MessageResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            detail.QueueId.Should().Be(messageId);
+            Assert.AreEqual(messageId, detail.QueueId);
         }
 
         [TestMethod]
@@ -204,7 +203,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -216,7 +215,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body");
-            body.Body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body.Body));
         }
 
         [TestMethod]
@@ -228,7 +227,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var headers = await _server.Client.GetFromJsonAsync<MessageHeadersResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/headers");
-            headers.Headers.Should().NotBeNull();
+            Assert.IsNotNull(headers.Headers);
         }
 
         // === Delete ===
@@ -242,12 +241,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var deleteResponse = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(4);
+            Assert.AreEqual(4, count);
         }
 
         [TestMethod]
@@ -255,7 +254,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Relational-specific ===
@@ -265,7 +264,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var config = await _server.Client.GetFromJsonAsync<ConfigurationResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/configuration");
-            config.ConfigurationJson.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(config.ConfigurationJson));
         }
 
         [TestMethod]
@@ -273,7 +272,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var jobs = await _server.Client.GetFromJsonAsync<List<JobResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/jobs");
-            jobs.Should().BeEmpty();
+            Assert.AreEqual(0, jobs.Count);
         }
 
         [TestMethod]
@@ -281,7 +280,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -289,7 +288,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -297,9 +296,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
 
         [TestMethod]
@@ -307,7 +306,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteErrorPathTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteErrorPathTests.cs
@@ -27,7 +27,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -93,7 +92,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/status");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -101,7 +100,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/features");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -109,7 +108,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/configuration");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -117,7 +116,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/maintenance");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -125,7 +124,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/messages?pageSize=10");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -133,7 +132,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/messages/count");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -141,7 +140,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -149,7 +148,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/history");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === DashboardExceptionFilter: InvalidOperationException for connections ===
@@ -159,7 +158,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{Guid.NewGuid()}/queues");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -167,7 +166,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/connections/{Guid.NewGuid()}/jobs");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Message detail/body/headers for nonexistent messages ===
@@ -177,7 +176,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -185,7 +184,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/body");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -193,7 +192,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/headers");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Requeue/reset for nonexistent messages ===
@@ -203,7 +202,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -211,7 +210,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/reset", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Delete nonexistent message ===
@@ -221,7 +220,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Invalid status parameter ===
@@ -231,7 +230,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=99");
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [TestMethod]
@@ -239,7 +238,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/count?status=99");
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [TestMethod]
@@ -247,7 +246,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=-99");
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         // === Edit body with null body returns 400 ===
@@ -262,7 +261,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var content = new StringContent("{}", Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         // === Edit body for nonexistent message returns 404 ===
@@ -275,7 +274,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await _server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/99999999/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Stale messages endpoint on nonexistent queue returns 404 ===
@@ -285,7 +284,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/messages/stale");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Delete all errors on nonexistent queue returns 404 ===
@@ -295,7 +294,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === History endpoints on nonexistent queue ===
@@ -305,7 +304,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -313,7 +312,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/history/99999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -321,7 +320,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/history");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         // === Exception filter returns JSON error body ===
@@ -331,15 +330,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{Guid.NewGuid()}/status");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
 
             var body = await response.Content.ReadAsStringAsync();
-            body.Should().NotBeNullOrEmpty();
+            Assert.IsFalse(string.IsNullOrEmpty(body));
 
             // The exception filter returns { "error": "..." }
             var doc = JsonDocument.Parse(body);
-            doc.RootElement.TryGetProperty("error", out var errorProp).Should().BeTrue();
-            errorProp.GetString().Should().Contain("An internal error occurred");
+            Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp));
+            StringAssert.Contains(errorProp.GetString(), "An internal error occurred");
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteErrorTests.cs
@@ -25,7 +25,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -90,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Error.Should().BeGreaterThan(0);
+            Assert.IsTrue(status.Error > 0);
         }
 
         [TestMethod]
@@ -98,8 +97,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
-            paged.Items[0].LastException.Should().NotBeNullOrEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsFalse(string.IsNullOrEmpty(paged.Items[0].LastException));
         }
 
         [TestMethod]
@@ -107,13 +106,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThan(0);
+            Assert.IsTrue(result.Deleted > 0);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().BeEmpty();
+            Assert.AreEqual(0, paged.Items.Count);
         }
 
         [TestMethod]
@@ -121,12 +120,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteHistoryEnabledTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteHistoryEnabledTests.cs
@@ -27,8 +27,8 @@ using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Queue;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 {
@@ -126,9 +126,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsTrue(result.Items.Count >= MessageCount);
         }
 
         [TestMethod]
@@ -137,11 +137,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=0&pageSize=2");
 
-            result.Should().NotBeNull();
-            result.Items.Should().HaveCount(2);
-            result.TotalCount.Should().BeGreaterThanOrEqualTo(MessageCount);
-            result.PageIndex.Should().Be(0);
-            result.PageSize.Should().Be(2);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Items.Count);
+            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.AreEqual(0, result.PageIndex);
+            Assert.AreEqual(2, result.PageSize);
         }
 
         [TestMethod]
@@ -150,9 +150,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=1&pageSize=2");
 
-            result.Should().NotBeNull();
-            result.Items.Should().HaveCount(2);
-            result.PageIndex.Should().Be(1);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Items.Count);
+            Assert.AreEqual(1, result.PageIndex);
         }
 
         [TestMethod]
@@ -161,9 +161,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=100&pageSize=25");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
-            result.TotalCount.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsTrue(result.TotalCount >= MessageCount);
         }
 
         [TestMethod]
@@ -173,9 +173,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().NotBeEmpty();
-            result.Items.Should().AllSatisfy(item => item.Status.Should().Be(2));
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Items.Count > 0);
+            AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
         [TestMethod]
@@ -185,8 +185,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=3&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -196,8 +196,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?status=1&pageSize=100");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -205,9 +205,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -215,9 +215,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=2");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
 
         [TestMethod]
@@ -225,9 +225,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=3");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -236,17 +236,17 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // First get a history record to obtain its QueueId
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
-            history.Items.Should().NotBeEmpty();
+            Assert.IsTrue(history.Items.Count > 0);
             var queueId = history.Items[0].QueueId;
 
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/{queueId}");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
             var record = await response.Content.ReadFromJsonAsync<HistoryResponse>();
-            record.Should().NotBeNull();
-            record.QueueId.Should().Be(queueId);
-            record.Status.Should().Be(2); // Complete
+            Assert.IsNotNull(record);
+            Assert.AreEqual(queueId, record.QueueId);
+            Assert.AreEqual(2, record.Status); // Complete
         }
 
         [TestMethod]
@@ -254,7 +254,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/99999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -263,12 +263,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            result.Items.Should().NotBeEmpty();
+            Assert.IsTrue(result.Items.Count > 0);
             var record = result.Items[0];
 
-            record.QueueId.Should().NotBeNullOrEmpty();
-            record.Status.Should().Be(2); // Complete
-            record.EnqueuedUtc.Should().BeAfter(DateTime.MinValue);
+            Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
+            Assert.AreEqual(2, record.Status); // Complete
+            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
         }
 
         [TestMethod]
@@ -277,15 +277,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Purge records "older than 0 days" = purge all
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(result.Deleted >= MessageCount);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -294,15 +294,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Purge records older than 365 days - none should qualify since they were just created
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=365");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
 
             // Verify count is unchanged
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            count.Should().BeGreaterThanOrEqualTo(MessageCount);
+            Assert.IsTrue(count >= MessageCount);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteHistoryTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -82,8 +81,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
-            result.Should().NotBeNull();
-            result.Items.Should().BeEmpty();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Items.Count);
         }
 
         [TestMethod]
@@ -91,9 +90,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            count.Should().Be(0);
+            Assert.AreEqual(0, count);
         }
 
         [TestMethod]
@@ -101,7 +100,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/99999");
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [TestMethod]
@@ -109,9 +108,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result.Deleted);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteMaintenanceTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteMaintenanceTests.cs
@@ -24,8 +24,8 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotNetWorkQueue.Tests.Shared;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 {
@@ -62,9 +62,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var status = await server.Client.GetFromJsonAsync<MaintenanceStatusResponse>(
                 $"api/v1/dashboard/queues/{queues[0].Id}/maintenance");
 
-            status.HostMaintenance.Should().BeFalse();
-            status.IsRunning.Should().BeFalse();
-            status.LastRunUtc.Should().BeNull();
+            Assert.IsFalse(status.HostMaintenance);
+            Assert.IsFalse(status.IsRunning);
+            Assert.IsNull(status.LastRunUtc);
         }
 
         [TestMethod]
@@ -102,8 +102,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var status = await server.Client.GetFromJsonAsync<MaintenanceStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId}/maintenance");
 
-            status.HostMaintenance.Should().BeTrue();
-            status.IsRunning.Should().BeTrue();
+            Assert.IsTrue(status.HostMaintenance);
+            Assert.IsTrue(status.IsRunning);
 
             // Wait for at least one monitor cycle to complete (monitors run on timer)
             // The heartbeat monitor runs immediately on Start, so LastRunUtc should populate quickly
@@ -117,8 +117,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Thread.Sleep(500);
             }
 
-            polled.LastRunUtc.Should().NotBeNull();
-            polled.LastRunUtc.Value.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(30));
+            Assert.IsNotNull(polled.LastRunUtc);
+            AssertHelper.AreClose(DateTime.UtcNow, polled.LastRunUtc.Value, TimeSpan.FromSeconds(30));
         }
 
         [TestMethod]
@@ -152,9 +152,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var status = await server.Client.GetFromJsonAsync<MaintenanceStatusResponse>(
                 $"api/v1/dashboard/queues/{queues[0].Id}/maintenance");
 
-            status.HostMaintenance.Should().BeFalse();
-            status.IsRunning.Should().BeFalse();
-            status.LastRunUtc.Should().BeNull();
+            Assert.IsFalse(status.HostMaintenance);
+            Assert.IsFalse(status.IsRunning);
+            Assert.IsNull(status.LastRunUtc);
         }
 
         [TestMethod]
@@ -213,20 +213,20 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 }
             }
 
-            queueId1.Should().NotBeEmpty();
-            queueId2.Should().NotBeEmpty();
+            Assert.AreNotEqual(Guid.Empty, queueId1);
+            Assert.AreNotEqual(Guid.Empty, queueId2);
 
             // Queue 1: maintenance hosted and running
             var status1 = await server.Client.GetFromJsonAsync<MaintenanceStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId1}/maintenance");
-            status1.HostMaintenance.Should().BeTrue();
-            status1.IsRunning.Should().BeTrue();
+            Assert.IsTrue(status1.HostMaintenance);
+            Assert.IsTrue(status1.IsRunning);
 
             // Queue 2: maintenance NOT hosted
             var status2 = await server.Client.GetFromJsonAsync<MaintenanceStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId2}/maintenance");
-            status2.HostMaintenance.Should().BeFalse();
-            status2.IsRunning.Should().BeFalse();
+            Assert.IsFalse(status2.HostMaintenance);
+            Assert.IsFalse(status2.IsRunning);
         }
 
         [TestMethod]
@@ -263,8 +263,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var status = await server.Client.GetFromJsonAsync<MaintenanceStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId}/maintenance");
 
-            status.HostMaintenance.Should().BeTrue();
-            status.IsRunning.Should().BeTrue();
+            Assert.IsTrue(status.HostMaintenance);
+            Assert.IsTrue(status.IsRunning);
 
             // Wait for at least one monitor cycle
             MaintenanceStatusResponse polled = null;
@@ -277,7 +277,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Thread.Sleep(500);
             }
 
-            polled.LastRunUtc.Should().NotBeNull();
+            Assert.IsNotNull(polled.LastRunUtc);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteProcessingTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -87,7 +86,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            status.Processing.Should().BeGreaterThanOrEqualTo(1);
+            Assert.IsTrue(status.Processing >= 1);
         }
 
         [TestMethod]
@@ -95,7 +94,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -103,12 +102,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}");
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteQueueConfigTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteQueueConfigTests.cs
@@ -25,7 +25,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -71,10 +70,10 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var config = await server.Client.GetFromJsonAsync<ConfigurationResponse>(
                 $"api/v1/dashboard/queues/{queueId}/configuration");
-            config.Should().NotBeNull();
-            config!.ConfigurationJson.Should().NotBeNullOrEmpty();
+            Assert.IsNotNull(config);
+            Assert.IsFalse(string.IsNullOrEmpty(config!.ConfigurationJson));
             // The configuration JSON should contain transport-specific settings
-            config.ConfigurationJson.Should().Contain("EnableStatus");
+            StringAssert.Contains(config.ConfigurationJson, "EnableStatus");
         }
 
         // === Status endpoint returns correct counts ===
@@ -110,11 +109,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var status = await server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId}/status");
-            status.Should().NotBeNull();
-            status!.Waiting.Should().Be(7);
-            status.Processing.Should().Be(0);
-            status.Error.Should().Be(0);
-            status.Total.Should().Be(7);
+            Assert.IsNotNull(status);
+            Assert.AreEqual(7, status!.Waiting);
+            Assert.AreEqual(0, status.Processing);
+            Assert.AreEqual(0, status.Error);
+            Assert.AreEqual(7, status.Total);
         }
 
         // === Features reflect transport options ===
@@ -153,14 +152,14 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var features = await server.Client.GetFromJsonAsync<QueueFeaturesResponse>(
                 $"api/v1/dashboard/queues/{queueId}/features");
-            features.Should().NotBeNull();
-            features!.EnableStatus.Should().BeTrue();
-            features.EnableStatusTable.Should().BeTrue();
-            features.EnableHeartBeat.Should().BeTrue();
-            features.EnablePriority.Should().BeTrue();
-            features.EnableDelayedProcessing.Should().BeTrue();
-            features.EnableMessageExpiration.Should().BeTrue();
-            features.EnableRoute.Should().BeTrue();
+            Assert.IsNotNull(features);
+            Assert.IsTrue(features!.EnableStatus);
+            Assert.IsTrue(features.EnableStatusTable);
+            Assert.IsTrue(features.EnableHeartBeat);
+            Assert.IsTrue(features.EnablePriority);
+            Assert.IsTrue(features.EnableDelayedProcessing);
+            Assert.IsTrue(features.EnableMessageExpiration);
+            Assert.IsTrue(features.EnableRoute);
         }
 
         [TestMethod]
@@ -193,15 +192,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var features = await server.Client.GetFromJsonAsync<QueueFeaturesResponse>(
                 $"api/v1/dashboard/queues/{queueId}/features");
-            features.Should().NotBeNull();
-            features!.EnableStatus.Should().BeTrue();
-            features.EnableStatusTable.Should().BeTrue();
+            Assert.IsNotNull(features);
+            Assert.IsTrue(features!.EnableStatus);
+            Assert.IsTrue(features.EnableStatusTable);
             // SQLite defaults EnableHeartBeat to true even when not explicitly set
-            features.EnableHeartBeat.Should().BeTrue();
-            features.EnablePriority.Should().BeFalse();
-            features.EnableDelayedProcessing.Should().BeFalse();
-            features.EnableMessageExpiration.Should().BeFalse();
-            features.EnableRoute.Should().BeFalse();
+            Assert.IsTrue(features.EnableHeartBeat);
+            Assert.IsFalse(features.EnablePriority);
+            Assert.IsFalse(features.EnableDelayedProcessing);
+            Assert.IsFalse(features.EnableMessageExpiration);
+            Assert.IsFalse(features.EnableRoute);
         }
 
         // === List all queues ===
@@ -229,14 +228,14 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
-            connections![0].QueueCount.Should().Be(1);
+            Assert.AreEqual(1, connections.Count);
+            Assert.AreEqual(1, connections![0].QueueCount);
 
             var queues = await server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{connections[0].Id}/queues");
-            queues.Should().HaveCount(1);
-            queues![0].QueueName.Should().Be(queueName);
-            queues[0].Id.Should().NotBeEmpty();
+            Assert.AreEqual(1, queues.Count);
+            Assert.AreEqual(queueName, queues![0].QueueName);
+            Assert.AreNotEqual(Guid.Empty, queues[0].Id);
         }
 
         // === Multiple queues on same connection ===
@@ -279,7 +278,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(2);
+            Assert.AreEqual(2, connections.Count);
 
             // Find queue IDs across connections
             Guid queueId1 = Guid.Empty, queueId2 = Guid.Empty;
@@ -294,19 +293,19 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 }
             }
 
-            queueId1.Should().NotBeEmpty();
-            queueId2.Should().NotBeEmpty();
+            Assert.AreNotEqual(Guid.Empty, queueId1);
+            Assert.AreNotEqual(Guid.Empty, queueId2);
 
             // Verify each queue has the correct message count
             var status1 = await server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId1}/status");
-            status1!.Waiting.Should().Be(4);
-            status1.Total.Should().Be(4);
+            Assert.AreEqual(4, status1!.Waiting);
+            Assert.AreEqual(4, status1.Total);
 
             var status2 = await server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId2}/status");
-            status2!.Waiting.Should().Be(6);
-            status2.Total.Should().Be(6);
+            Assert.AreEqual(6, status2!.Waiting);
+            Assert.AreEqual(6, status2.Total);
         }
 
         // === Jobs endpoint returns empty for queues without jobs ===
@@ -337,7 +336,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var jobs = await server.Client.GetFromJsonAsync<List<JobResponse>>(
                 $"api/v1/dashboard/connections/{connections[0].Id}/jobs");
-            jobs.Should().BeEmpty();
+            Assert.AreEqual(0, jobs.Count);
         }
 
         // === Settings endpoint returns expected values ===
@@ -365,8 +364,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var settings = await server.Client.GetFromJsonAsync<DashboardSettingsResponse>(
                 "api/v1/dashboard/settings");
-            settings.Should().NotBeNull();
-            settings!.ReadOnly.Should().BeFalse();
+            Assert.IsNotNull(settings);
+            Assert.IsFalse(settings!.ReadOnly);
         }
 
         // === Stale messages returns empty when no stale messages ===
@@ -403,8 +402,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages/stale");
-            paged.Should().NotBeNull();
-            paged!.Items.Should().BeEmpty();
+            Assert.IsNotNull(paged);
+            Assert.AreEqual(0, paged!.Items.Count);
         }
 
         // === Errors returns empty when no errors ===
@@ -440,9 +439,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors");
-            paged.Should().NotBeNull();
-            paged!.Items.Should().BeEmpty();
-            paged.TotalCount.Should().Be(0);
+            Assert.IsNotNull(paged);
+            Assert.AreEqual(0, paged!.Items.Count);
+            Assert.AreEqual(0, paged.TotalCount);
         }
 
         // === Message count with valid status filters ===
@@ -479,30 +478,30 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Status 0 = Waiting
             var waitingResponse = await server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/count?status=0");
-            waitingResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, waitingResponse.StatusCode);
             var waitingCount = await waitingResponse.Content.ReadFromJsonAsync<long>();
-            waitingCount.Should().Be(5);
+            Assert.AreEqual(5, waitingCount);
 
             // Status 1 = Processing (should be 0)
             var processingResponse = await server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/count?status=1");
-            processingResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, processingResponse.StatusCode);
             var processingCount = await processingResponse.Content.ReadFromJsonAsync<long>();
-            processingCount.Should().Be(0);
+            Assert.AreEqual(0, processingCount);
 
             // Status 2 = Error (should be 0)
             var errorResponse = await server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/count?status=2");
-            errorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, errorResponse.StatusCode);
             var errorCount = await errorResponse.Content.ReadFromJsonAsync<long>();
-            errorCount.Should().Be(0);
+            Assert.AreEqual(0, errorCount);
 
             // No filter = total
             var totalResponse = await server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/count");
-            totalResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, totalResponse.StatusCode);
             var totalCount = await totalResponse.Content.ReadFromJsonAsync<long>();
-            totalCount.Should().Be(5);
+            Assert.AreEqual(5, totalCount);
         }
 
         // === Delete all errors when empty returns zero ===
@@ -538,9 +537,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var response = await server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            result!.Deleted.Should().Be(0);
+            Assert.AreEqual(0, result!.Deleted);
         }
 
         // === Error retries for nonexistent message returns empty ===
@@ -576,7 +575,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var retries = await server.Client.GetFromJsonAsync<List<ErrorRetryResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages/99999999/retries");
-            retries.Should().BeEmpty();
+            Assert.AreEqual(0, retries.Count);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteSettingsAndReadOnlyTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteSettingsAndReadOnlyTests.cs
@@ -26,7 +26,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -59,8 +58,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var settings = await server.Client.GetFromJsonAsync<DashboardSettingsResponse>(
                 "api/v1/dashboard/settings");
-            settings.Should().NotBeNull();
-            settings.ReadOnly.Should().BeFalse();
+            Assert.IsNotNull(settings);
+            Assert.IsFalse(settings.ReadOnly);
         }
 
         [TestMethod]
@@ -87,8 +86,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var settings = await server.Client.GetFromJsonAsync<DashboardSettingsResponse>(
                 "api/v1/dashboard/settings");
-            settings.Should().NotBeNull();
-            settings.ReadOnly.Should().BeTrue();
+            Assert.IsNotNull(settings);
+            Assert.IsTrue(settings.ReadOnly);
         }
 
         // === ReadOnly mode blocks write operations ===
@@ -120,15 +119,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // GET requests should still work
             var connections = await server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            connections.Should().HaveCount(1);
+            Assert.AreEqual(1, connections.Count);
 
             var queues = await server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{connections[0].Id}/queues");
-            queues.Should().HaveCount(1);
+            Assert.AreEqual(1, queues.Count);
 
             var status = await server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{queues[0].Id}/status");
-            status.Total.Should().Be(3);
+            Assert.AreEqual(3, status.Total);
         }
 
         [TestMethod]
@@ -167,7 +166,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var response = await server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/{messageId}");
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [TestMethod]
@@ -200,7 +199,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var response = await server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/12345/requeue", null);
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [TestMethod]
@@ -233,7 +232,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var response = await server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{queueId}/errors");
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [TestMethod]
@@ -275,7 +274,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 Encoding.UTF8, "application/json");
             var response = await server.Client.PutAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/{messageId}/body", content);
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [TestMethod]
@@ -308,7 +307,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var response = await server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{queueId}/messages/12345/reset", null);
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [TestMethod]
@@ -341,7 +340,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var response = await server.Client.DeleteAsync(
                 $"api/v1/dashboard/queues/{queueId}/history");
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteStaleTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
 using DotNetWorkQueue.Dashboard.Api.Models;
 using DotNetWorkQueue.Transport.SQLite.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -89,7 +88,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
         }
 
         [TestMethod]
@@ -97,12 +96,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            paged.Items.Should().NotBeEmpty();
+            Assert.IsTrue(paged.Items.Count > 0);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(
                 $"api/v1/dashboard/queues/{_queueId}/messages/{messageId}/reset", null);
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SwaggerEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SwaggerEndpointTests.cs
@@ -19,7 +19,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Dashboard.Api.Integration.Tests.Helpers;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
@@ -50,11 +49,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var response = await _server.Client.GetAsync("swagger/v1/swagger.json");
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var content = await response.Content.ReadAsStringAsync();
-            content.Should().NotBeNullOrEmpty();
-            content.Should().Contain("\"openapi\"");
-            content.Should().Contain("DotNetWorkQueue Dashboard");
+            Assert.IsFalse(string.IsNullOrEmpty(content));
+            StringAssert.Contains(content, "\"openapi\"");
+            StringAssert.Contains(content, "DotNetWorkQueue Dashboard");
         }
     }
 }


### PR DESCRIPTION
Migrates `DotNetWorkQueue.Dashboard.Api.Integration.Tests` off FluentAssertions to built-in MSTest assertions. Part of #159 (remove the MIT-pinned FluentAssertions 6.12.2). **Test-only — no production assemblies, no version bump.**

## Scope
- **52 files / 838 `.Should()` sites** under `Tests/` migrated to `Assert.*` / `StringAssert.*` / `AssertHelper.*`.
- Added `DotNetWorkQueue.Tests.Shared` `ProjectReference`; removed the FluentAssertions `PackageReference`.
- `Source/Directory.Packages.props` **untouched** (the package line is removed in the final cleanup phase).

## Non-1:1 mappings (verified against actual types)
- `BeCloseTo` (3) → `AssertHelper.AreClose` (`DateTimeOffset`/`DateTime` overloads).
- `AllSatisfy` (6) → `AssertHelper.AllSatisfy`.
- `NotBeEmpty` on `Guid` subjects (`ConsumerId`, `queueId1/2`, `queues[].Id`) → `Assert.AreNotEqual(Guid.Empty, …)`.
- `NotBeNullOrEmpty` on `List<>` subjects (`connections`, `queues`) → `Assert.IsNotNull` + `Count > 0`; string subjects → `Assert.IsFalse(string.IsNullOrEmpty(…))`.
- `Contain` on the CORS `origins` collection → `Assert.IsTrue(origins.Contains(…))`.

## Verification
- **Release build** (both `net10.0` + `net8.0`, `TreatWarningsAsErrors`): **0 warnings / 0 errors** — any leftover FA symbol or wrong type mapping would be a compile error.
- Project-wide grep: **0** `FluentAssertions` / `using FluentAssertions` / `.Should()`.
- **Local runtime gate** (Memory + SQLite + LiteDb subset): **219/219 passed** on net8.0 and net10.0.
- SQL Server / PostgreSQL / Redis suites validate on Jenkins (external services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the integration test suite to use built-in MSTest assertions instead of a third-party assertion library.
  * Improved consistency across dashboard, queue, history, error, processing, and configuration test coverage.
  * Added shared test helpers for repeated validation patterns in a few scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->