### PR TITLE
Silence low-value imported analyzer noise via .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,19 +10,26 @@ root = true
 # and cleans local build output. Only low-value / migration-artifact / wrong-for-
 # our-design rules are silenced; genuinely useful rules (CA2254, CA1873, CA1854,
 # CA1513, CA1816, MSTEST0037, and all csharpsquid rules) are left active.
+#
+# NOTE: EditorConfig does not support inline comments — a '#' after a value is
+# parsed as part of the value. Every rationale below is therefore on its own line.
 # ---------------------------------------------------------------------------
 
 [*.cs]
 # MSTest analyzer style nags (test-only rules) — fallout from the FluentAssertions -> MSTest migration.
-dotnet_diagnostic.MSTEST0049.severity = none   # "pass TestContext.CancellationToken to the overload accepting one"
-dotnet_diagnostic.MSTEST0046.severity = none   # "use Assert.Contains instead of StringAssert.Contains"
-dotnet_diagnostic.CA2263.severity = none       # "prefer the generic overload Assert.IsInstanceOfType<T>"
-
-# CA1859 recommends concrete return types for performance, but the public API here
+# MSTEST0049: "pass TestContext.CancellationToken to the overload accepting one"
+dotnet_diagnostic.MSTEST0049.severity = none
+# MSTEST0046: "use Assert.Contains instead of StringAssert.Contains"
+dotnet_diagnostic.MSTEST0046.severity = none
+# CA2263: "prefer the generic overload Assert.IsInstanceOfType<T>"
+dotnet_diagnostic.CA2263.severity = none
+# CA1859: recommends concrete return types for performance, but the public API
 # deliberately returns interfaces (IQueueOutputMessage, etc.) as the contract.
 dotnet_diagnostic.CA1859.severity = none
 
 # Test projects only: rules that are noise in tests but kept active in production code.
 [**/*Tests*/**.cs]
-dotnet_diagnostic.CA1822.severity = none       # "member can be marked static" — not useful on test methods
-dotnet_diagnostic.CA1806.severity = none       # "instance never used" — tests new-up a type to assert its ctor throws
+# CA1822: "member can be marked static" — not useful on test methods.
+dotnet_diagnostic.CA1822.severity = none
+# CA1806: "instance never used" — tests new-up a type to assert its ctor throws.
+dotnet_diagnostic.CA1806.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+root = true
+
+# ---------------------------------------------------------------------------
+# Suppression of imported .NET analyzer (Roslyn CA*/MSTest MSTEST*) diagnostics
+# that SonarCloud CI analysis surfaces as "external_roslyn" issues.
+#
+# These are external issues: SonarCloud's Quality Profile cannot deactivate them,
+# so severity is managed here at the source. Setting `none` stops the analyzer
+# from emitting them at build time, which both removes them from the Sonar import
+# and cleans local build output. Only low-value / migration-artifact / wrong-for-
+# our-design rules are silenced; genuinely useful rules (CA2254, CA1873, CA1854,
+# CA1513, CA1816, MSTEST0037, and all csharpsquid rules) are left active.
+# ---------------------------------------------------------------------------
+
+[*.cs]
+# MSTest analyzer style nags (test-only rules) — fallout from the FluentAssertions -> MSTest migration.
+dotnet_diagnostic.MSTEST0049.severity = none   # "pass TestContext.CancellationToken to the overload accepting one"
+dotnet_diagnostic.MSTEST0046.severity = none   # "use Assert.Contains instead of StringAssert.Contains"
+dotnet_diagnostic.CA2263.severity = none       # "prefer the generic overload Assert.IsInstanceOfType<T>"
+
+# CA1859 recommends concrete return types for performance, but the public API here
+# deliberately returns interfaces (IQueueOutputMessage, etc.) as the contract.
+dotnet_diagnostic.CA1859.severity = none
+
+# Test projects only: rules that are noise in tests but kept active in production code.
+[**/*Tests*/**.cs]
+dotnet_diagnostic.CA1822.severity = none       # "member can be marked static" — not useful on test methods
+dotnet_diagnostic.CA1806.severity = none       # "instance never used" — tests new-up a type to assert its ctor throws


### PR DESCRIPTION
Reduces SonarCloud noise introduced when we switched to CI-based analysis (PR #179), which imports the .NET SDK's Roslyn (`CA*`) and MSTest (`MSTEST*`) analyzer diagnostics as `external_roslyn` issues — ~2,240 of the 2,888 total. SonarCloud's Quality Profile can't deactivate *external* issues, so the only lever is `.editorconfig` `severity = none` at the source (which also cleans local build output).

## Silenced (~1,319) — with rationale
| Rule | Ct | Reason |
|---|--:|---|
| `MSTEST0049` | 831 | test-infra style ("pass TestContext.CancellationToken"), no value |
| `MSTEST0046` | 112 | `Assert.Contains` vs `StringAssert.Contains` — cosmetic migration artifact |
| `CA2263` | 57 | generic `IsInstanceOfType<T>` — test cosmetic |
| `CA1859` | 88 | recommends concrete return types, but the public API **intentionally** returns interfaces (`IQueueOutputMessage`, …) |
| `CA1822` | 207 | "can be static" — **test-scoped only**, kept active in production |
| `CA1806` | 24 | "instance never used" — tests `new` a type to assert its ctor throws; **test-scoped only** |

## Kept active (genuinely useful)
`CA2254` (log templates), `CA1873` (expensive log args), `CA1854` (`TryGetValue`), `CA1513` (`ObjectDisposedException.ThrowIf`), `CA1816` (`GC.SuppressFinalize`), `MSTEST0037` (better assert failure messages), and all 633 `csharpsquid` findings.

## Notes
- `CA1822`/`CA1806` are scoped via `[**/*Tests*/**.cs]` (verified the glob matches all test project layouts incl. root-level files, and excludes production).
- Expected effect: master re-analysis drops from **2,888 → ~1,570**, leaving the actionable set (21 bugs, 6 vulns, real maintainability) clearly visible.
- No production code changed; `severity = none` only reduces diagnostics, so no Release `TreatWarningsAsErrors` impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a root `.editorconfig` to suppress selected imported .NET analyzer diagnostics that caused CI noise.
  * Applied extra rule suppressions for test code to reduce low-signal warnings.
  * Preserved higher-value code quality checks while disabling only specific, lower-priority rule IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->