### PR TITLE
Refs #159: migrate TaskScheduler.Integration.Tests to MSTest assertions (Phase 7)

### DIFF
--- a/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/ConcurrencyRegressionTests.cs
+++ b/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/ConcurrencyRegressionTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using DotNetWorkQueue;
 using DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests
@@ -77,7 +76,7 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.T
                 Assert.Fail("Deadlock detected: 30-second timeout elapsed waiting for worker threads");
             }
 
-            _sync.GetCurrentTaskCount().Should().Be(0, "all increments are matched by decrements; final count must be zero");
+            Assert.AreEqual(0, _sync.GetCurrentTaskCount(), "all increments are matched by decrements; final count must be zero");
         }
     }
 }

--- a/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests.csproj
+++ b/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="MSTest.TestFramework" />

--- a/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/EndToEndSchedulingTests.cs
+++ b/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/EndToEndSchedulingTests.cs
@@ -3,7 +3,6 @@ using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.IntegrationTests.Shared;
 using DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler;
 using DotNetWorkQueue.Transport.Memory.Basic;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests
@@ -63,9 +62,9 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.T
                     {
                         using (var queue = creator.CreateConsumer(queueConnection))
                         {
-                            queue.Should().NotBeNull(
+                            Assert.IsNotNull(queue,
                                 "scheduler-wired consumer container constructed and resolved a consumer");
-                            queue.Configuration.Should().NotBeNull(
+                            Assert.IsNotNull(queue.Configuration,
                                 "the scheduler injection must not break configuration resolution");
                         }
                     }

--- a/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/NodeDiscoveryTests.cs
+++ b/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/NodeDiscoveryTests.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotNetWorkQueue;
 using DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests
@@ -78,10 +77,10 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.T
 
                 // Wait up to 10 seconds for node B to receive the update (UDP + timer-driven).
                 var fired = signal.Wait(TimeSpan.FromSeconds(10));
-                fired.Should().BeTrue("node B must receive RemoteCountChanged from node A within 10 seconds");
+                Assert.IsTrue(fired, "node B must receive RemoteCountChanged from node A within 10 seconds");
 
                 // Node B's aggregate count should reflect node A's bump.
-                nodeB.Sync.GetCurrentTaskCount().Should().BeGreaterThanOrEqualTo(1,
+                Assert.IsTrue(nodeB.Sync.GetCurrentTaskCount() >= 1,
                     "node B should see node A's remote task count");
             }
         }
@@ -107,10 +106,10 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.T
                     nodeA.Sync.IncreaseCurrentTaskCount();
 
                     var discovered = discoverySignal.Wait(TimeSpan.FromSeconds(10));
-                    discovered.Should().BeTrue("node B must see node A's count before we test disposal");
+                    Assert.IsTrue(discovered, "node B must see node A's count before we test disposal");
 
                     var countBeforeDispose = nodeB.Sync.GetCurrentTaskCount();
-                    countBeforeDispose.Should().BeGreaterThanOrEqualTo(1, "should have a remote count to decay");
+                    Assert.IsTrue(countBeforeDispose >= 1, "should have a remote count to decay");
 
                     // Dispose node A — node B should observe it drop off the remote list.
                     nodeA.Dispose();
@@ -126,7 +125,7 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.T
                         Thread.Sleep(100);
                     }
 
-                    countAfterDispose.Should().BeLessThan(countBeforeDispose,
+                    Assert.IsTrue(countAfterDispose < countBeforeDispose,
                         "node B's aggregate count should drop after node A is disposed (RemovedNode decay)");
                 }
                 finally


### PR DESCRIPTION
Migrates `DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests` off FluentAssertions to built-in MSTest assertions. Part of #159. **Test-only — no production assemblies, no version bump.**

## Scope
- **3 files / 8 `.Should()` sites** (`NodeDiscoveryTests`, `EndToEndSchedulingTests`, `ConcurrencyRegressionTests`) → `Assert.*`.
- Each FA `because` message preserved as the MSTest `message` argument (`Assert.IsTrue(x, msg)`, `IsNotNull(x, msg)`, `AreEqual(e, a, msg)`).
- Removed the FluentAssertions `PackageReference`. No `Tests.Shared` reference needed (no non-1:1 patterns).
- `Source/Directory.Packages.props` **untouched** (final cleanup is a later PR).

## Verification
- **Release build** (net10.0, `TreatWarningsAsErrors`): **0 warnings / 0 errors**.
- Project-wide grep: **0** `FluentAssertions` / `using FluentAssertions` / `.Should()`.
- **Local `dotnet test`: 4/4 passed** (net10.0). Also validated on the dedicated Jenkins TaskScheduler stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated integration tests to use standard assertion APIs consistently.
  - Preserved existing concurrency, end-to-end, and node-discovery coverage while keeping the same validation behavior.

- **Chores**
  - Removed an unused test-only dependency from the integration test project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->