### PR TITLE
Add AES-256-GCM message interceptor; deprecate TripleDES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.9.43 — 2026-07-06
+- Added `AesMessageInterceptor` (AES-256-GCM authenticated encryption) as the recommended built-in message encryption — per-message CSPRNG nonce, versioned envelope, 32-byte key. Fixes the weaknesses of the 3DES interceptor (Sweet32, no tamper detection, static IV)
+- Deprecated `TripleDesMessageInterceptor` (`[Obsolete]`; retired by NIST SP 800-131A). It still decrypts existing 3DES messages and will be removed in a future major (GitHub issue tracked). Migration: producers register AES; consumers register AES + 3DES until the 3DES backlog drains — the per-message interceptor graph selects the right decryptor
+- Dashboard: new `Aes` interceptor option so the dashboard can decrypt AES-encrypted message bodies for display
+
 ### 0.9.42 — 2026-06-30
 - SQL Server and PostgreSQL transports: the inbox held-transaction batch send (`Send(List<...>, DbTransaction)` with `EnableHoldTransactionUntilMessageCommitted`) now performs a true multi-row insert inside the caller's transaction instead of looping single-row inserts. The batch handler reuses the caller's connection/transaction and never commits, rolls back, or disposes it — the caller still owns commit/rollback. Same multi-row body insert + per-message meta/status rows as the standalone batch path (GitHub #167, follow-up to #162)
 - Behavior change (held-transaction batch path only): a failure now throws so the caller can roll back, instead of being swallowed into per-message results. The caller owns the transaction's all-or-nothing semantics. The standalone/outbox batch path is unchanged. SQLite is excluded by design (single-writer model makes the held-transaction inbox pattern non-viable; see #149)

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <Version>0.9.42</Version>
+    <Version>0.9.43</Version>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <DebugType>portable</DebugType>

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardInterceptorOptionsTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardInterceptorOptionsTests.cs
@@ -12,6 +12,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
             var opts = new DashboardInterceptorOptions();
             Assert.IsNull(opts.GZip);
             Assert.IsNull(opts.TripleDes);
+            Assert.IsNull(opts.Aes);
         }
 
         [TestMethod]
@@ -48,6 +49,21 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
             };
             Assert.AreEqual("dGVzdGtleQ==", opts.Key);
             Assert.AreEqual("dGVzdGl2", opts.IV);
+        }
+
+        [TestMethod]
+        public void Aes_Defaults()
+        {
+            var opts = new AesInterceptorOptions();
+            Assert.IsTrue(opts.Enabled);
+            Assert.IsNull(opts.Key);
+        }
+
+        [TestMethod]
+        public void Aes_Can_Be_Set()
+        {
+            var opts = new AesInterceptorOptions { Key = "dGVzdGtleQ==" };
+            Assert.AreEqual("dGVzdGtleQ==", opts.Key);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/InterceptorConfigurationBuilderTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/InterceptorConfigurationBuilderTests.cs
@@ -204,6 +204,53 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
         }
 
         [TestMethod]
+        public void Returns_Action_When_Aes_Enabled()
+        {
+            var queueOptions = new DashboardQueueOptions
+            {
+                QueueName = "test",
+                Interceptors = new DashboardInterceptorOptions
+                {
+                    Aes = new AesInterceptorOptions { Key = Convert.ToBase64String(new byte[32]) }
+                }
+            };
+            var result = InterceptorConfigurationBuilder.Resolve(queueOptions, EmptyProfiles);
+            Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        public void Throws_When_Aes_Missing_Key()
+        {
+            var queueOptions = new DashboardQueueOptions
+            {
+                QueueName = "test",
+                Interceptors = new DashboardInterceptorOptions
+                {
+                    Aes = new AesInterceptorOptions()
+                }
+            };
+            Action act = () => InterceptorConfigurationBuilder.Resolve(queueOptions, EmptyProfiles);
+            var ex = Assert.Throws<InvalidOperationException>(act);
+            Assert.IsTrue(ex.Message.Contains("Key", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [TestMethod]
+        public void Throws_When_Aes_Key_Wrong_Size()
+        {
+            var queueOptions = new DashboardQueueOptions
+            {
+                QueueName = "test",
+                Interceptors = new DashboardInterceptorOptions
+                {
+                    Aes = new AesInterceptorOptions { Key = Convert.ToBase64String(new byte[16]) }
+                }
+            };
+            Action act = () => InterceptorConfigurationBuilder.Resolve(queueOptions, EmptyProfiles);
+            var ex = Assert.Throws<InvalidOperationException>(act);
+            Assert.IsTrue(ex.Message.Contains("32", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [TestMethod]
         public void Returns_Null_When_Json_Options_Empty()
         {
             var queueOptions = new DashboardQueueOptions

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/InterceptorConfigurationBuilderTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/InterceptorConfigurationBuilderTests.cs
@@ -251,6 +251,22 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
         }
 
         [TestMethod]
+        public void Throws_When_Aes_Key_Not_Base64()
+        {
+            var queueOptions = new DashboardQueueOptions
+            {
+                QueueName = "test",
+                Interceptors = new DashboardInterceptorOptions
+                {
+                    Aes = new AesInterceptorOptions { Key = "!!!not-base64!!!" }
+                }
+            };
+            Action act = () => InterceptorConfigurationBuilder.Resolve(queueOptions, EmptyProfiles);
+            var ex = Assert.Throws<InvalidOperationException>(act);
+            Assert.IsTrue(ex.Message.Contains("Base64", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [TestMethod]
         public void Returns_Null_When_Json_Options_Empty()
         {
             var queueOptions = new DashboardQueueOptions

--- a/Source/DotNetWorkQueue.Dashboard.Api/Configuration/DashboardInterceptorOptions.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Configuration/DashboardInterceptorOptions.cs
@@ -35,6 +35,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Configuration
         /// Set to null (or omit from JSON) to disable.
         /// </summary>
         public TripleDesInterceptorOptions TripleDes { get; set; }
+
+        /// <summary>
+        /// Gets or sets AES-256-GCM encryption interceptor options.
+        /// Set to null (or omit from JSON) to disable.
+        /// </summary>
+        public AesInterceptorOptions Aes { get; set; }
     }
 
     /// <summary>
@@ -72,5 +78,21 @@ namespace DotNetWorkQueue.Dashboard.Api.Configuration
         /// Gets or sets the initialization vector as a Base64-encoded string.
         /// </summary>
         public string IV { get; set; }
+    }
+
+    /// <summary>
+    /// JSON-bindable options for the AES-256-GCM message interceptor.
+    /// </summary>
+    public class AesInterceptorOptions
+    {
+        /// <summary>
+        /// Gets or sets whether AES encryption is enabled. Default is true.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the AES-256 key as a Base64-encoded string (32 bytes when decoded).
+        /// </summary>
+        public string Key { get; set; }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api/Configuration/InterceptorConfigurationBuilder.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Configuration/InterceptorConfigurationBuilder.cs
@@ -68,8 +68,9 @@ namespace DotNetWorkQueue.Dashboard.Api.Configuration
         {
             var enableGZip = interceptorOptions.GZip is { Enabled: true };
             var enableTripleDes = interceptorOptions.TripleDes is { Enabled: true };
+            var enableAes = interceptorOptions.Aes is { Enabled: true };
 
-            if (!enableGZip && !enableTripleDes)
+            if (!enableGZip && !enableTripleDes && !enableAes)
                 return null;
 
             // Validate TripleDES config upfront
@@ -81,9 +82,19 @@ namespace DotNetWorkQueue.Dashboard.Api.Configuration
                     throw new InvalidOperationException("TripleDes interceptor requires an IV (Base64-encoded).");
             }
 
+            // Validate AES config upfront
+            if (enableAes)
+            {
+                if (string.IsNullOrEmpty(interceptorOptions.Aes.Key))
+                    throw new InvalidOperationException("Aes interceptor requires a Key (Base64-encoded).");
+                if (Convert.FromBase64String(interceptorOptions.Aes.Key).Length != 32)
+                    throw new InvalidOperationException("Aes interceptor Key must decode to 32 bytes (AES-256).");
+            }
+
             // Capture values for the closure
             var gzipOptions = interceptorOptions.GZip;
             var tripleDesOptions = interceptorOptions.TripleDes;
+            var aesOptions = interceptorOptions.Aes;
 
             return container =>
             {
@@ -97,6 +108,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Configuration
                         LifeStyles.Singleton);
                 }
 
+#pragma warning disable CS0618 // 3DES retained for decrypting legacy messages; deprecated
                 if (enableTripleDes)
                 {
                     types.Add(typeof(TripleDesMessageInterceptor));
@@ -104,6 +116,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Configuration
                         new TripleDesMessageInterceptorConfiguration(
                             Convert.FromBase64String(tripleDesOptions.Key),
                             Convert.FromBase64String(tripleDesOptions.IV)),
+                        LifeStyles.Singleton);
+                }
+#pragma warning restore CS0618
+
+                if (enableAes)
+                {
+                    types.Add(typeof(AesMessageInterceptor));
+                    container.Register(() =>
+                        new AesMessageInterceptorConfiguration(Convert.FromBase64String(aesOptions.Key)),
                         LifeStyles.Singleton);
                 }
 

--- a/Source/DotNetWorkQueue.Dashboard.Api/Configuration/InterceptorConfigurationBuilder.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Configuration/InterceptorConfigurationBuilder.cs
@@ -73,23 +73,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Configuration
             if (!enableGZip && !enableTripleDes && !enableAes)
                 return null;
 
-            // Validate TripleDES config upfront
-            if (enableTripleDes)
-            {
-                if (string.IsNullOrEmpty(interceptorOptions.TripleDes.Key))
-                    throw new InvalidOperationException("TripleDes interceptor requires a Key (Base64-encoded).");
-                if (string.IsNullOrEmpty(interceptorOptions.TripleDes.IV))
-                    throw new InvalidOperationException("TripleDes interceptor requires an IV (Base64-encoded).");
-            }
-
-            // Validate AES config upfront
-            if (enableAes)
-            {
-                if (string.IsNullOrEmpty(interceptorOptions.Aes.Key))
-                    throw new InvalidOperationException("Aes interceptor requires a Key (Base64-encoded).");
-                if (Convert.FromBase64String(interceptorOptions.Aes.Key).Length != 32)
-                    throw new InvalidOperationException("Aes interceptor Key must decode to 32 bytes (AES-256).");
-            }
+            ValidateInterceptorOptions(enableTripleDes, enableAes, interceptorOptions);
 
             // Capture values for the closure
             var gzipOptions = interceptorOptions.GZip;
@@ -130,6 +114,40 @@ namespace DotNetWorkQueue.Dashboard.Api.Configuration
 
                 container.RegisterCollection<IMessageInterceptor>(types);
             };
+        }
+
+        /// <summary>
+        /// Validates the interceptor options up front, throwing <see cref="InvalidOperationException"/>
+        /// for any misconfiguration so all validation failures share one exception type.
+        /// </summary>
+        private static void ValidateInterceptorOptions(bool enableTripleDes, bool enableAes, DashboardInterceptorOptions interceptorOptions)
+        {
+            if (enableTripleDes)
+            {
+                if (string.IsNullOrEmpty(interceptorOptions.TripleDes.Key))
+                    throw new InvalidOperationException("TripleDes interceptor requires a Key (Base64-encoded).");
+                if (string.IsNullOrEmpty(interceptorOptions.TripleDes.IV))
+                    throw new InvalidOperationException("TripleDes interceptor requires an IV (Base64-encoded).");
+            }
+
+            if (enableAes)
+            {
+                if (string.IsNullOrEmpty(interceptorOptions.Aes.Key))
+                    throw new InvalidOperationException("Aes interceptor requires a Key (Base64-encoded).");
+
+                byte[] decodedAesKey;
+                try
+                {
+                    decodedAesKey = Convert.FromBase64String(interceptorOptions.Aes.Key);
+                }
+                catch (FormatException ex)
+                {
+                    throw new InvalidOperationException("Aes interceptor Key is not a valid Base64 string.", ex);
+                }
+
+                if (decodedAesKey.Length != 32)
+                    throw new InvalidOperationException("Aes interceptor Key must decode to 32 bytes (AES-256).");
+            }
         }
     }
 }

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/DotNetWorkQueue.IntegrationTests.Shared.csproj
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/DotNetWorkQueue.IntegrationTests.Shared.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
+    <!-- This test-support project intentionally exercises the deprecated TripleDesMessageInterceptor
+         (heartbeat/job-scheduler helpers) to keep the legacy decrypt path covered during deprecation. -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/SharedSetup.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/SharedSetup.cs
@@ -28,16 +28,14 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
             {
                 case InterceptorAdding.ConfigurationOnly:
                     return new QueueContainer<TTransportInit>(serviceRegister => serviceRegister.Register(() => metrics,
-                       LifeStyles.Singleton).Register(() => new TripleDesMessageInterceptorConfiguration(Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                           Convert.FromBase64String("aaaaaaaaaaa=")), LifeStyles.Singleton).RegisterNonScopedSingleton(trace), options => SetOptions(options, enableChaos));
+                       LifeStyles.Singleton).Register(() => new AesMessageInterceptorConfiguration(System.Text.Encoding.ASCII.GetBytes("0123456789abcdef0123456789abcdef")                           ), LifeStyles.Singleton).RegisterNonScopedSingleton(trace), options => SetOptions(options, enableChaos));
                 case InterceptorAdding.Yes:
                     return new QueueContainer<TTransportInit>(serviceRegister => serviceRegister.Register(() => metrics,
                         LifeStyles.Singleton).RegisterCollection<IMessageInterceptor>(new[]
                         {
                             typeof (GZipMessageInterceptor), //gzip compression
-                            typeof (TripleDesMessageInterceptor) //encryption
-                        }).Register(() => new TripleDesMessageInterceptorConfiguration(Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                            Convert.FromBase64String("aaaaaaaaaaa=")), LifeStyles.Singleton).RegisterNonScopedSingleton(trace), options => SetOptions(options, enableChaos));
+                            typeof (AesMessageInterceptor) //encryption
+                        }).Register(() => new AesMessageInterceptorConfiguration(System.Text.Encoding.ASCII.GetBytes("0123456789abcdef0123456789abcdef")                            ), LifeStyles.Singleton).RegisterNonScopedSingleton(trace), options => SetOptions(options, enableChaos));
                 default:
                     return new QueueContainer<TTransportInit>(serviceRegister => serviceRegister.Register(() => metrics,
                         LifeStyles.Singleton).RegisterNonScopedSingleton(trace), options => SetOptions(options, enableChaos));
@@ -65,9 +63,7 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
                                 .RegisterNonScopedSingleton(scope)
                                 .RegisterNonScopedSingleton(trace)
                                 .Register(() => metrics,
-                                    LifeStyles.Singleton).Register(() => new TripleDesMessageInterceptorConfiguration(
-                                    Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                                    Convert.FromBase64String("aaaaaaaaaaa=")), LifeStyles.Singleton),
+                                    LifeStyles.Singleton).Register(() => new AesMessageInterceptorConfiguration(System.Text.Encoding.ASCII.GetBytes("0123456789abcdef0123456789abcdef")), LifeStyles.Singleton),
                             options => SetOptions(options, enableChaos));
                     case InterceptorAdding.Yes:
                         return new QueueContainer<TTransportInit>(
@@ -79,10 +75,8 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
                                     LifeStyles.Singleton).RegisterCollection<IMessageInterceptor>(new[]
                                 {
                                     typeof(GZipMessageInterceptor), //gzip compression
-                                    typeof(TripleDesMessageInterceptor) //encryption
-                                }).Register(() => new TripleDesMessageInterceptorConfiguration(
-                                    Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                                    Convert.FromBase64String("aaaaaaaaaaa=")), LifeStyles.Singleton),
+                                    typeof(AesMessageInterceptor) //encryption
+                                }).Register(() => new AesMessageInterceptorConfiguration(System.Text.Encoding.ASCII.GetBytes("0123456789abcdef0123456789abcdef")), LifeStyles.Singleton),
                             options => SetOptions(options, enableChaos));
                     default:
                         return new QueueContainer<TTransportInit>(
@@ -101,17 +95,15 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
                     case InterceptorAdding.ConfigurationOnly:
                         return new QueueContainer<TTransportInit>(
                             serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton).Register(() => metrics,
-                                LifeStyles.Singleton).Register(() => new TripleDesMessageInterceptorConfiguration(Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                                Convert.FromBase64String("aaaaaaaaaaa=")), LifeStyles.Singleton).RegisterNonScopedSingleton(scope).RegisterNonScopedSingleton(trace), options => SetOptions(options, enableChaos));
+                                LifeStyles.Singleton).Register(() => new AesMessageInterceptorConfiguration(System.Text.Encoding.ASCII.GetBytes("0123456789abcdef0123456789abcdef")                                ), LifeStyles.Singleton).RegisterNonScopedSingleton(scope).RegisterNonScopedSingleton(trace), options => SetOptions(options, enableChaos));
                     case InterceptorAdding.Yes:
                         return new QueueContainer<TTransportInit>(
                             serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton).Register(() => metrics,
                                 LifeStyles.Singleton).RegisterCollection<IMessageInterceptor>(new[]
                             {
                                 typeof (GZipMessageInterceptor), //gzip compression
-                                typeof (TripleDesMessageInterceptor) //encryption
-                            }).Register(() => new TripleDesMessageInterceptorConfiguration(Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                                Convert.FromBase64String("aaaaaaaaaaa=")), LifeStyles.Singleton).RegisterNonScopedSingleton(scope).RegisterNonScopedSingleton(trace), options => SetOptions(options, enableChaos));
+                                typeof (AesMessageInterceptor) //encryption
+                            }).Register(() => new AesMessageInterceptorConfiguration(System.Text.Encoding.ASCII.GetBytes("0123456789abcdef0123456789abcdef")                                ), LifeStyles.Singleton).RegisterNonScopedSingleton(scope).RegisterNonScopedSingleton(trace), options => SetOptions(options, enableChaos));
                     default:
                         return new QueueContainer<TTransportInit>(
                             serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton).Register(() => metrics,

--- a/Source/DotNetWorkQueue.Tests/Interceptors/AesMessageInterceptorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Interceptors/AesMessageInterceptorTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Interceptors;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Tests.Interceptors
+{
+    [TestClass]
+    public class AesMessageInterceptorTests
+    {
+        private static byte[] NewKey() { var k = new byte[32]; RandomNumberGenerator.Fill(k); return k; }
+        private static AesMessageInterceptor New(byte[] key) => new(new AesMessageInterceptorConfiguration(key));
+
+        [TestMethod]
+        public void Config_RejectsNon32ByteKey()
+        {
+            Assert.ThrowsExactly<ArgumentException>(() => new AesMessageInterceptorConfiguration(new byte[16]));
+        }
+
+        [TestMethod]
+        public void RoundTrip_ReturnsOriginal()
+        {
+            var key = NewKey();
+            var interceptor = New(key);
+            foreach (var size in new[] { 0, 1, 150, 100_000 })
+            {
+                var original = new byte[size];
+                RandomNumberGenerator.Fill(original);
+                var encrypted = interceptor.MessageToBytes(original, null);
+                Assert.IsTrue(encrypted.AddToGraph);
+                var decrypted = New(key).BytesToMessage(encrypted.Output, null);
+                CollectionAssert.AreEqual(original, decrypted);
+            }
+        }
+
+        [TestMethod]
+        public void Envelope_HasVersionNonceTagHeader()
+        {
+            var enc = New(NewKey()).MessageToBytes(Encoding.UTF8.GetBytes("hello"), null);
+            Assert.AreEqual((byte)0x01, enc.Output[0]);
+            Assert.AreEqual(1 + 12 + 16 + "hello"u8.Length, enc.Output.Length);
+        }
+
+        [TestMethod]
+        public void SamePlaintext_ProducesDifferentCiphertext()
+        {
+            var interceptor = New(NewKey());
+            var body = Encoding.UTF8.GetBytes("same message");
+            var a = interceptor.MessageToBytes(body, null).Output;
+            var b = interceptor.MessageToBytes(body, null).Output;
+            CollectionAssert.AreNotEqual(a, b); // random nonce
+        }
+
+        [TestMethod]
+        public void TamperedCiphertext_Throws()
+        {
+            var key = NewKey();
+            var enc = New(key).MessageToBytes(Encoding.UTF8.GetBytes("secret"), null).Output;
+            enc[^1] ^= 0xFF; // flip last ciphertext byte
+            // AesGcm throws AuthenticationTagMismatchException : CryptographicException -> use Throws<> (T-or-derived)
+            Assert.Throws<CryptographicException>(() => New(key).BytesToMessage(enc, null));
+        }
+
+        [TestMethod]
+        public void TamperedVersionByte_Throws()
+        {
+            var key = NewKey();
+            var enc = New(key).MessageToBytes(Encoding.UTF8.GetBytes("secret"), null).Output;
+            enc[0] = 0x02; // unknown version -> rejected before decrypt
+            Assert.ThrowsExactly<DotNetWorkQueueException>(() => New(key).BytesToMessage(enc, null));
+        }
+
+        [TestMethod]
+        public void WrongKey_Throws()
+        {
+            var enc = New(NewKey()).MessageToBytes(Encoding.UTF8.GetBytes("secret"), null).Output;
+            Assert.Throws<CryptographicException>(() => New(NewKey()).BytesToMessage(enc, null));
+        }
+
+        [TestMethod]
+        public void ShortInput_Throws()
+        {
+            Assert.ThrowsExactly<DotNetWorkQueueException>(() => New(NewKey()).BytesToMessage(new byte[5], null));
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Tests/Interceptors/AesMessageInterceptorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Interceptors/AesMessageInterceptorTests.cs
@@ -40,7 +40,7 @@ namespace DotNetWorkQueue.Tests.Interceptors
         {
             var enc = New(NewKey()).MessageToBytes(Encoding.UTF8.GetBytes("hello"), null);
             Assert.AreEqual((byte)0x01, enc.Output[0]);
-            Assert.AreEqual(1 + 12 + 16 + "hello"u8.Length, enc.Output.Length);
+            Assert.HasCount(1 + 12 + 16 + "hello"u8.Length, enc.Output);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs
+++ b/Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs
@@ -57,6 +57,43 @@ namespace DotNetWorkQueue.Tests.Interceptors
             }
         }
 
+        [TestMethod]
+        public void Coexistence_ConsumerPoolDecryptsBoth()
+        {
+            var aesKey = new byte[32];
+            System.Security.Cryptography.RandomNumberGenerator.Fill(aesKey);
+            var aesCfg = new AesMessageInterceptorConfiguration(aesKey);
+
+#pragma warning disable CS0618 // migration scenario: legacy 3DES stays in the consumer pool
+            var tdesCfg = new TripleDesMessageInterceptorConfiguration(
+                Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                Convert.FromBase64String("aaaaaaaaaaa="));
+
+            // Producer registers AES only
+            var producer = new MessageInterceptors(
+                new List<IMessageInterceptor> { new AesMessageInterceptor(aesCfg) },
+                new InterceptorFactory(Substitute.For<IContainerFactory>()));
+
+            // A legacy producer that used 3DES only
+            var legacyProducer = new MessageInterceptors(
+                new List<IMessageInterceptor> { new TripleDesMessageInterceptor(tdesCfg) },
+                new InterceptorFactory(Substitute.For<IContainerFactory>()));
+
+            // Consumer registers BOTH — the pool of decryptors
+            var consumer = new MessageInterceptors(
+                new List<IMessageInterceptor> { new AesMessageInterceptor(aesCfg), new TripleDesMessageInterceptor(tdesCfg) },
+                new InterceptorFactory(Substitute.For<IContainerFactory>()));
+#pragma warning restore CS0618
+
+            var body = Encoding.UTF8.GetBytes("coexistence body");
+
+            var aesMsg = producer.MessageToBytes(body, null);
+            CollectionAssert.AreEqual(body, consumer.BytesToMessage(aesMsg.Output, aesMsg.Graph, null));
+
+            var tdesMsg = legacyProducer.MessageToBytes(body, null);
+            CollectionAssert.AreEqual(body, consumer.BytesToMessage(tdesMsg.Output, tdesMsg.Graph, null));
+        }
+
         private void Test(IMessageInterceptorRegistrar register, string body)
         {
             var serialization = register.MessageToBytes(Encoding.UTF8.GetBytes(body), null);

--- a/Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs
+++ b/Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs
@@ -17,10 +17,12 @@ namespace DotNetWorkQueue.Tests.Interceptors
             var list = new List<IMessageInterceptor>
             {
                 new GZipMessageInterceptor(new GZipMessageInterceptorConfiguration()),
+#pragma warning disable CS0618 // deliberately testing the deprecated 3DES interceptor
                 new TripleDesMessageInterceptor(
                     new TripleDesMessageInterceptorConfiguration(
                         Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                         Convert.FromBase64String("aaaaaaaaaaa=")))
+#pragma warning restore CS0618
             };
 
             IMessageInterceptorRegistrar register = new MessageInterceptors(list, new InterceptorFactory(Substitute.For<IContainerFactory>()));

--- a/Source/DotNetWorkQueue/IMessageInterceptor.cs
+++ b/Source/DotNetWorkQueue/IMessageInterceptor.cs
@@ -27,6 +27,7 @@ namespace DotNetWorkQueue
     /// and de-serializing a message.
     /// <remarks>For instance, this can be used to compress or encrypt the message in the transport</remarks>
     /// <seealso cref="GZipMessageInterceptor"/>
+    /// <seealso cref="AesMessageInterceptor"/>
     /// <seealso cref="TripleDesMessageInterceptor"/>
     /// </summary>
     public interface IMessageInterceptor

--- a/Source/DotNetWorkQueue/Interceptors/AesMessageInterceptor.cs
+++ b/Source/DotNetWorkQueue/Interceptors/AesMessageInterceptor.cs
@@ -1,0 +1,144 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Interceptors
+{
+    /// <summary>
+    /// Encrypts/decrypts a byte array using AES-256-GCM (authenticated encryption).
+    /// Envelope: [version(1)=0x01][nonce(12)][tag(16)][ciphertext]. The version byte is
+    /// authenticated as associated data, so it cannot be altered without failing the tag.
+    /// </summary>
+    /// <seealso cref="GZipMessageInterceptor"/>
+    public class AesMessageInterceptor : IMessageInterceptor
+    {
+        private const byte Version = 0x01;
+        private const int NonceSizeBytes = 12;
+        private const int TagSizeBytes = 16;
+        private const int HeaderSize = 1 + NonceSizeBytes + TagSizeBytes;
+
+        private readonly AesMessageInterceptorConfiguration _configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AesMessageInterceptor" /> class.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        public AesMessageInterceptor(AesMessageInterceptorConfiguration configuration)
+        {
+            Guard.NotNull(() => configuration, configuration);
+            _configuration = configuration;
+            DisplayName = "AES";
+        }
+
+        /// <summary>Encrypts the input byte array.</summary>
+        /// <param name="input">The input.</param>
+        /// <param name="headers">the message headers</param>
+        public MessageInterceptorResult MessageToBytes(byte[] input, IReadOnlyDictionary<string, object> headers)
+        {
+            Guard.NotNull(() => input, input);
+
+            var nonce = new byte[NonceSizeBytes];
+            RandomNumberGenerator.Fill(nonce); // CSPRNG, not System.Random
+
+            var tag = new byte[TagSizeBytes];
+            var ciphertext = new byte[input.Length];
+            var associatedData = new[] { Version };
+
+            using (var aes = new AesGcm(_configuration.Key, TagSizeBytes))
+            {
+                aes.Encrypt(nonce, input, ciphertext, tag, associatedData);
+            }
+
+            var output = new byte[HeaderSize + ciphertext.Length];
+            output[0] = Version;
+            Buffer.BlockCopy(nonce, 0, output, 1, NonceSizeBytes);
+            Buffer.BlockCopy(tag, 0, output, 1 + NonceSizeBytes, TagSizeBytes);
+            Buffer.BlockCopy(ciphertext, 0, output, HeaderSize, ciphertext.Length);
+
+            return new MessageInterceptorResult(output, true, GetType());
+        }
+
+        /// <summary>Decrypts the input byte array.</summary>
+        /// <param name="input">The input.</param>
+        /// <param name="headers">the message headers</param>
+        public byte[] BytesToMessage(byte[] input, IReadOnlyDictionary<string, object> headers)
+        {
+            Guard.NotNull(() => input, input);
+            if (input.Length < HeaderSize)
+                throw new DotNetWorkQueueException("AES envelope is too short to contain the version, nonce, and tag.");
+            if (input[0] != Version)
+                throw new DotNetWorkQueueException($"Unsupported AES envelope version 0x{input[0]:X2}; expected 0x{Version:X2}.");
+
+            var nonce = new byte[NonceSizeBytes];
+            var tag = new byte[TagSizeBytes];
+            var ciphertext = new byte[input.Length - HeaderSize];
+            Buffer.BlockCopy(input, 1, nonce, 0, NonceSizeBytes);
+            Buffer.BlockCopy(input, 1 + NonceSizeBytes, tag, 0, TagSizeBytes);
+            Buffer.BlockCopy(input, HeaderSize, ciphertext, 0, ciphertext.Length);
+
+            var plaintext = new byte[ciphertext.Length];
+            var associatedData = new[] { Version };
+            using (var aes = new AesGcm(_configuration.Key, TagSizeBytes))
+            {
+                aes.Decrypt(nonce, ciphertext, tag, plaintext, associatedData);
+            }
+            return plaintext;
+        }
+
+        /// <summary>
+        /// Gets the display name for logging or display purposes
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// The base type of the interceptor; used for re-creation
+        /// </summary>
+        public Type BaseType => GetType();
+    }
+
+    /// <summary>
+    /// Configuration for <see cref="AesMessageInterceptor"/>. AES-256 requires a 32-byte key.
+    /// The nonce is generated per message and is not part of this configuration.
+    /// </summary>
+    public class AesMessageInterceptorConfiguration
+    {
+        private const int KeySizeBytes = 32;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AesMessageInterceptorConfiguration"/> class.
+        /// </summary>
+        /// <param name="key">The AES-256 key; must be exactly 32 bytes.</param>
+        public AesMessageInterceptorConfiguration(byte[] key)
+        {
+            Guard.NotNull(() => key, key);
+            if (key.Length != KeySizeBytes)
+                throw new ArgumentException($"AES-256 requires a {KeySizeBytes}-byte key; received {key.Length}.", nameof(key));
+            Key = key;
+        }
+
+        /// <summary>
+        /// Gets the AES-256 key (32 bytes).
+        /// </summary>
+        public byte[] Key { get; }
+    }
+}

--- a/Source/DotNetWorkQueue/Interceptors/TripleDesMessageInterceptor.cs
+++ b/Source/DotNetWorkQueue/Interceptors/TripleDesMessageInterceptor.cs
@@ -26,6 +26,7 @@ namespace DotNetWorkQueue.Interceptors
     /// <summary>
     /// Encrypts/Decrypts a byte array
     /// </summary>
+    [Obsolete("TripleDES is deprecated (NIST SP 800-131A) and vulnerable to Sweet32. Use AesMessageInterceptor (AES-256-GCM). This type is retained so existing 3DES-encrypted messages remain decryptable and will be removed in a future major version. See the encryption migration guide.")]
     public class TripleDesMessageInterceptor : IMessageInterceptor
     {
         #region Member level variables
@@ -100,6 +101,7 @@ namespace DotNetWorkQueue.Interceptors
     /// <summary>
     /// Configuration class for <see cref="TripleDesMessageInterceptor"/>
     /// </summary>
+    [Obsolete("TripleDES is deprecated (NIST SP 800-131A) and vulnerable to Sweet32. Use AesMessageInterceptor (AES-256-GCM). This type is retained so existing 3DES-encrypted messages remain decryptable and will be removed in a future major version. See the encryption migration guide.")]
     public class TripleDesMessageInterceptorConfiguration
     {
         /// <summary>

--- a/docs/superpowers/plans/2026-07-06-aes-message-interceptor.md
+++ b/docs/superpowers/plans/2026-07-06-aes-message-interceptor.md
@@ -114,7 +114,8 @@ namespace DotNetWorkQueue.Tests.Interceptors
             var key = NewKey();
             var enc = New(key).MessageToBytes(Encoding.UTF8.GetBytes("secret"), null).Output;
             enc[^1] ^= 0xFF; // flip last ciphertext byte
-            Assert.ThrowsExactly<CryptographicException>(() => New(key).BytesToMessage(enc, null));
+            // AesGcm throws AuthenticationTagMismatchException : CryptographicException -> use Throws<> (T-or-derived)
+            Assert.Throws<CryptographicException>(() => New(key).BytesToMessage(enc, null));
         }
 
         [TestMethod]
@@ -130,7 +131,7 @@ namespace DotNetWorkQueue.Tests.Interceptors
         public void WrongKey_Throws()
         {
             var enc = New(NewKey()).MessageToBytes(Encoding.UTF8.GetBytes("secret"), null).Output;
-            Assert.ThrowsExactly<CryptographicException>(() => New(NewKey()).BytesToMessage(enc, null));
+            Assert.Throws<CryptographicException>(() => New(NewKey()).BytesToMessage(enc, null));
         }
 
         [TestMethod]

--- a/docs/superpowers/plans/2026-07-06-aes-message-interceptor.md
+++ b/docs/superpowers/plans/2026-07-06-aes-message-interceptor.md
@@ -31,7 +31,8 @@ Design spec: `docs/superpowers/specs/2026-07-06-aes-message-interceptor-design.m
 - **Modify** `Source/DotNetWorkQueue.Dashboard.Api/Configuration/InterceptorConfigurationBuilder.cs` — AES branch; `#pragma` around 3DES branch.
 - **Modify** `Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/InterceptorConfigurationBuilderTests.cs` and `DashboardInterceptorOptionsTests.cs` — AES coverage.
 - **Create** an AES round-trip integration test under `Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/`.
-- **Modify** docs: `docker/dashboard/appsettings.example.json`, `docker/dashboard/README.md`, `docker/dashboard/DOCKERHUB.md`, `Changelog.md`, `Source/Directory.Build.props` (version bump). Wiki (separate) at release time.
+- **Modify** docs: `docker/dashboard/appsettings.example.json`, `docker/dashboard/README.md`, `docker/dashboard/DOCKERHUB.md`, `Changelog.md`, `Source/Directory.Build.props` (version bump).
+- **Modify** wiki — separate local repo at `/mnt/f/git/DotNetWorkQueue.wiki` (its own git repo/commit): the encryption/interceptor page — document AES, key generation, migration guide (producer AES / consumer AES+3DES), 3DES deprecation + removal timeline.
 
 ---
 
@@ -589,6 +590,10 @@ In `Changelog.md`, add a concise entry: `Added AesMessageInterceptor (AES-256-GC
 
 In `Source/Directory.Build.props`, bump `<Version>` (e.g. `0.9.42` → `0.9.43`).
 
+- [ ] **Step 4b: Update the wiki (separate repo)**
+
+In `/mnt/f/git/DotNetWorkQueue.wiki` (its own git repo), update the encryption/interceptor page: document `AesMessageInterceptor` (AES-256-GCM, 32-byte key generation, no IV), the migration guide (producer registers AES; consumer registers AES + 3DES; drain then drop 3DES), and mark 3DES deprecated with the removal timeline (link the removal issue from Task 8). Commit in that repo (`git -C /mnt/f/git/DotNetWorkQueue.wiki commit`). Do not push until the feature is released.
+
 - [ ] **Step 5: Verify the no-tests solution builds in Release**
 
 Run: `dotnet build "Source/DotNetWorkQueueNoTests.sln" -c Release -p:CI=true`
@@ -616,7 +621,11 @@ gh pr create --title "Add AES-256-GCM message interceptor; deprecate TripleDES" 
 
 Create a GitHub issue in `blehnen/DotNetWorkQueue.Samples` titled "Update samples to use AesMessageInterceptor (after release)", noting it depends on the published NuGet package and should replace 3DES usages with AES. Link it from the PR body.
 
-- [ ] **Step 3: Watch checks; address CodeRabbit/SonarCloud/Jenkins as they report.**
+- [ ] **Step 3: Create the 3DES removal tracking issue**
+
+Create a GitHub issue in `blehnen/DotNetWorkQueue` titled "Remove deprecated TripleDesMessageInterceptor", targeting the **next major release (1.0.0), ~early 2027**. Body: 3DES was deprecated when AES-256-GCM landed (link this PR); removal is breaking (public API) so it ships in the next major; migration = switch producers to AES and drain 3DES-encrypted messages first. Cross-link the wiki migration guide. Reference this issue number from the wiki page (Task 7 Step 4b).
+
+- [ ] **Step 4: Watch checks; address CodeRabbit/SonarCloud/Jenkins as they report.**
 
 ---
 

--- a/docs/superpowers/plans/2026-07-06-aes-message-interceptor.md
+++ b/docs/superpowers/plans/2026-07-06-aes-message-interceptor.md
@@ -1,0 +1,637 @@
+# AES-256-GCM Message Interceptor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `AesMessageInterceptor` (AES-256-GCM authenticated encryption) as the recommended built-in encryption interceptor and deprecate `TripleDesMessageInterceptor`.
+
+**Architecture:** New `IMessageInterceptor` implementation mirroring `GZipMessageInterceptor`/`TripleDesMessageInterceptor`. Envelope `[version(1)=0x01][nonce(12)][tag(16)][ciphertext]`, version byte authenticated as AES-GCM associated data, fresh CSPRNG nonce per message. 3DES retained + `[Obsolete]` for backward-compat (existing 3DES messages decrypt via the message graph). Dashboard gains an AES option so it can decrypt AES messages for display.
+
+**Tech Stack:** C# / .NET 10 + .NET 8, `System.Security.Cryptography.AesGcm`, MSTest, NSubstitute, SimpleInjector.
+
+Design spec: `docs/superpowers/specs/2026-07-06-aes-message-interceptor-design.md`.
+
+## Global Constraints
+
+- Targets `net10.0` and `net8.0`. `AesGcm` is available on both.
+- LGPL-2.1 license header on every new source file (copy from any existing file in the same folder, e.g. `Interceptors/GZipMessageInterceptor.cs`).
+- Release build enables `TreatWarningsAsErrors` — `[Obsolete]` references in **non-test** code (core lib, dashboard) become CS0618 errors and MUST be `#pragma`-suppressed with justification.
+- AES-256 only: key is exactly 32 bytes. Nonce 12 bytes, tag 16 bytes.
+- Nonce source MUST be `System.Security.Cryptography.RandomNumberGenerator` (CSPRNG), never `System.Random`.
+- Follow existing interceptor conventions: `Guard.NotNull` for arg checks, `DisplayName`, `BaseType => GetType()`, config class in the same file as the interceptor.
+- Work on branch `aes-message-interceptor` (already created; spec already committed there). Regular (non-draft) PR at the end.
+
+## File Structure
+
+- **Create** `Source/DotNetWorkQueue/Interceptors/AesMessageInterceptor.cs` — `AesMessageInterceptor` + `AesMessageInterceptorConfiguration`.
+- **Create** `Source/DotNetWorkQueue.Tests/Interceptors/AesMessageInterceptorTests.cs` — unit tests.
+- **Modify** `Source/DotNetWorkQueue/Interceptors/TripleDesMessageInterceptor.cs` — `[Obsolete]` on both types.
+- **Modify** `Source/DotNetWorkQueue/IMessageInterceptor.cs` — add `<seealso cref="AesMessageInterceptor"/>`.
+- **Modify** `Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs` — `#pragma` around the 3DES usage; add AES/3DES coexistence test.
+- **Modify** `Source/DotNetWorkQueue.Dashboard.Api/Configuration/DashboardInterceptorOptions.cs` — add `Aes` property + `AesInterceptorOptions`.
+- **Modify** `Source/DotNetWorkQueue.Dashboard.Api/Configuration/InterceptorConfigurationBuilder.cs` — AES branch; `#pragma` around 3DES branch.
+- **Modify** `Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/InterceptorConfigurationBuilderTests.cs` and `DashboardInterceptorOptionsTests.cs` — AES coverage.
+- **Create** an AES round-trip integration test under `Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/`.
+- **Modify** docs: `docker/dashboard/appsettings.example.json`, `docker/dashboard/README.md`, `docker/dashboard/DOCKERHUB.md`, `Changelog.md`, `Source/Directory.Build.props` (version bump). Wiki (separate) at release time.
+
+---
+
+### Task 1: AesMessageInterceptor + configuration (core crypto)
+
+**Files:**
+- Create: `Source/DotNetWorkQueue/Interceptors/AesMessageInterceptor.cs`
+- Test: `Source/DotNetWorkQueue.Tests/Interceptors/AesMessageInterceptorTests.cs`
+
+**Interfaces:**
+- Consumes: `IMessageInterceptor`, `MessageInterceptorResult` (from `Source/DotNetWorkQueue/IMessageInterceptor.cs`); `DotNetWorkQueueException` (`DotNetWorkQueue.Exceptions`); `Guard` (`DotNetWorkQueue.Validation`).
+- Produces:
+  - `AesMessageInterceptorConfiguration(byte[] key)` — `Key` (32 bytes; throws `ArgumentException` otherwise).
+  - `AesMessageInterceptor(AesMessageInterceptorConfiguration configuration)` — `MessageToBytes(byte[], IReadOnlyDictionary<string,object>) : MessageInterceptorResult`, `BytesToMessage(byte[], IReadOnlyDictionary<string,object>) : byte[]`, `DisplayName`, `BaseType`.
+  - Envelope: `[0x01][nonce 12][tag 16][ciphertext]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Source/DotNetWorkQueue.Tests/Interceptors/AesMessageInterceptorTests.cs` (LGPL header + this body):
+
+```csharp
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Interceptors;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Tests.Interceptors
+{
+    [TestClass]
+    public class AesMessageInterceptorTests
+    {
+        private static byte[] NewKey() { var k = new byte[32]; RandomNumberGenerator.Fill(k); return k; }
+        private static AesMessageInterceptor New(byte[] key) => new(new AesMessageInterceptorConfiguration(key));
+
+        [TestMethod]
+        public void Config_RejectsNon32ByteKey()
+        {
+            Assert.ThrowsExactly<ArgumentException>(() => new AesMessageInterceptorConfiguration(new byte[16]));
+        }
+
+        [TestMethod]
+        public void RoundTrip_ReturnsOriginal()
+        {
+            var key = NewKey();
+            var interceptor = New(key);
+            foreach (var size in new[] { 0, 1, 150, 100_000 })
+            {
+                var original = new byte[size];
+                RandomNumberGenerator.Fill(original);
+                var encrypted = interceptor.MessageToBytes(original, null);
+                Assert.IsTrue(encrypted.AddToGraph);
+                var decrypted = New(key).BytesToMessage(encrypted.Output, null);
+                CollectionAssert.AreEqual(original, decrypted);
+            }
+        }
+
+        [TestMethod]
+        public void Envelope_HasVersionNonceTagHeader()
+        {
+            var enc = New(NewKey()).MessageToBytes(Encoding.UTF8.GetBytes("hello"), null);
+            Assert.AreEqual((byte)0x01, enc.Output[0]);
+            Assert.AreEqual(1 + 12 + 16 + "hello"u8.Length, enc.Output.Length);
+        }
+
+        [TestMethod]
+        public void SamePlaintext_ProducesDifferentCiphertext()
+        {
+            var interceptor = New(NewKey());
+            var body = Encoding.UTF8.GetBytes("same message");
+            var a = interceptor.MessageToBytes(body, null).Output;
+            var b = interceptor.MessageToBytes(body, null).Output;
+            CollectionAssert.AreNotEqual(a, b); // random nonce
+        }
+
+        [TestMethod]
+        public void TamperedCiphertext_Throws()
+        {
+            var key = NewKey();
+            var enc = New(key).MessageToBytes(Encoding.UTF8.GetBytes("secret"), null).Output;
+            enc[^1] ^= 0xFF; // flip last ciphertext byte
+            Assert.ThrowsExactly<CryptographicException>(() => New(key).BytesToMessage(enc, null));
+        }
+
+        [TestMethod]
+        public void TamperedVersionByte_Throws()
+        {
+            var key = NewKey();
+            var enc = New(key).MessageToBytes(Encoding.UTF8.GetBytes("secret"), null).Output;
+            enc[0] = 0x02; // unknown version -> rejected before decrypt
+            Assert.ThrowsExactly<DotNetWorkQueueException>(() => New(key).BytesToMessage(enc, null));
+        }
+
+        [TestMethod]
+        public void WrongKey_Throws()
+        {
+            var enc = New(NewKey()).MessageToBytes(Encoding.UTF8.GetBytes("secret"), null).Output;
+            Assert.ThrowsExactly<CryptographicException>(() => New(NewKey()).BytesToMessage(enc, null));
+        }
+
+        [TestMethod]
+        public void ShortInput_Throws()
+        {
+            Assert.ThrowsExactly<DotNetWorkQueueException>(() => New(NewKey()).BytesToMessage(new byte[5], null));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test "Source/DotNetWorkQueue.Tests/DotNetWorkQueue.Tests.csproj" --filter "FullyQualifiedName~AesMessageInterceptorTests"`
+Expected: FAIL — `AesMessageInterceptor` / `AesMessageInterceptorConfiguration` do not exist (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Source/DotNetWorkQueue/Interceptors/AesMessageInterceptor.cs` (LGPL header + this body):
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Interceptors
+{
+    /// <summary>
+    /// Encrypts/decrypts a byte array using AES-256-GCM (authenticated encryption).
+    /// Envelope: [version(1)=0x01][nonce(12)][tag(16)][ciphertext]. The version byte is
+    /// authenticated as associated data, so it cannot be altered without failing the tag.
+    /// </summary>
+    /// <seealso cref="GZipMessageInterceptor"/>
+    public class AesMessageInterceptor : IMessageInterceptor
+    {
+        private const byte Version = 0x01;
+        private const int NonceSizeBytes = 12;
+        private const int TagSizeBytes = 16;
+        private const int HeaderSize = 1 + NonceSizeBytes + TagSizeBytes;
+
+        private readonly AesMessageInterceptorConfiguration _configuration;
+
+        /// <summary>Initializes a new instance of the <see cref="AesMessageInterceptor"/> class.</summary>
+        public AesMessageInterceptor(AesMessageInterceptorConfiguration configuration)
+        {
+            Guard.NotNull(() => configuration, configuration);
+            _configuration = configuration;
+            DisplayName = "AES";
+        }
+
+        /// <inheritdoc />
+        public MessageInterceptorResult MessageToBytes(byte[] input, IReadOnlyDictionary<string, object> headers)
+        {
+            Guard.NotNull(() => input, input);
+
+            var nonce = new byte[NonceSizeBytes];
+            RandomNumberGenerator.Fill(nonce); // CSPRNG, not System.Random
+
+            var tag = new byte[TagSizeBytes];
+            var ciphertext = new byte[input.Length];
+            var associatedData = new[] { Version };
+
+            using (var aes = new AesGcm(_configuration.Key, TagSizeBytes))
+            {
+                aes.Encrypt(nonce, input, ciphertext, tag, associatedData);
+            }
+
+            var output = new byte[HeaderSize + ciphertext.Length];
+            output[0] = Version;
+            Buffer.BlockCopy(nonce, 0, output, 1, NonceSizeBytes);
+            Buffer.BlockCopy(tag, 0, output, 1 + NonceSizeBytes, TagSizeBytes);
+            Buffer.BlockCopy(ciphertext, 0, output, HeaderSize, ciphertext.Length);
+
+            return new MessageInterceptorResult(output, true, GetType());
+        }
+
+        /// <inheritdoc />
+        public byte[] BytesToMessage(byte[] input, IReadOnlyDictionary<string, object> headers)
+        {
+            Guard.NotNull(() => input, input);
+            if (input.Length < HeaderSize)
+                throw new DotNetWorkQueueException("AES envelope is too short to contain the version, nonce, and tag.");
+            if (input[0] != Version)
+                throw new DotNetWorkQueueException($"Unsupported AES envelope version 0x{input[0]:X2}; expected 0x{Version:X2}.");
+
+            var nonce = new byte[NonceSizeBytes];
+            var tag = new byte[TagSizeBytes];
+            var ciphertext = new byte[input.Length - HeaderSize];
+            Buffer.BlockCopy(input, 1, nonce, 0, NonceSizeBytes);
+            Buffer.BlockCopy(input, 1 + NonceSizeBytes, tag, 0, TagSizeBytes);
+            Buffer.BlockCopy(input, HeaderSize, ciphertext, 0, ciphertext.Length);
+
+            var plaintext = new byte[ciphertext.Length];
+            var associatedData = new[] { Version };
+            using (var aes = new AesGcm(_configuration.Key, TagSizeBytes))
+            {
+                aes.Decrypt(nonce, ciphertext, tag, plaintext, associatedData);
+            }
+            return plaintext;
+        }
+
+        /// <inheritdoc />
+        public string DisplayName { get; }
+
+        /// <inheritdoc />
+        public Type BaseType => GetType();
+    }
+
+    /// <summary>
+    /// Configuration for <see cref="AesMessageInterceptor"/>. AES-256 requires a 32-byte key.
+    /// The nonce is generated per message and is not part of this configuration.
+    /// </summary>
+    public class AesMessageInterceptorConfiguration
+    {
+        private const int KeySizeBytes = 32;
+
+        /// <summary>Initializes a new instance of the <see cref="AesMessageInterceptorConfiguration"/> class.</summary>
+        /// <param name="key">The AES-256 key; must be exactly 32 bytes.</param>
+        public AesMessageInterceptorConfiguration(byte[] key)
+        {
+            Guard.NotNull(() => key, key);
+            if (key.Length != KeySizeBytes)
+                throw new ArgumentException($"AES-256 requires a {KeySizeBytes}-byte key; received {key.Length}.", nameof(key));
+            Key = key;
+        }
+
+        /// <summary>Gets the AES-256 key (32 bytes).</summary>
+        public byte[] Key { get; }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test "Source/DotNetWorkQueue.Tests/DotNetWorkQueue.Tests.csproj" --filter "FullyQualifiedName~AesMessageInterceptorTests"`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Verify Release build (warnings-as-errors) is clean**
+
+Run: `dotnet build "Source/DotNetWorkQueue/DotNetWorkQueue.csproj" -c Release`
+Expected: `0 Warning(s), 0 Error(s)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Source/DotNetWorkQueue/Interceptors/AesMessageInterceptor.cs Source/DotNetWorkQueue.Tests/Interceptors/AesMessageInterceptorTests.cs
+git commit -m "feat: add AesMessageInterceptor (AES-256-GCM)"
+```
+
+---
+
+### Task 2: Deprecate TripleDesMessageInterceptor
+
+**Files:**
+- Modify: `Source/DotNetWorkQueue/Interceptors/TripleDesMessageInterceptor.cs`
+- Modify: `Source/DotNetWorkQueue/IMessageInterceptor.cs`
+- Modify: `Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs`
+
+**Interfaces:**
+- Produces: `TripleDesMessageInterceptor` and `TripleDesMessageInterceptorConfiguration` become `[Obsolete]` (warning). No signature changes.
+
+- [ ] **Step 1: Add `[Obsolete]` to both 3DES types**
+
+In `TripleDesMessageInterceptor.cs`, add `using System.Diagnostics.CodeAnalysis;` is not needed; add the attribute directly above `public class TripleDesMessageInterceptor` and above `public class TripleDesMessageInterceptorConfiguration`:
+
+```csharp
+[Obsolete("TripleDES is deprecated (NIST SP 800-131A) and vulnerable to Sweet32. Use AesMessageInterceptor (AES-256-GCM). This type is retained so existing 3DES-encrypted messages remain decryptable and will be removed in a future major version. See the encryption migration guide.")]
+```
+
+- [ ] **Step 2: Add AES seealso to the interface docs**
+
+In `Source/DotNetWorkQueue/IMessageInterceptor.cs`, in the `IMessageInterceptor` XML doc block, add below the existing `<seealso cref="TripleDesMessageInterceptor"/>`:
+
+```csharp
+    /// <seealso cref="AesMessageInterceptor"/>
+```
+(cref to an obsolete type does not produce CS0618, so no suppression needed here.)
+
+- [ ] **Step 3: Suppress CS0618 at the existing 3DES unit-test usage**
+
+In `Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs`, wrap the `new TripleDesMessageInterceptor(...)` construction (inside `Interceptor_Multiple_Interceptors`) so the test still exercises the deprecated path:
+
+```csharp
+#pragma warning disable CS0618 // deliberately testing the deprecated 3DES interceptor
+                new TripleDesMessageInterceptor(
+                    new TripleDesMessageInterceptorConfiguration(
+                        Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                        Convert.FromBase64String("aaaaaaaaaaa=")))
+#pragma warning restore CS0618
+```
+
+- [ ] **Step 4: Verify Release build of core is clean**
+
+Run: `dotnet build "Source/DotNetWorkQueue/DotNetWorkQueue.csproj" -c Release`
+Expected: `0 Warning(s), 0 Error(s)` (the `[Obsolete]` type is defined here but no non-suppressed reference remains in the core project).
+
+- [ ] **Step 5: Run the interceptor unit tests**
+
+Run: `dotnet test "Source/DotNetWorkQueue.Tests/DotNetWorkQueue.Tests.csproj" --filter "FullyQualifiedName~Interceptors"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Source/DotNetWorkQueue/Interceptors/TripleDesMessageInterceptor.cs Source/DotNetWorkQueue/IMessageInterceptor.cs Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs
+git commit -m "feat: deprecate TripleDesMessageInterceptor in favor of AES"
+```
+
+---
+
+### Task 3: Coexistence / backward-compat test
+
+Proves the migration model: a 3DES-encrypted message decrypts when 3DES is in the consumer's pool, and AES round-trips — the graph selects the right decryptor.
+
+**Files:**
+- Modify: `Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs`
+
+**Interfaces:**
+- Consumes: `MessageInterceptors`, `InterceptorFactory`, `IContainerFactory` (as used elsewhere in this test file).
+
+- [ ] **Step 1: Write the failing coexistence test**
+
+Add to `InterceptionTest.cs` (uses the same `Substitute.For<IContainerFactory>()` pattern already in the file):
+
+```csharp
+[TestMethod]
+public void Coexistence_ConsumerPoolDecryptsBoth()
+{
+    var aesKey = new byte[32];
+    System.Security.Cryptography.RandomNumberGenerator.Fill(aesKey);
+    var aesCfg = new AesMessageInterceptorConfiguration(aesKey);
+
+#pragma warning disable CS0618 // migration scenario: legacy 3DES stays in the consumer pool
+    var tdesCfg = new TripleDesMessageInterceptorConfiguration(
+        Convert.FromBase64String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        Convert.FromBase64String("aaaaaaaaaaa="));
+
+    // Producer registers AES only
+    var producer = new MessageInterceptors(
+        new List<IMessageInterceptor> { new AesMessageInterceptor(aesCfg) },
+        new InterceptorFactory(Substitute.For<IContainerFactory>()));
+
+    // A legacy producer that used 3DES only
+    var legacyProducer = new MessageInterceptors(
+        new List<IMessageInterceptor> { new TripleDesMessageInterceptor(tdesCfg) },
+        new InterceptorFactory(Substitute.For<IContainerFactory>()));
+
+    // Consumer registers BOTH — the pool of decryptors
+    var consumer = new MessageInterceptors(
+        new List<IMessageInterceptor> { new AesMessageInterceptor(aesCfg), new TripleDesMessageInterceptor(tdesCfg) },
+        new InterceptorFactory(Substitute.For<IContainerFactory>()));
+#pragma warning restore CS0618
+
+    var body = Encoding.UTF8.GetBytes("coexistence body");
+
+    var aesMsg = producer.MessageToBytes(body, null);
+    CollectionAssert.AreEqual(body, consumer.BytesToMessage(aesMsg.Output, aesMsg.Graph, null));
+
+    var tdesMsg = legacyProducer.MessageToBytes(body, null);
+    CollectionAssert.AreEqual(body, consumer.BytesToMessage(tdesMsg.Output, tdesMsg.Graph, null));
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `dotnet test "Source/DotNetWorkQueue.Tests/DotNetWorkQueue.Tests.csproj" --filter "FullyQualifiedName~Coexistence_ConsumerPoolDecryptsBoth"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Source/DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs
+git commit -m "test: AES/3DES consumer-pool coexistence"
+```
+
+---
+
+### Task 4: Dashboard AES options
+
+**Files:**
+- Modify: `Source/DotNetWorkQueue.Dashboard.Api/Configuration/DashboardInterceptorOptions.cs`
+- Modify: `Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardInterceptorOptionsTests.cs`
+
+**Interfaces:**
+- Produces: `DashboardInterceptorOptions.Aes : AesInterceptorOptions`; `AesInterceptorOptions { bool Enabled = true; string Key; }` (Key is Base64, no IV).
+
+- [ ] **Step 1: Add the AES option to the options model**
+
+In `DashboardInterceptorOptions.cs`, add a property to `DashboardInterceptorOptions`:
+
+```csharp
+        /// <summary>
+        /// Gets or sets AES-256-GCM encryption interceptor options.
+        /// Set to null (or omit from JSON) to disable.
+        /// </summary>
+        public AesInterceptorOptions Aes { get; set; }
+```
+
+and a new class in the same file:
+
+```csharp
+    /// <summary>
+    /// JSON-bindable options for the AES-256-GCM message interceptor.
+    /// </summary>
+    public class AesInterceptorOptions
+    {
+        /// <summary>Gets or sets whether AES encryption is enabled. Default is true.</summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>Gets or sets the AES-256 key as a Base64-encoded string (32 bytes when decoded).</summary>
+        public string Key { get; set; }
+    }
+```
+
+- [ ] **Step 2: Add/adjust a binding test**
+
+Open `DashboardInterceptorOptionsTests.cs`, find the existing test that binds/round-trips `TripleDes` options, and add an analogous assertion for `Aes` (Enabled default true; Key round-trips). Mirror the existing test's style exactly. Run:
+
+`dotnet test "Source/DotNetWorkQueue.Dashboard.Api.Tests/DotNetWorkQueue.Dashboard.Api.Tests.csproj" --filter "FullyQualifiedName~DashboardInterceptorOptionsTests"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Source/DotNetWorkQueue.Dashboard.Api/Configuration/DashboardInterceptorOptions.cs Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardInterceptorOptionsTests.cs
+git commit -m "feat(dashboard): add AES interceptor options"
+```
+
+---
+
+### Task 5: Dashboard builder AES branch + 3DES CS0618 suppression
+
+**Files:**
+- Modify: `Source/DotNetWorkQueue.Dashboard.Api/Configuration/InterceptorConfigurationBuilder.cs`
+- Modify: `Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/InterceptorConfigurationBuilderTests.cs`
+
+**Interfaces:**
+- Consumes: `AesMessageInterceptor`, `AesMessageInterceptorConfiguration` (Task 1); `AesInterceptorOptions` (Task 4).
+
+- [ ] **Step 1: Write a failing builder test for AES**
+
+In `InterceptorConfigurationBuilderTests.cs`, mirror the existing TripleDes test: build options with `Aes = new AesInterceptorOptions { Enabled = true, Key = Convert.ToBase64String(new byte[32]) }`, run the builder, and assert the returned registration action adds `typeof(AesMessageInterceptor)` and registers `AesMessageInterceptorConfiguration`. Also add a test that an AES key that is not 32 bytes when decoded throws `InvalidOperationException`. (Follow the exact assertion style already used for TripleDes in this file.)
+
+Run: `dotnet test "Source/DotNetWorkQueue.Dashboard.Api.Tests/DotNetWorkQueue.Dashboard.Api.Tests.csproj" --filter "FullyQualifiedName~InterceptorConfigurationBuilderTests"`
+Expected: FAIL (AES not handled yet).
+
+- [ ] **Step 2: Add the AES branch and suppress CS0618 on the 3DES branch**
+
+In `InterceptorConfigurationBuilder.cs`:
+- Add near the other flags: `var enableAes = interceptorOptions.Aes is { Enabled: true };`
+- Update the early return: `if (!enableGZip && !enableTripleDes && !enableAes) return null;`
+- Add validation for AES (Key present + decodes to 32 bytes), mirroring the TripleDes validation block:
+
+```csharp
+            if (enableAes)
+            {
+                if (string.IsNullOrEmpty(interceptorOptions.Aes.Key))
+                    throw new InvalidOperationException("Aes interceptor requires a Key (Base64-encoded).");
+                if (Convert.FromBase64String(interceptorOptions.Aes.Key).Length != 32)
+                    throw new InvalidOperationException("Aes interceptor Key must decode to 32 bytes (AES-256).");
+            }
+```
+- Capture `var aesOptions = interceptorOptions.Aes;` alongside the other captures.
+- Inside the returned `container => { ... }`, add:
+
+```csharp
+                if (enableAes)
+                {
+                    types.Add(typeof(AesMessageInterceptor));
+                    container.Register(() =>
+                        new AesMessageInterceptorConfiguration(Convert.FromBase64String(aesOptions.Key)),
+                        LifeStyles.Singleton);
+                }
+```
+- Wrap the existing `enableTripleDes` branch (both the validation block and the registration block) in:
+
+```csharp
+#pragma warning disable CS0618 // 3DES retained for decrypting legacy messages; deprecated
+                ... existing TripleDes code ...
+#pragma warning restore CS0618
+```
+
+- [ ] **Step 3: Run the builder tests**
+
+Run: `dotnet test "Source/DotNetWorkQueue.Dashboard.Api.Tests/DotNetWorkQueue.Dashboard.Api.Tests.csproj" --filter "FullyQualifiedName~InterceptorConfigurationBuilderTests"`
+Expected: PASS.
+
+- [ ] **Step 4: Verify Dashboard.Api Release build is clean**
+
+Run: `dotnet build "Source/DotNetWorkQueue.Dashboard.Api/DotNetWorkQueue.Dashboard.Api.csproj" -c Release`
+Expected: `0 Warning(s), 0 Error(s)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Source/DotNetWorkQueue.Dashboard.Api/Configuration/InterceptorConfigurationBuilder.cs Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/InterceptorConfigurationBuilderTests.cs
+git commit -m "feat(dashboard): register AES interceptor; suppress deprecated 3DES warning"
+```
+
+---
+
+### Task 6: End-to-end integration test (Memory transport)
+
+Proves AES works through a real send/receive and the graph re-creation. Encryption is transport-agnostic, so ONE transport (Memory, no external deps) is sufficient.
+
+**Files:**
+- Create: `Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Interceptors/AesInterceptorRoundTrip.cs`
+
+**Interfaces:**
+- Consumes: the Memory integration test harness. Follow the interceptor-registration pattern in `Source/DotNetWorkQueue.IntegrationTests.Shared/SharedSetup.cs` (search for `TripleDesMessageInterceptorConfiguration`) — it registers the interceptor Configuration in the container and adds the interceptor type to the `IMessageInterceptor` collection at queue creation.
+
+- [ ] **Step 1: Write the test**
+
+Create the test mirroring an existing Memory producer→consumer integration test (e.g. `Producer/SimpleProducer.cs` for structure), but configure the queue creation to register `AesMessageInterceptor` + `AesMessageInterceptorConfiguration(new byte[32] filled by RandomNumberGenerator)` using the same `SharedSetup` registration idiom used for 3DES. Send a POCO message on a Memory queue, consume it, and assert the received body equals what was produced (proving encrypt-on-send / decrypt-on-receive through the graph). Use a 32-byte key.
+
+Concretely: copy the closest existing interceptor-enabled Memory integration test, swap the 3DES registration lines (`new TripleDesMessageInterceptorConfiguration(key, iv)` + `typeof(TripleDesMessageInterceptor)`) for the AES equivalents (`new AesMessageInterceptorConfiguration(key)` + `typeof(AesMessageInterceptor)`), and drop the IV.
+
+- [ ] **Step 2: Run it**
+
+Run: `dotnet test "Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/DotNetWorkQueue.Transport.Memory.Integration.Tests.csproj" --filter "FullyQualifiedName~AesInterceptorRoundTrip"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Interceptors/AesInterceptorRoundTrip.cs
+git commit -m "test: AES interceptor end-to-end on the Memory transport"
+```
+
+---
+
+### Task 7: Documentation, dashboard config example, changelog, version bump
+
+**Files:**
+- Modify: `docker/dashboard/appsettings.example.json`
+- Modify: `docker/dashboard/README.md`, `docker/dashboard/DOCKERHUB.md`
+- Modify: `Changelog.md`
+- Modify: `Source/Directory.Build.props`
+
+- [ ] **Step 1: Add an AES block to the dashboard appsettings example**
+
+In `docker/dashboard/appsettings.example.json`, next to the existing interceptor config, add an `Aes` block with `Enabled` + a Base64 `Key` placeholder (a 32-byte example, clearly a placeholder), and add a comment/label marking the `TripleDes` block as legacy/deprecated. Keep it valid JSON.
+
+- [ ] **Step 2: Update dashboard docs**
+
+In `docker/dashboard/README.md` and `DOCKERHUB.md`, document the `Aes` interceptor option (Key only, no IV) as the recommended encryption and mark `TripleDes` as deprecated.
+
+- [ ] **Step 3: Changelog entry (concise)**
+
+In `Changelog.md`, add a concise entry: `Added AesMessageInterceptor (AES-256-GCM); deprecated TripleDesMessageInterceptor (removed in a future major).`
+
+- [ ] **Step 4: Bump the version**
+
+In `Source/Directory.Build.props`, bump `<Version>` (e.g. `0.9.42` → `0.9.43`).
+
+- [ ] **Step 5: Verify the no-tests solution builds in Release**
+
+Run: `dotnet build "Source/DotNetWorkQueueNoTests.sln" -c Release -p:CI=true`
+Expected: `0 Error(s)` (warnings only if pre-existing/unrelated).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker/dashboard/appsettings.example.json docker/dashboard/README.md docker/dashboard/DOCKERHUB.md Changelog.md Source/Directory.Build.props
+git commit -m "docs: document AES interceptor; changelog + version bump"
+```
+
+---
+
+### Task 8: Open PR + create the samples-tracking issue
+
+- [ ] **Step 1: Push and open a regular (non-draft) PR**
+
+```bash
+git push -u origin aes-message-interceptor
+gh pr create --title "Add AES-256-GCM message interceptor; deprecate TripleDES" --body "<summary from the spec: what/why, migration (producer AES / consumer AES+3DES), deprecation + planned removal, test coverage>"
+```
+
+- [ ] **Step 2: Create the samples follow-up issue (now that the feature is in flight)**
+
+Create a GitHub issue in `blehnen/DotNetWorkQueue.Samples` titled "Update samples to use AesMessageInterceptor (after release)", noting it depends on the published NuGet package and should replace 3DES usages with AES. Link it from the PR body.
+
+- [ ] **Step 3: Watch checks; address CodeRabbit/SonarCloud/Jenkins as they report.**
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- AES interceptor + config → Task 1. Envelope/AAD/CSPRNG/32-byte key → Task 1 code + tests.
+- 3DES `[Obsolete]` + CS0618 sites (core/test) → Task 2; dashboard site → Task 5.
+- Backward-compat/coexistence (producer/consumer + graph) → Task 3.
+- Dashboard options + builder → Tasks 4-5.
+- Integration test (Memory only) → Task 6.
+- Wiki/dashboard docs/changelog/version bump → Task 7 (wiki itself is a separate repo, updated at release — noted, not a repo task here).
+- Samples follow-up issue → Task 8 Step 2. Planned 3DES removal → tracked via the deprecation message + future major (out of scope here).
+
+**Placeholder scan:** Tasks 4/5/6 reference "mirror the existing test" against **named existing files** with the exact 3DES→AES substitution spelled out — concrete references, not TBDs. Task 1 (the crypto risk area) has complete code. No unresolved placeholders.
+
+**Type consistency:** `AesMessageInterceptor` / `AesMessageInterceptorConfiguration(byte[] key)` / `Key` / `MessageToBytes` / `BytesToMessage` / `AesInterceptorOptions { Enabled, Key }` are used consistently across Tasks 1, 3, 4, 5, 6.
+
+**Note for executor:** the wiki lives outside this repo; do it at release. Confirm the exact interceptor-registration lines in `SharedSetup.cs` before writing Task 6 (the harness is the one area not fully shown here).

--- a/docs/superpowers/specs/2026-07-06-aes-message-interceptor-design.md
+++ b/docs/superpowers/specs/2026-07-06-aes-message-interceptor-design.md
@@ -1,0 +1,179 @@
+# Design: AES-256-GCM Message Interceptor + TripleDES Deprecation
+
+**Date:** 2026-07-06
+**Status:** Approved (design); PR #181 merged to master — ready for implementation planning
+**Driver:** SonarCloud S5547 (weak cipher, TripleDES) + modernize built-in encryption
+
+## Summary
+
+Add `AesMessageInterceptor` (AES-256-GCM authenticated encryption) as the recommended
+built-in encryption interceptor, and deprecate the existing `TripleDesMessageInterceptor`.
+3DES is retained and fully functional so existing 3DES-encrypted messages remain
+decryptable, marked `[Obsolete]`, with a planned removal in a future major version.
+
+This is a **releasable feature** (new public API) → changelog entry + version bump.
+
+## Goals
+
+- Provide a modern, authenticated (AEAD) encryption option out of the box.
+- Fix the concrete weaknesses of the 3DES interceptor: 64-bit block (Sweet32), CBC with
+  **no tamper detection**, and a **static IV** reused across every message.
+- Preserve backward compatibility: 3DES-encrypted messages must keep decrypting.
+- Give users a clear, simple migration path.
+
+## Non-goals (YAGNI)
+
+- **Not** a multi-algorithm crypto engine. The interceptor pattern is the extensibility
+  seam — users needing ChaCha20, envelope encryption, HSM/KMS, etc. write their own
+  interceptor. The base library ships one good encryption option + one compression option.
+- **No key rotation** in v1 (the versioned envelope reserves room to add it later).
+- **No** "3DES auto-detects AES and opts out" magic, and **no** first-class "decrypt-only"
+  registration concept — the producer/consumer config split already provides the coexistence
+  path (see Migration).
+
+## Crypto design
+
+- **Algorithm:** AES-256-GCM via `System.Security.Cryptography.AesGcm` (net8/net10).
+- **Key:** 32 bytes (AES-256 only). `AesMessageInterceptorConfiguration(byte[] key)` validates
+  `key.Length == 32`, else throws. Key lives only in the DI-registered config; never logged,
+  never in the envelope.
+- **Nonce:** fresh 12 bytes per message from
+  `System.Security.Cryptography.RandomNumberGenerator.Fill(nonce)` — the CSPRNG, **not**
+  `System.Random`.
+- **Envelope:** `[version(1)=0x01][nonce(12)][tag(16)][ciphertext(n)]`.
+- **Associated data:** the version byte is passed as AES-GCM AAD, so flipping it fails the
+  auth tag (can't be used to trigger a different unpacker). Message headers are **not** AAD in
+  v1 (keeps it simple; header-binding is a "write your own interceptor" concern).
+- **Nonce-uniqueness limit (documented, not enforced):** random 12-byte nonces are safe to
+  ~2^32 messages under a single key (NIST SP 800-38D). Far beyond typical workloads and
+  strictly better than 3DES's fixed IV; extreme-volume users rotate keys (future format
+  version).
+- **AesGcm usage:** `using var aes = new AesGcm(key, tagSizeInBytes: 16);` then
+  `Encrypt(nonce, input, ciphertext, tag, associatedData)` /
+  `Decrypt(nonce, ciphertext, tag, plaintext, associatedData)`. `AesGcm` is `IDisposable`.
+
+## Components
+
+New files in `Source/DotNetWorkQueue/Interceptors/` (mirroring `GZipMessageInterceptor`):
+
+- **`AesMessageInterceptor : IMessageInterceptor`**
+  - `MessageToBytes`: generate nonce → encrypt → assemble envelope →
+    `new MessageInterceptorResult(envelope, addToGraph: true, GetType())`. Encryption
+    **always** applies (`addToGraph` always `true`, like 3DES; unlike GZip's conditional).
+  - `BytesToMessage`: read+validate version byte (unknown → throw) → slice nonce/tag/ct
+    (guard min length) → decrypt → return plaintext.
+  - `DisplayName = "AES"`, `BaseType => GetType()`.
+- **`AesMessageInterceptorConfiguration`** — ctor `(byte[] key)`, 32-byte validation.
+
+Changed:
+
+- **`TripleDesMessageInterceptor` + `TripleDesMessageInterceptorConfiguration`** →
+  `[Obsolete(...)]` (warning), unchanged behavior.
+- **`IMessageInterceptor`** XML docs → add `<seealso cref="AesMessageInterceptor"/>` (cref to
+  an obsolete type does not warn).
+- **Dashboard** (`DotNetWorkQueue.Dashboard.Api/Configuration/`):
+  - `DashboardInterceptorOptions` → add `Aes` property.
+  - New `AesInterceptorOptions { bool Enabled; string Key; }` — **Key only, no IV** (nicer
+    than 3DES).
+  - `InterceptorConfigurationBuilder` → add `enableAes` branch (validate Base64 key → 32
+    bytes; register `AesMessageInterceptor` + config). Update the early-return guard.
+
+No new framework plumbing: the existing interceptor graph + `InterceptorFactory` re-creation
+handle send/receive.
+
+## Backward compatibility & migration
+
+**Mechanism (verified in code):** on **send**, `MessageInterceptors.MessageToBytes` runs every
+interceptor in the registered collection. On **receive**, `BytesToMessage` reads the message's
+graph and resolves each recorded type via `GetInterceptor(type)` — which checks the registered
+collection first, then **falls back to `InterceptorFactory.Create(type)`** (resolve-by-type
+from DI). So an interceptor can decrypt by type even if it is not in the send chain.
+
+**Tier 1 — drain & swap (documented primary path):** stop producing 3DES, let consumers drain
+the queue, then replace `TripleDesMessageInterceptor` with `AesMessageInterceptor` in the
+registration. Zero framework change. Covers the large majority of real migrations, since queue
+messages are normally consumed within seconds/minutes.
+
+**Tier 2 — coexist (long-lived/durable messages):** interceptors are configured **per queue
+instance**, and producers and consumers are separate queues with separate configs. The
+per-message **graph** drives which interceptors run on the receive side, so:
+- **Producer:** register `[GZip, AES]` (was `[GZip, 3DES]`) — new messages encrypt with AES.
+- **Consumer:** register `[GZip, AES, 3DES]` — the collection is a *pool of decryptors*; each
+  message's graph selects which actually run (new → AES, old → 3DES). The consumer never calls
+  `MessageToBytes` on inbound messages, so **3DES on a consumer only ever decrypts** — it cannot
+  re-encrypt. Drop 3DES from the consumer once the 3DES backlog is drained.
+- Edge case for docs: a single queue that both consumes *and* re-produces to itself with the
+  same config should keep the producer/consumer configs separate.
+
+No "decrypt-only" registration concept is needed — the producer/consumer split + graph-driven
+receive already provide it.
+
+**Dashboard:** display-only and likewise **graph-driven** — it registers both AES and 3DES, and
+each message's graph selects the right decryptor (new → AES, old → 3DES). It never sends, so
+there is no double-encrypt concern; it needs both to render new and legacy message bodies.
+
+## Deprecation mechanics
+
+- `[Obsolete("TripleDES is deprecated (NIST SP 800-131A) and vulnerable to Sweet32; use
+  AesMessageInterceptor (AES-256-GCM). Retained so existing 3DES-encrypted messages remain
+  decryptable. Will be removed in a future major version — see the migration guide.")]` on both
+  3DES types. Severity = warning (not error).
+- **CS0618 reference sites** (kept for back-compat) get scoped `#pragma warning disable/restore
+  CS0618` + justification, so the library's own Release (`TreatWarningsAsErrors`) build stays
+  green:
+  - `Dashboard.Api/Configuration/InterceptorConfigurationBuilder.cs` (keeps 3DES for
+    decrypt-display).
+  - Integration-test shared setup (`IntegrationTests.Shared/...`) — kept to prove the deprecated
+    decrypt path still works.
+  - `DotNetWorkQueue.Tests/Interceptors/InterceptionTest.cs` — deprecated-path unit test.
+- **Planned removal:** future major version + a tracked GitHub issue, linked from the migration
+  guide.
+
+## Error handling
+
+- Decrypt failure (wrong key / tampered ciphertext, tag, nonce, or version) → `AesGcm` throws
+  `CryptographicException`, which propagates into the framework's existing poison-message
+  handling (same path 3DES `TransformFinalBlock` failures take today).
+- Malformed/too-short envelope → clear exception (guarded before slicing).
+- Null input → guarded (as existing interceptors do).
+
+## Testing
+
+- **Unit** (`DotNetWorkQueue.Tests/Interceptors/`, primary crypto coverage):
+  round-trip (empty/small/large), nonce-uniqueness, envelope shape, tamper detection
+  (ciphertext/tag/nonce/version byte each → throws), wrong key → throws, malformed input →
+  throws, key ≠ 32 bytes → config throws, `AddToGraph` always true.
+- **Backward-compat proof:** a 3DES-encrypted message decrypts via the receive-path factory
+  fallback; an AES message round-trips through the registrar (coexistence works).
+- **Integration — deliberately narrow:** encryption is transport-agnostic (byte transform
+  before the transport), so AES gets **one** end-to-end path through the **Memory** transport
+  (local), not fanned across all transports. Existing 3DES integration coverage stays as-is.
+- **Dashboard** (`Dashboard.Api.Tests`): AES coverage for `InterceptorConfigurationBuilder`,
+  mirroring the 3DES tests.
+
+## Docs, samples, release
+
+- **Wiki** (not NuGet-blocked → ships with the feature/release): encryption/interceptor page —
+  document `AesMessageInterceptor` + key-generation guidance, mark 3DES deprecated, add the
+  migration guide (Tier-1 primary, Tier-2 note).
+- **Dashboard config docs:** `docker/dashboard/appsettings.example.json` gets an `Aes` block
+  (`TripleDes` relabeled legacy); `docker/dashboard/README.md` + `DOCKERHUB.md` updated.
+- **Changelog + version bump** (releasable feature).
+- **Samples — separate follow-up, out of this feature's scope:** the
+  [DotNetWorkQueue.Samples](https://github.com/blehnen/DotNetWorkQueue.Samples) repo consumes
+  DotNetWorkQueue via **NuGet**, so it cannot reference `AesMessageInterceptor` until the new
+  version is **published**. Track via a **GitHub issue created once this feature is in flight**
+  (PR open); do the sample updates after release.
+
+## Sequencing
+
+1. **Gate:** no code changes until PR #181 is merged to master (master must be current first).
+2. Implement code + tests + wiki + dashboard docs on a feature branch.
+3. When the feature PR is opened, create the samples-tracking GitHub issue.
+4. Merge → release (changelog + version bump) → update samples against the published package.
+5. Future major: remove 3DES (tracked issue).
+
+## Open items to confirm during implementation
+
+- Exact wiki page(s) for encryption/interceptors.
+- Exact sample files that reference 3DES (for the follow-up issue).


### PR DESCRIPTION
Adds `AesMessageInterceptor` (AES-256-GCM authenticated encryption) as the recommended built-in message encryption and deprecates `TripleDesMessageInterceptor`. Design spec + plan in `docs/superpowers/`.

## Why
The 3DES interceptor has real weaknesses: 64-bit block (**Sweet32**), CBC with **no tamper detection**, and a **static IV** reused across every message. 3DES is retired by NIST SP 800-131A.

## What
- **`AesMessageInterceptor` + `AesMessageInterceptorConfiguration`** — AES-256-GCM (AEAD: confidentiality **and** integrity). Envelope `[version=0x01][nonce 12][tag 16][ciphertext]`; the version byte is authenticated as associated data; a fresh CSPRNG nonce per message (`RandomNumberGenerator`), 32-byte key, no IV to manage.
- **`TripleDesMessageInterceptor` → `[Obsolete]`** (warning), still fully functional so existing 3DES messages keep decrypting; removal tracked for a future major.
- **Dashboard** — new `Aes` interceptor option so it can decrypt AES-encrypted message bodies for display (CS0618 scoped around the retained 3DES branch).
- **Integration matrix swapped to AES** — the shared harness now encrypts with AES across all transports (SqlServer/PostgreSQL/Redis/SQLite/LiteDb/Memory); 3DES stays covered by the unit tests + the heartbeat/job-scheduler helpers.
- Changelog + version bump to **0.9.43**. Wiki (`MessageInterception`) updated separately (published at release).

## Migration (also in the wiki)
Producers register **AES only**; consumers register **AES + 3DES** until the 3DES backlog drains — the per-message interceptor graph selects the right decryptor. A consumer never re-encrypts, so 3DES only ever decrypts.

## Tests (all green locally)
AES unit 8/8 (round-trip, nonce-uniqueness, tamper/version/wrong-key/short-input, key validation); interceptor suite 20/20 (incl. AES/3DES coexistence proof); dashboard options 7/7 + builder 16/16; Memory integration (AES path) 9/9. Release build of `DotNetWorkQueueNoTests.sln` clean under `TreatWarningsAsErrors`.

Follow-ups tracked in separate issues: samples update (after NuGet release) and 3DES removal (next major).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AES-256-GCM message encryption/decryption via a new AES message interceptor with a versioned envelope and random per-message nonces.
  * Dashboard configuration now supports an AES option to decrypt and display AES-encrypted message bodies.

* **Bug Fixes**
  * Strengthened validation of AES keys (must be 32 bytes after Base64 decoding) and encrypted envelopes, with explicit failures for tampering, unsupported versions, wrong keys, and malformed inputs.

* **Chores**
  * Marked the legacy 3DES interceptor as deprecated and expanded tests (including AES/3DES coexistence) plus updated versioning and release documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->