### PR TITLE
test: apply MSTEST0037 fixer (specific Assert methods)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/ConsumersEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/ConsumersEndpointTests.cs
@@ -54,7 +54,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var registration = await response.Content.ReadFromJsonAsync<ConsumerRegistrationResponse>();
             Assert.IsNotNull(registration);
             Assert.AreNotEqual(Guid.Empty, registration!.ConsumerId);
-            Assert.IsTrue(registration.HeartbeatIntervalSeconds > 0);
+            Assert.IsGreaterThan(0, registration.HeartbeatIntervalSeconds);
         }
 
         [TestMethod]
@@ -105,7 +105,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
 
-            Assert.AreEqual(1, consumers.Count);
+            Assert.HasCount(1, consumers);
             var c = consumers![0];
             Assert.AreEqual(250, c.MessagesProcessed);
             Assert.AreEqual(10, c.MessagesErrored);
@@ -178,7 +178,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.AreEqual(0, consumers.Count);
+            Assert.IsEmpty(consumers);
         }
 
         // === List ===
@@ -192,7 +192,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
 
-            Assert.AreEqual(2, consumers.Count);
+            Assert.HasCount(2, consumers);
         }
 
         [TestMethod]
@@ -203,7 +203,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 $"api/v1/dashboard/consumers?queueId={_queueId}");
 
-            Assert.AreEqual(1, consumers.Count);
+            Assert.HasCount(1, consumers);
             Assert.AreEqual(_queueId, consumers![0].MatchedQueueId);
         }
 
@@ -215,7 +215,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 $"api/v1/dashboard/consumers?queueId={Guid.NewGuid()}");
 
-            Assert.AreEqual(0, consumers.Count);
+            Assert.IsEmpty(consumers);
         }
 
         [TestMethod]
@@ -226,7 +226,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
 
-            Assert.AreEqual(1, consumers.Count);
+            Assert.HasCount(1, consumers);
             var c = consumers![0];
             Assert.AreEqual("TESTMACHINE", c.MachineName);
             Assert.AreEqual(9876, c.ProcessId);
@@ -257,7 +257,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var counts = await _server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
 
-            Assert.AreEqual(0, counts.Count);
+            Assert.IsEmpty(counts);
         }
 
         // === Full lifecycle ===
@@ -276,7 +276,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // List — verify metrics are present
             var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.AreEqual(1, consumers.Count);
+            Assert.HasCount(1, consumers);
             Assert.AreEqual(42, consumers![0].MessagesProcessed);
             Assert.AreEqual(3, consumers[0].MessagesErrored);
             Assert.AreEqual(2, consumers[0].MessagesRolledBack);
@@ -295,7 +295,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Verify gone
             consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.AreEqual(0, consumers.Count);
+            Assert.IsEmpty(consumers);
         }
 
         // === Helpers ===

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/CorsIntegrationTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/CorsIntegrationTests.cs
@@ -58,7 +58,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             Assert.IsTrue(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins),
                 "because the CORS middleware should have added the allow-origin header for the matching origin");
-            Assert.IsTrue(origins.Contains("https://example.com"));
+            Assert.Contains("https://example.com", origins);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/DashboardStartupTimingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/DashboardStartupTimingTests.cs
@@ -90,13 +90,13 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
             Assert.IsNotNull(connections);
-            Assert.IsTrue(connections.Count > 0);
+            Assert.IsNotEmpty(connections);
             var connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{connectionId}/queues");
             Assert.IsNotNull(queues);
-            Assert.IsTrue(queues.Count > 0);
+            Assert.IsNotEmpty(queues);
             var queueId = queues[0].Id;
 
             // --- Phase 2: create the queue with history enabled and populate it ---
@@ -145,14 +145,14 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/history?pageSize=100");
             Assert.IsNotNull(history);
-            Assert.IsTrue(history.Items.Count >= MessageCount,
+            Assert.IsGreaterThanOrEqualTo(MessageCount, history.Items.Count,
                 "history reads must survive a stale/default options cache on the dashboard side");
 
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{queueId}/history/count");
             countResponse.EnsureSuccessStatusCode();
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/EdgeCaseTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/EdgeCaseTests.cs
@@ -74,7 +74,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
             Assert.AreEqual(5, paged.TotalCount);
         }
 
@@ -83,7 +83,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=10&pageIndex=99");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
             Assert.AreEqual(5, paged.TotalCount);
         }
 

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/EmptyQueueTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/EmptyQueueTests.cs
@@ -84,7 +84,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
             Assert.AreEqual(0, paged.TotalCount);
         }
     }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbEndpointTests.cs
@@ -62,12 +62,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             _queueId = queues[0].Id;
         }
 
@@ -85,7 +85,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections[0].QueueCount);
         }
 
@@ -94,7 +94,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
@@ -133,7 +133,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -141,7 +141,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            Assert.AreEqual(2, paged.Items.Count);
+            Assert.HasCount(2, paged.Items);
             Assert.AreEqual(5, paged.TotalCount);
         }
 
@@ -150,7 +150,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -261,7 +261,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -269,7 +269,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var jobs = await _server.Client.GetFromJsonAsync<List<JobResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/jobs");
-            Assert.AreEqual(0, jobs.Count);
+            Assert.IsEmpty(jobs);
         }
 
         [TestMethod]
@@ -277,7 +277,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbErrorTests.cs
@@ -88,7 +88,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Error > 0);
+            Assert.IsGreaterThan(0, status.Error);
         }
 
         [TestMethod]
@@ -96,7 +96,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             Assert.IsFalse(string.IsNullOrEmpty(paged.Items[0].LastException));
         }
 
@@ -107,11 +107,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/errors");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted > 0);
+            Assert.IsGreaterThan(0, result.Deleted);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbHistoryTests.cs
@@ -87,7 +87,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -221,8 +221,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
-            Assert.IsTrue(result.Items.Count >= MessageCount);
+            Assert.IsNotEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Items.Count);
         }
 
         [TestMethod]
@@ -232,8 +232,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=0&pageSize=2");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Items.Count);
-            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.HasCount(2, result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.TotalCount);
             Assert.AreEqual(0, result.PageIndex);
             Assert.AreEqual(2, result.PageSize);
         }
@@ -245,7 +245,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=1&pageSize=2");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Items.Count);
+            Assert.HasCount(2, result.Items);
             Assert.AreEqual(1, result.PageIndex);
         }
 
@@ -256,8 +256,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=100&pageSize=25");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
-            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.IsEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.TotalCount);
         }
 
         [TestMethod]
@@ -268,7 +268,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
@@ -280,7 +280,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=3&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -291,7 +291,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=1&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -301,7 +301,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -311,7 +311,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=2");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -329,7 +329,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
-            Assert.IsTrue(history.Items.Count > 0);
+            Assert.IsNotEmpty(history.Items);
             var recordQueueId = history.Items[0].QueueId;
 
             var response = await _server.Client.GetAsync(
@@ -356,12 +356,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             var record = result.Items[0];
 
             Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
             Assert.AreEqual(2, record.Status); // Complete
-            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
+            Assert.IsGreaterThan(DateTime.MinValue, record.EnqueuedUtc);
         }
 
         [TestMethod]
@@ -372,7 +372,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Deleted);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(
@@ -395,7 +395,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbProcessingTests.cs
@@ -84,7 +84,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Processing >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, status.Processing);
         }
 
         [TestMethod]
@@ -92,7 +92,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/LiteDbStaleTests.cs
@@ -87,7 +87,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             await DashboardPollingHelper.WaitForStaleAsync(_server.Client, _queueId);
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryEndpointTests.cs
@@ -60,12 +60,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Discover connection and queue IDs
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             Assert.AreEqual(_queueName, queues[0].QueueName);
             _queueId = queues[0].Id;
         }
@@ -84,7 +84,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections[0].QueueCount);
         }
 
@@ -93,7 +93,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
@@ -132,7 +132,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -140,7 +140,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            Assert.AreEqual(2, paged.Items.Count);
+            Assert.HasCount(2, paged.Items);
             Assert.AreEqual(5, paged.TotalCount);
         }
 
@@ -149,7 +149,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -271,7 +271,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var jobs = await _server.Client.GetFromJsonAsync<List<JobResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/jobs");
-            Assert.AreEqual(0, jobs.Count);
+            Assert.IsEmpty(jobs);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryHistoryTests.cs
@@ -84,7 +84,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -209,8 +209,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
-            Assert.IsTrue(result.Items.Count >= MessageCount);
+            Assert.IsNotEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Items.Count);
         }
 
         [TestMethod]
@@ -220,8 +220,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=0&pageSize=2");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Items.Count);
-            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.HasCount(2, result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.TotalCount);
             Assert.AreEqual(0, result.PageIndex);
             Assert.AreEqual(2, result.PageSize);
         }
@@ -233,7 +233,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=1&pageSize=2");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Items.Count);
+            Assert.HasCount(2, result.Items);
             Assert.AreEqual(1, result.PageIndex);
         }
 
@@ -244,8 +244,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=100&pageSize=25");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
-            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.IsEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.TotalCount);
         }
 
         [TestMethod]
@@ -256,7 +256,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
@@ -268,7 +268,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=3&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -279,7 +279,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=1&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -289,7 +289,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -299,7 +299,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=2");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -317,7 +317,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
-            Assert.IsTrue(history.Items.Count > 0);
+            Assert.IsNotEmpty(history.Items);
             var recordQueueId = history.Items[0].QueueId;
 
             var response = await _server.Client.GetAsync(
@@ -344,12 +344,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             var record = result.Items[0];
 
             Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
             Assert.AreEqual(2, record.Status); // Complete
-            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
+            Assert.IsGreaterThan(DateTime.MinValue, record.EnqueuedUtc);
         }
 
         [TestMethod]
@@ -360,7 +360,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Deleted);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(
@@ -383,7 +383,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryStatefulTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MemoryStatefulTests.cs
@@ -58,11 +58,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{connections[0].Id}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             _queueId = queues[0].Id;
 
             // Start blocking consumer with 2 workers — each picks up 1 message and blocks
@@ -105,7 +105,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            Assert.AreEqual(2, paged.Items.Count);
+            Assert.HasCount(2, paged.Items);
         }
 
         [TestMethod]
@@ -113,7 +113,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -121,7 +121,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var detail = await _server.Client.GetFromJsonAsync<MessageResponse>(
@@ -134,7 +134,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var body = await _server.Client.GetFromJsonAsync<MessageBodyResponse>(
@@ -147,7 +147,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var deleteResponse = await _server.Client.DeleteAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiQueueTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiQueueTests.cs
@@ -72,12 +72,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(2, queues.Count);
+            Assert.HasCount(2, queues);
 
             // Assign queue IDs by matching queue names
             foreach (var q in queues)
@@ -102,7 +102,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(2, connections[0].QueueCount);
         }
 
@@ -111,11 +111,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged1 = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId1}/messages?pageSize=100");
-            Assert.AreEqual(3, paged1.Items.Count);
+            Assert.HasCount(3, paged1.Items);
 
             var paged2 = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId2}/messages?pageSize=100");
-            Assert.AreEqual(2, paged2.Items.Count);
+            Assert.HasCount(2, paged2.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiSourcePartialFailureTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiSourcePartialFailureTests.cs
@@ -103,7 +103,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Verify server2 is healthy first
             var connections = await _server2.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
 
             // Dispose server2
             await _server2.DisposeAsync();
@@ -131,7 +131,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server1.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections[0].QueueCount);
         }
 
@@ -151,7 +151,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server1.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages?pageSize=100");
-            Assert.AreEqual(3, paged.Items.Count);
+            Assert.HasCount(3, paged.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiSourceTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/MultiSourceTests.cs
@@ -86,7 +86,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server1.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections[0].QueueCount);
         }
 
@@ -95,7 +95,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server2.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections[0].QueueCount);
         }
 
@@ -107,8 +107,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var connections2 = await _server2.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
 
-            Assert.AreEqual(1, connections1.Count);
-            Assert.AreEqual(1, connections2.Count);
+            Assert.HasCount(1, connections1);
+            Assert.HasCount(1, connections2);
 
             var ids1 = connections1.Select(c => c.Id).ToHashSet();
             var ids2 = connections2.Select(c => c.Id).ToHashSet();
@@ -128,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server1.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages?pageSize=100");
-            Assert.AreEqual(3, paged.Items.Count);
+            Assert.HasCount(3, paged.Items);
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server2.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages?pageSize=100");
-            Assert.AreEqual(2, paged.Items.Count);
+            Assert.HasCount(2, paged.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlEditBodyTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlEditBodyTests.cs
@@ -128,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var content = new StringContent(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlEndpointTests.cs
@@ -63,12 +63,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             _queueId = queues[0].Id;
         }
 
@@ -86,7 +86,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections[0].QueueCount);
         }
 
@@ -95,7 +95,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
@@ -136,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            Assert.AreEqual(2, paged.Items.Count);
+            Assert.HasCount(2, paged.Items);
             Assert.AreEqual(5, paged.TotalCount);
         }
 
@@ -153,7 +153,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -282,7 +282,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -290,7 +290,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlErrorTests.cs
@@ -89,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Error > 0);
+            Assert.IsGreaterThan(0, status.Error);
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             Assert.IsFalse(string.IsNullOrEmpty(paged.Items[0].LastException));
         }
 
@@ -108,11 +108,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/errors");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted > 0);
+            Assert.IsGreaterThan(0, result.Deleted);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -120,7 +120,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlHistoryEnabledTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlHistoryEnabledTests.cs
@@ -135,8 +135,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
-            Assert.IsTrue(result.Items.Count >= MessageCount);
+            Assert.IsNotEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Items.Count);
         }
 
         [TestMethod]
@@ -146,7 +146,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -157,7 +157,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
@@ -167,12 +167,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             var record = result.Items[0];
 
             Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
             Assert.AreEqual(2, record.Status); // Complete
-            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
+            Assert.IsGreaterThan(DateTime.MinValue, record.EnqueuedUtc);
         }
 
         [TestMethod]
@@ -183,7 +183,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Deleted);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlHistoryTests.cs
@@ -82,7 +82,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlProcessingTests.cs
@@ -85,7 +85,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Processing >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, status.Processing);
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -101,7 +101,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/PostgreSqlStaleTests.cs
@@ -88,7 +88,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -96,7 +96,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisEndpointTests.cs
@@ -57,12 +57,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             _queueId = queues[0].Id;
         }
 
@@ -80,7 +80,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections[0].QueueCount);
         }
 
@@ -89,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
@@ -128,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -136,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            Assert.AreEqual(2, paged.Items.Count);
+            Assert.HasCount(2, paged.Items);
             Assert.AreEqual(5, paged.TotalCount);
         }
 
@@ -145,7 +145,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -256,7 +256,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -273,7 +273,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisErrorTests.cs
@@ -83,7 +83,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Error > 0);
+            Assert.IsGreaterThan(0, status.Error);
         }
 
         [TestMethod]
@@ -91,7 +91,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             // Redis does not store exception text, so LastException may be null
         }
 
@@ -102,11 +102,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/errors");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted > 0);
+            Assert.IsGreaterThan(0, result.Deleted);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -114,7 +114,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisHistoryTests.cs
@@ -82,7 +82,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -205,8 +205,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
-            Assert.IsTrue(result.Items.Count >= MessageCount);
+            Assert.IsNotEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Items.Count);
         }
 
         [TestMethod]
@@ -216,8 +216,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=0&pageSize=2");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Items.Count);
-            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.HasCount(2, result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.TotalCount);
             Assert.AreEqual(0, result.PageIndex);
             Assert.AreEqual(2, result.PageSize);
         }
@@ -229,7 +229,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=1&pageSize=2");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Items.Count);
+            Assert.HasCount(2, result.Items);
             Assert.AreEqual(1, result.PageIndex);
         }
 
@@ -240,8 +240,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=100&pageSize=25");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
-            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.IsEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.TotalCount);
         }
 
         [TestMethod]
@@ -252,7 +252,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
@@ -264,7 +264,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=3&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -275,7 +275,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=1&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -285,7 +285,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -295,7 +295,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=2");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -313,7 +313,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
-            Assert.IsTrue(history.Items.Count > 0);
+            Assert.IsNotEmpty(history.Items);
             var recordQueueId = history.Items[0].QueueId;
 
             var response = await _server.Client.GetAsync(
@@ -340,12 +340,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             var record = result.Items[0];
 
             Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
             Assert.AreEqual(2, record.Status); // Complete
-            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
+            Assert.IsGreaterThan(DateTime.MinValue, record.EnqueuedUtc);
         }
 
         [TestMethod]
@@ -356,7 +356,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Deleted);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(
@@ -379,7 +379,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisProcessingTests.cs
@@ -79,7 +79,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Processing >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, status.Processing);
         }
 
         [TestMethod]
@@ -87,7 +87,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -95,7 +95,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/RedisStaleTests.cs
@@ -82,7 +82,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -90,7 +90,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerEditBodyTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerEditBodyTests.cs
@@ -128,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var content = new StringContent(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerEndpointTests.cs
@@ -63,12 +63,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             _queueId = queues[0].Id;
         }
 
@@ -86,7 +86,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections[0].QueueCount);
         }
 
@@ -95,7 +95,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
@@ -136,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            Assert.AreEqual(2, paged.Items.Count);
+            Assert.HasCount(2, paged.Items);
             Assert.AreEqual(5, paged.TotalCount);
         }
 
@@ -153,7 +153,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -282,7 +282,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -290,7 +290,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerErrorTests.cs
@@ -89,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Error > 0);
+            Assert.IsGreaterThan(0, status.Error);
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             Assert.IsFalse(string.IsNullOrEmpty(paged.Items[0].LastException));
         }
 
@@ -108,11 +108,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/errors");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted > 0);
+            Assert.IsGreaterThan(0, result.Deleted);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -120,7 +120,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerHistoryEnabledTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerHistoryEnabledTests.cs
@@ -127,8 +127,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
-            Assert.IsTrue(result.Items.Count >= MessageCount);
+            Assert.IsNotEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Items.Count);
         }
 
         [TestMethod]
@@ -138,7 +138,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -148,7 +148,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
@@ -158,12 +158,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             var record = result.Items[0];
 
             Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
             Assert.AreEqual(2, record.Status);
-            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
+            Assert.IsGreaterThan(DateTime.MinValue, record.EnqueuedUtc);
         }
 
         [TestMethod]
@@ -173,7 +173,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Deleted);
 
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerHistoryTests.cs
@@ -82,7 +82,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerProcessingTests.cs
@@ -85,7 +85,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Processing >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, status.Processing);
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -101,7 +101,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqlServerStaleTests.cs
@@ -90,7 +90,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -98,7 +98,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteBulkOperationsTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteBulkOperationsTests.cs
@@ -116,12 +116,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{queueId}/messages/reset-all", null);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<BulkActionResponse>();
-            Assert.IsTrue(result.Count >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, result.Count);
 
             // Verify waiting count increased
             var status = await server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId}/status");
-            Assert.IsTrue(status.Waiting >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, status.Waiting);
         }
 
         // === Error Retries ===
@@ -164,7 +164,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // No retries for this message
             var retries = await server.Client.GetFromJsonAsync<List<ErrorRetryResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages/{messageId}/retries");
-            Assert.AreEqual(0, retries.Count);
+            Assert.IsEmpty(retries);
         }
 
         [TestMethod]
@@ -207,15 +207,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Get the error message ID
             var errors = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors");
-            Assert.IsTrue(errors.Items.Count > 0);
+            Assert.IsNotEmpty(errors.Items);
             var messageId = errors.Items[0].QueueId;
 
             // Check retries for this message
             var retries = await server.Client.GetFromJsonAsync<List<ErrorRetryResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages/{messageId}/retries");
-            Assert.IsTrue(retries.Count > 0);
+            Assert.IsNotEmpty(retries);
             Assert.IsFalse(string.IsNullOrEmpty(retries[0].ExceptionType));
-            Assert.IsTrue(retries[0].RetryCount >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, retries[0].RetryCount);
         }
 
         // === Requeue single error then verify status returns to waiting ===
@@ -270,12 +270,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Verify status shows it back in Waiting
             var status = await server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{queueId}/status");
-            Assert.IsTrue(status.Waiting >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, status.Waiting);
 
             // Verify error count is reduced
             var errorsAfter = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors");
-            Assert.IsTrue(errorsAfter.Items.Count < errors.Items.Count);
+            Assert.IsLessThan(errors.Items.Count, errorsAfter.Items.Count);
         }
 
         // === Reset stale (single message) already tested in SqliteStaleTests,
@@ -405,14 +405,14 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // First page
             var page0 = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors?pageIndex=0&pageSize=2");
-            Assert.AreEqual(2, page0.Items.Count);
-            Assert.IsTrue(page0.TotalCount >= 3);
+            Assert.HasCount(2, page0.Items);
+            Assert.IsGreaterThanOrEqualTo(3, page0.TotalCount);
 
             // Second page
             var page1 = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors?pageIndex=1&pageSize=2");
-            Assert.IsTrue(page1.Items.Count > 0);
-            Assert.IsTrue(page1.Items.Count >= 1);
+            Assert.IsNotEmpty(page1.Items);
+            Assert.IsGreaterThanOrEqualTo(1, page1.Items.Count);
 
             // Error detail fields
             Assert.IsFalse(string.IsNullOrEmpty(page0.Items[0].LastException));

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteConsumerTrackingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteConsumerTrackingTests.cs
@@ -74,12 +74,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var registration = await response.Content.ReadFromJsonAsync<ConsumerRegistrationResponse>();
             Assert.IsNotNull(registration);
             Assert.AreNotEqual(Guid.Empty, registration!.ConsumerId);
-            Assert.IsTrue(registration.HeartbeatIntervalSeconds > 0);
+            Assert.IsGreaterThan(0, registration.HeartbeatIntervalSeconds);
 
             // Verify consumer appears in list and is matched to the queue
             var consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.AreEqual(1, consumers.Count);
+            Assert.HasCount(1, consumers);
             Assert.AreEqual(queueId, consumers![0].MatchedQueueId);
             Assert.AreEqual("SQLITEHOST", consumers[0].MachineName);
             Assert.AreEqual(queueName, consumers[0].QueueName);
@@ -136,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Verify timestamp updated and metrics present
             var consumersAfter = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.IsTrue(consumersAfter![0].LastHeartbeat >= initialHeartbeat);
+            Assert.IsGreaterThanOrEqualTo(initialHeartbeat, consumersAfter![0].LastHeartbeat);
             Assert.AreEqual(50, consumersAfter[0].MessagesProcessed);
             Assert.AreEqual(2, consumersAfter[0].MessagesErrored);
             Assert.AreEqual(1, consumersAfter[0].MessagesRolledBack);
@@ -183,12 +183,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Filter by queueId should return only the 2 matched
             var filtered = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 $"api/v1/dashboard/consumers?queueId={queueId}");
-            Assert.AreEqual(2, filtered.Count);
+            Assert.HasCount(2, filtered);
 
             // All should return all 3
             var all = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.AreEqual(3, all.Count);
+            Assert.HasCount(3, all);
         }
 
         // === Unregister removes consumer ===
@@ -222,7 +222,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Verify registered
             var consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.AreEqual(1, consumers.Count);
+            Assert.HasCount(1, consumers);
 
             // Unregister
             var deleteResponse = await server.Client.DeleteAsync(
@@ -232,7 +232,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Verify gone
             consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.AreEqual(0, consumers.Count);
+            Assert.IsEmpty(consumers);
         }
 
         // === Consumer pruning service prunes stale consumers ===
@@ -269,7 +269,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // Verify it exists
             var consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.AreEqual(1, consumers.Count);
+            Assert.HasCount(1, consumers);
 
             // Wait for the pruning service to remove it (stale threshold = 2s, prune interval = 1s)
             // Poll up to 10 seconds to account for timing
@@ -332,12 +332,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // GET consumers returns empty list (not 404)
             var consumers = await server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
                 "api/v1/dashboard/consumers");
-            Assert.AreEqual(0, consumers.Count);
+            Assert.IsEmpty(consumers);
 
             // GET counts returns empty dictionary
             var counts = await server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
-            Assert.AreEqual(0, counts.Count);
+            Assert.IsEmpty(counts);
         }
 
         // === Consumer counts per queue ===
@@ -372,7 +372,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // No consumers initially
             var counts = await server.Client.GetFromJsonAsync<Dictionary<Guid, int>>(
                 "api/v1/dashboard/consumers/count");
-            Assert.AreEqual(0, counts.Count);
+            Assert.IsEmpty(counts);
 
             // Register two
             await server.Client.PostAsJsonAsync("api/v1/dashboard/consumers/register",

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteEditBodyTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteEditBodyTests.cs
@@ -128,7 +128,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var content = new StringContent(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteEndpointTests.cs
@@ -63,12 +63,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             _connectionId = connections[0].Id;
 
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             _queueId = queues[0].Id;
         }
 
@@ -86,7 +86,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var connections = await _server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections[0].QueueCount);
         }
 
@@ -95,7 +95,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var queues = await _server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             Assert.AreEqual(_queueName, queues[0].QueueName);
         }
 
@@ -136,7 +136,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?pageSize=2&pageIndex=0");
-            Assert.AreEqual(2, paged.Items.Count);
+            Assert.HasCount(2, paged.Items);
             Assert.AreEqual(5, paged.TotalCount);
         }
 
@@ -153,7 +153,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=0&pageSize=100");
-            Assert.AreEqual(5, paged.Items.Count);
+            Assert.HasCount(5, paged.Items);
         }
 
         [TestMethod]
@@ -272,7 +272,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var jobs = await _server.Client.GetFromJsonAsync<List<JobResponse>>(
                 $"api/v1/dashboard/connections/{_connectionId}/jobs");
-            Assert.AreEqual(0, jobs.Count);
+            Assert.IsEmpty(jobs);
         }
 
         [TestMethod]
@@ -280,7 +280,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -288,7 +288,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteErrorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteErrorTests.cs
@@ -89,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Error > 0);
+            Assert.IsGreaterThan(0, status.Error);
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             Assert.IsFalse(string.IsNullOrEmpty(paged.Items[0].LastException));
         }
 
@@ -108,11 +108,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/errors");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted > 0);
+            Assert.IsGreaterThan(0, result.Deleted);
 
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.AreEqual(0, paged.Items.Count);
+            Assert.IsEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -120,7 +120,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/errors");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteHistoryEnabledTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteHistoryEnabledTests.cs
@@ -127,8 +127,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
-            Assert.IsTrue(result.Items.Count >= MessageCount);
+            Assert.IsNotEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Items.Count);
         }
 
         [TestMethod]
@@ -138,8 +138,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=0&pageSize=2");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Items.Count);
-            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.HasCount(2, result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.TotalCount);
             Assert.AreEqual(0, result.PageIndex);
             Assert.AreEqual(2, result.PageSize);
         }
@@ -151,7 +151,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=1&pageSize=2");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Items.Count);
+            Assert.HasCount(2, result.Items);
             Assert.AreEqual(1, result.PageIndex);
         }
 
@@ -162,8 +162,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?pageIndex=100&pageSize=25");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
-            Assert.IsTrue(result.TotalCount >= MessageCount);
+            Assert.IsEmpty(result.Items);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.TotalCount);
         }
 
         [TestMethod]
@@ -174,7 +174,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=2&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             AssertHelper.AllSatisfy(result.Items, item => Assert.AreEqual(2, item.Status));
         }
 
@@ -186,7 +186,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=3&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -197,7 +197,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?status=1&pageSize=100");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]
@@ -207,7 +207,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -217,7 +217,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history/count?status=2");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var count = await response.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
 
         [TestMethod]
@@ -236,7 +236,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // First get a history record to obtain its QueueId
             var history = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
-            Assert.IsTrue(history.Items.Count > 0);
+            Assert.IsNotEmpty(history.Items);
             var queueId = history.Items[0].QueueId;
 
             var response = await _server.Client.GetAsync(
@@ -263,12 +263,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var result = await _server.Client.GetFromJsonAsync<PagedResponse<HistoryResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/history?pageSize=1");
 
-            Assert.IsTrue(result.Items.Count > 0);
+            Assert.IsNotEmpty(result.Items);
             var record = result.Items[0];
 
             Assert.IsFalse(string.IsNullOrEmpty(record.QueueId));
             Assert.AreEqual(2, record.Status); // Complete
-            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
+            Assert.IsGreaterThan(DateTime.MinValue, record.EnqueuedUtc);
         }
 
         [TestMethod]
@@ -279,7 +279,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history?olderThanDays=0");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadFromJsonAsync<DeleteAllResponse>();
-            Assert.IsTrue(result.Deleted >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, result.Deleted);
 
             // Verify count is now 0
             var countResponse = await _server.Client.GetAsync(
@@ -302,7 +302,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var countResponse = await _server.Client.GetAsync(
                 $"api/v1/dashboard/queues/{_queueId}/history/count");
             var count = await countResponse.Content.ReadFromJsonAsync<long>();
-            Assert.IsTrue(count >= MessageCount);
+            Assert.IsGreaterThanOrEqualTo(MessageCount, count);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteHistoryTests.cs
@@ -82,7 +82,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
                 $"api/v1/dashboard/queues/{_queueId}/history");
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Items.Count);
+            Assert.IsEmpty(result.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteProcessingTests.cs
@@ -86,7 +86,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var status = await _server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{_queueId}/status");
-            Assert.IsTrue(status.Processing >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, status.Processing);
         }
 
         [TestMethod]
@@ -94,7 +94,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=100");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -102,7 +102,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages?status=1&pageSize=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.DeleteAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteQueueConfigTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteQueueConfigTests.cs
@@ -228,12 +228,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
             Assert.AreEqual(1, connections![0].QueueCount);
 
             var queues = await server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{connections[0].Id}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
             Assert.AreEqual(queueName, queues![0].QueueName);
             Assert.AreNotEqual(Guid.Empty, queues[0].Id);
         }
@@ -278,7 +278,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var connections = await server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(2, connections.Count);
+            Assert.HasCount(2, connections);
 
             // Find queue IDs across connections
             Guid queueId1 = Guid.Empty, queueId2 = Guid.Empty;
@@ -336,7 +336,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var jobs = await server.Client.GetFromJsonAsync<List<JobResponse>>(
                 $"api/v1/dashboard/connections/{connections[0].Id}/jobs");
-            Assert.AreEqual(0, jobs.Count);
+            Assert.IsEmpty(jobs);
         }
 
         // === Settings endpoint returns expected values ===
@@ -403,7 +403,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var paged = await server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages/stale");
             Assert.IsNotNull(paged);
-            Assert.AreEqual(0, paged!.Items.Count);
+            Assert.IsEmpty(paged!.Items);
         }
 
         // === Errors returns empty when no errors ===
@@ -440,7 +440,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             var paged = await server.Client.GetFromJsonAsync<PagedResponse<ErrorMessageResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/errors");
             Assert.IsNotNull(paged);
-            Assert.AreEqual(0, paged!.Items.Count);
+            Assert.IsEmpty(paged!.Items);
             Assert.AreEqual(0, paged.TotalCount);
         }
 
@@ -575,7 +575,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
 
             var retries = await server.Client.GetFromJsonAsync<List<ErrorRetryResponse>>(
                 $"api/v1/dashboard/queues/{queueId}/messages/99999999/retries");
-            Assert.AreEqual(0, retries.Count);
+            Assert.IsEmpty(retries);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteSettingsAndReadOnlyTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteSettingsAndReadOnlyTests.cs
@@ -119,11 +119,11 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             // GET requests should still work
             var connections = await server.Client.GetFromJsonAsync<List<ConnectionResponse>>(
                 "api/v1/dashboard/connections");
-            Assert.AreEqual(1, connections.Count);
+            Assert.HasCount(1, connections);
 
             var queues = await server.Client.GetFromJsonAsync<List<QueueInfoResponse>>(
                 $"api/v1/dashboard/connections/{connections[0].Id}/queues");
-            Assert.AreEqual(1, queues.Count);
+            Assert.HasCount(1, queues);
 
             var status = await server.Client.GetFromJsonAsync<QueueStatusResponse>(
                 $"api/v1/dashboard/queues/{queues[0].Id}/status");

--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteStaleTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/SqliteStaleTests.cs
@@ -88,7 +88,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
         }
 
         [TestMethod]
@@ -96,7 +96,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
         {
             var paged = await _server.Client.GetFromJsonAsync<PagedResponse<MessageResponse>>(
                 $"api/v1/dashboard/queues/{_queueId}/messages/stale?thresholdSeconds=1");
-            Assert.IsTrue(paged.Items.Count > 0);
+            Assert.IsNotEmpty(paged.Items);
             var messageId = paged.Items[0].QueueId;
 
             var response = await _server.Client.PostAsync(

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardConnectionOptionsTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardConnectionOptionsTests.cs
@@ -13,7 +13,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
         {
             var opts = new DashboardConnectionOptions();
             opts.AddQueue("TestQueue");
-            Assert.AreEqual(1, (opts.Queues).Count());
+            Assert.HasCount(1, opts.Queues);
             Assert.AreEqual("TestQueue", opts.Queues[0].QueueName);
         }
 
@@ -42,7 +42,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
             opts.AddQueue("Queue1");
             opts.AddQueue("Queue2");
             opts.AddQueue("Queue3");
-            Assert.AreEqual(3, (opts.Queues).Count());
+            Assert.HasCount(3, opts.Queues);
         }
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
         {
             var opts = new DashboardConnectionOptions();
             opts.AddQueueWithProfile("TestQueue", "encrypted");
-            Assert.AreEqual(1, (opts.Queues).Count());
+            Assert.HasCount(1, opts.Queues);
             Assert.AreEqual("TestQueue", opts.Queues[0].QueueName);
             Assert.AreEqual("encrypted", opts.Queues[0].InterceptorProfile);
             Assert.IsNull(opts.Queues[0].InterceptorConfiguration);
@@ -65,7 +65,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
                 GZip = new GZipInterceptorOptions { MinimumSize = 200 }
             };
             opts.AddQueue("TestQueue", interceptors);
-            Assert.AreEqual(1, (opts.Queues).Count());
+            Assert.HasCount(1, opts.Queues);
             Assert.AreEqual("TestQueue", opts.Queues[0].QueueName);
             Assert.AreSame(interceptors, opts.Queues[0].Interceptors);
             Assert.IsNull(opts.Queues[0].InterceptorConfiguration);

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardOptionsTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Configuration/DashboardOptionsTests.cs
@@ -95,7 +95,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
         public void CorsOrigins_Defaults_To_Empty()
         {
             var opts = new DashboardOptions();
-            Assert.IsFalse((opts.CorsOrigins).Any());
+            Assert.IsEmpty(opts.CorsOrigins);
         }
 
         [TestMethod]
@@ -107,7 +107,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
                 CorsOrigins = new[] { "http://localhost:5000" }
             };
             Assert.IsTrue(opts.EnableCors);
-            Assert.AreEqual(1, (opts.CorsOrigins).Count());
+            Assert.HasCount(1, opts.CorsOrigins);
             Assert.AreEqual("http://localhost:5000", (opts.CorsOrigins).Single());
         }
 
@@ -115,7 +115,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
         public void AssemblyPaths_Defaults_To_Empty()
         {
             var opts = new DashboardOptions();
-            Assert.IsFalse((opts.AssemblyPaths).Any());
+            Assert.IsEmpty(opts.AssemblyPaths);
         }
 
         [TestMethod]
@@ -125,7 +125,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Configuration
             {
                 AssemblyPaths = new[] { "/app/plugins", "/opt/dlls" }
             };
-            Assert.AreEqual(2, (opts.AssemblyPaths).Count());
+            Assert.HasCount(2, opts.AssemblyPaths);
             Assert.AreEqual("/app/plugins", opts.AssemblyPaths[0]);
             Assert.AreEqual("/opt/dlls", opts.AssemblyPaths[1]);
         }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Controllers/ConnectionsControllerTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Controllers/ConnectionsControllerTests.cs
@@ -41,7 +41,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Controllers
 
             Assert.IsNotNull(result);
             var items = result.Value as IReadOnlyList<ConnectionResponse>;
-            Assert.AreEqual(1, (items).Count());
+            Assert.HasCount(1, items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Controllers/ConsumersControllerTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Controllers/ConsumersControllerTests.cs
@@ -182,7 +182,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Controllers
 
             Assert.IsNotNull(result);
             var items = result!.Value as List<ConsumerInfoResponse>;
-            Assert.AreEqual(1, (items).Count());
+            Assert.HasCount(1, items);
         }
 
         [TestMethod]
@@ -204,7 +204,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Controllers
 
             var result = controller.GetConsumers() as OkObjectResult;
             var items = result!.Value as List<ConsumerInfoResponse>;
-            Assert.AreEqual(1, (items).Count());
+            Assert.HasCount(1, items);
             Assert.AreEqual(500, items![0].MessagesProcessed);
             Assert.AreEqual(10, items[0].MessagesErrored);
             Assert.AreEqual(7, items[0].MessagesRolledBack);
@@ -233,7 +233,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Controllers
 
             Assert.IsNotNull(result);
             var items = result!.Value as ConsumerInfoResponse[];
-            Assert.IsFalse((items).Any());
+            Assert.IsEmpty(items);
         }
 
         // === GetConsumerCounts ===
@@ -262,7 +262,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Controllers
 
             Assert.IsNotNull(result);
             var counts = result!.Value as Dictionary<Guid, int>;
-            Assert.IsFalse((counts).Any());
+            Assert.IsEmpty(counts);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/DashboardApiTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/DashboardApiTests.cs
@@ -16,7 +16,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests
             var options = new DashboardOptions();
             using var api = new DashboardApi(options, NullLogger<DashboardApi>.Instance);
 
-            Assert.IsFalse((api.Connections).Any());
+            Assert.IsEmpty(api.Connections);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Extensions/DashboardExtensionsCorsAndAuthTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Extensions/DashboardExtensionsCorsAndAuthTests.cs
@@ -96,7 +96,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Extensions
 
             convention.Apply(controllerModel);
 
-            Assert.AreEqual(1, (controllerModel.Filters.OfType<AuthorizeFilter>()).Count());
+            Assert.HasCount(1, controllerModel.Filters.OfType<AuthorizeFilter>());
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Extensions
 
             convention.Apply(controllerModel);
 
-            Assert.IsFalse((controllerModel.Filters).Any());
+            Assert.IsEmpty(controllerModel.Filters);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Extensions/DashboardExtensionsFromConfigurationTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Extensions/DashboardExtensionsFromConfigurationTests.cs
@@ -52,7 +52,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Extensions
             var provider = services.BuildServiceProvider();
             var options = provider.GetRequiredService<DashboardOptions>();
             Assert.IsFalse(options.EnableSwagger);
-            Assert.IsTrue((options.ConnectionRegistrations).Any());
+            Assert.IsNotEmpty(options.ConnectionRegistrations);
         }
 
         // Task 2: Parameterized test over all 5 valid transport names
@@ -82,7 +82,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Extensions
 
             var provider = services.BuildServiceProvider();
             var options = provider.GetRequiredService<DashboardOptions>();
-            Assert.IsTrue((options.ConnectionRegistrations).Any());
+            Assert.IsNotEmpty(options.ConnectionRegistrations);
         }
 
         // Task 2: Unknown-transport error test

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Extensions/DashboardExtensionsTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Extensions/DashboardExtensionsTests.cs
@@ -131,7 +131,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Extensions
                 .Where(sd => sd.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService))
                 .ToList();
 
-            Assert.IsTrue(hostedServiceRegistrations.Count > 0,
+            Assert.IsNotEmpty(hostedServiceRegistrations,
                 "ConsumerPruningService should be registered as IHostedService");
         }
 
@@ -152,7 +152,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Extensions
                     && sd.ImplementationType == typeof(DotNetWorkQueue.Dashboard.Api.Services.ConsumerPruningService))
                 .ToList();
 
-            Assert.AreEqual(0, pruningServiceRegistrations.Count,
+            Assert.IsEmpty(pruningServiceRegistrations,
                 "ConsumerPruningService should not be registered when tracking is disabled");
         }
 
@@ -182,7 +182,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Extensions
                 // If PreloadAssemblies threw, we wouldn't get here
                 var provider = services.BuildServiceProvider();
                 var opts = provider.GetRequiredService<DashboardOptions>();
-                Assert.AreEqual(1, (opts.AssemblyPaths).Count());
+                Assert.HasCount(1, opts.AssemblyPaths);
                 Assert.AreEqual(pluginDir, (opts.AssemblyPaths).Single());
             }
             finally

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Services/ConsumerRegistryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Services/ConsumerRegistryTests.cs
@@ -61,7 +61,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             registry.Register("testQueue", "MACHINE1", 1234, null);
 
             var entries = registry.GetAll();
-            Assert.AreEqual(1, (entries).Count());
+            Assert.HasCount(1, entries);
             Assert.AreEqual(queueId, entries[0].MatchedQueueId);
         }
 
@@ -94,10 +94,10 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             var after = DateTimeOffset.UtcNow;
 
             var entry = registry.GetAll()[0];
-            Assert.IsTrue((entry.RegisteredAt) >= (before));
-            Assert.IsTrue((entry.RegisteredAt) <= (after));
-            Assert.IsTrue((entry.LastHeartbeat) >= (before));
-            Assert.IsTrue((entry.LastHeartbeat) <= (after));
+            Assert.IsGreaterThanOrEqualTo(before, entry.RegisteredAt);
+            Assert.IsLessThanOrEqualTo(after, entry.RegisteredAt);
+            Assert.IsGreaterThanOrEqualTo(before, entry.LastHeartbeat);
+            Assert.IsLessThanOrEqualTo(after, entry.LastHeartbeat);
         }
 
         [TestMethod]
@@ -111,7 +111,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             var result = registry.Heartbeat(id);
 
             Assert.IsTrue(result);
-            Assert.IsTrue((registry.GetAll()[0].LastHeartbeat) > (initialHeartbeat));
+            Assert.IsGreaterThan(initialHeartbeat, registry.GetAll()[0].LastHeartbeat);
         }
 
         [TestMethod]
@@ -172,7 +172,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             var id = registry.Register("testQueue", "MACHINE1", 1234, null);
 
             Assert.IsTrue(registry.Unregister(id));
-            Assert.IsFalse((registry.GetAll()).Any());
+            Assert.IsEmpty(registry.GetAll());
         }
 
         [TestMethod]
@@ -189,7 +189,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             registry.Register("testQueue", "MACHINE1", 1234, null);
             registry.Register("testQueue", "MACHINE2", 5678, null);
 
-            Assert.AreEqual(2, (registry.GetAll()).Count());
+            Assert.HasCount(2, registry.GetAll());
         }
 
         [TestMethod]
@@ -200,7 +200,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             registry.Register("otherQueue", "MACHINE2", 5678, null);
 
             var matched = registry.GetByQueue(queueId);
-            Assert.AreEqual(1, (matched).Count());
+            Assert.HasCount(1, matched);
             Assert.AreEqual("MACHINE1", matched[0].MachineName);
         }
 
@@ -210,7 +210,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             var registry = CreateRegistry(out _);
             registry.Register("testQueue", "MACHINE1", 1234, null);
 
-            Assert.IsFalse((registry.GetByQueue(Guid.NewGuid())).Any());
+            Assert.IsEmpty(registry.GetByQueue(Guid.NewGuid()));
         }
 
         [TestMethod]
@@ -232,7 +232,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             var registry = CreateRegistry(out _);
             registry.Register("unknownQueue", "MACHINE1", 1234, null);
 
-            Assert.IsFalse((registry.GetCountsByQueue()).Any());
+            Assert.IsEmpty(registry.GetCountsByQueue());
         }
 
         [TestMethod]
@@ -244,7 +244,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             // With a zero threshold, everything is stale
             var pruned = registry.PruneStale(TimeSpan.Zero);
             Assert.AreEqual(1, pruned);
-            Assert.IsFalse((registry.GetAll()).Any());
+            Assert.IsEmpty(registry.GetAll());
         }
 
         [TestMethod]
@@ -255,7 +255,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
 
             var pruned = registry.PruneStale(TimeSpan.FromMinutes(5));
             Assert.AreEqual(0, pruned);
-            Assert.AreEqual(1, (registry.GetAll()).Count());
+            Assert.HasCount(1, registry.GetAll());
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api.Tests/Services/DashboardServiceTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Tests/Services/DashboardServiceTests.cs
@@ -34,7 +34,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
 
             var result = service.GetConnections();
 
-            Assert.AreEqual(1, (result).Count());
+            Assert.HasCount(1, result);
             Assert.AreEqual("Test Connection", result[0].DisplayName);
             Assert.AreEqual(1, result[0].QueueCount);
         }
@@ -47,7 +47,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
 
             var result = service.GetQueues(connectionId);
 
-            Assert.AreEqual(1, (result).Count());
+            Assert.HasCount(1, result);
             Assert.AreEqual("TestQueue", result[0].QueueName);
         }
 
@@ -184,7 +184,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetJobsByConnectionAsync(connectionId);
 
-            Assert.AreEqual(1, (result).Count());
+            Assert.HasCount(1, result);
             Assert.AreEqual("ConnectionJob", result[0].JobName);
         }
 
@@ -209,7 +209,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             var service = new DashboardService(api, NullLogger<DashboardService>.Instance, new DashboardOptions());
             var result = await service.GetJobsByConnectionAsync(connectionId);
 
-            Assert.IsFalse((result).Any());
+            Assert.IsEmpty(result);
         }
 
         [TestMethod]
@@ -304,7 +304,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             Assert.IsFalse(string.IsNullOrEmpty(result.Body));
             Assert.AreEqual("System.String", result.TypeName);
             Assert.IsFalse(result.WasIntercepted);
-            Assert.IsFalse((result.InterceptorChain).Any());
+            Assert.IsEmpty(result.InterceptorChain);
             Assert.IsNull(result.DecodingError);
         }
 
@@ -595,7 +595,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             StringAssert.Contains(result.DecodingError, "Padding is invalid and cannot be removed");
             StringAssert.Contains(result.DecodingError, "Verify that the dashboard has the same interceptors configured");
             Assert.IsTrue(result.WasIntercepted);
-            Assert.AreEqual(2, (result.InterceptorChain).Count());
+            Assert.HasCount(2, result.InterceptorChain);
             CollectionAssert.Contains((System.Collections.ICollection)result.InterceptorChain, "TripleDesMessageInterceptor");
             CollectionAssert.Contains((System.Collections.ICollection)result.InterceptorChain, "GZipMessageInterceptor");
         }
@@ -649,7 +649,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             StringAssert.Contains(result.DecodingError, "Could not load assembly");
             StringAssert.Contains(result.DecodingError, "ensure the assembly containing the message type is available");
             Assert.IsFalse(result.WasIntercepted);
-            Assert.IsFalse((result.InterceptorChain).Any());
+            Assert.IsEmpty(result.InterceptorChain);
         }
 
         [TestMethod]
@@ -700,7 +700,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             Assert.AreEqual("Unexpected deserialization failure", result.DecodingError);
             // Even for generic exceptions, interceptor info should be populated since headers parsed OK
             Assert.IsTrue(result.WasIntercepted);
-            Assert.AreEqual(1, (result.InterceptorChain).Count());
+            Assert.HasCount(1, result.InterceptorChain);
             CollectionAssert.Contains((System.Collections.ICollection)result.InterceptorChain, "GZipMessageInterceptor");
         }
 
@@ -754,7 +754,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Tests.Services
             Assert.IsFalse(string.IsNullOrEmpty(result.Body));
             Assert.IsNull(result.DecodingError);
             Assert.IsTrue(result.WasIntercepted);
-            Assert.AreEqual(2, (result.InterceptorChain).Count());
+            Assert.HasCount(2, result.InterceptorChain);
             CollectionAssert.Contains((System.Collections.ICollection)result.InterceptorChain, "TripleDesMessageInterceptor");
             CollectionAssert.Contains((System.Collections.ICollection)result.InterceptorChain, "GZipMessageInterceptor");
         }

--- a/Source/DotNetWorkQueue.Dashboard.Client.Tests/DashboardApiClientTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Client.Tests/DashboardApiClientTests.cs
@@ -57,7 +57,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var result = await client.GetConnectionsAsync();
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(1, result.Value.Count);
+            Assert.HasCount(1, result.Value);
             Assert.AreEqual("Test", result.Value[0].DisplayName);
             Assert.AreEqual(3, result.Value[0].QueueCount);
         }
@@ -105,7 +105,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var result = await client.GetConsumersAsync();
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(1, result.Value.Count);
+            Assert.HasCount(1, result.Value);
             Assert.AreEqual(consumerId, result.Value[0].ConsumerId);
             Assert.AreEqual("M1", result.Value[0].MachineName);
         }
@@ -183,7 +183,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var result = await client.GetQueuesAsync(Guid.NewGuid());
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(1, result.Value.Count);
+            Assert.HasCount(1, result.Value);
             Assert.AreEqual(id, result.Value[0].Id);
             Assert.AreEqual("my-queue", result.Value[0].QueueName);
         }
@@ -200,7 +200,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var result = await client.GetJobsAsync(Guid.NewGuid());
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(1, result.Value.Count);
+            Assert.HasCount(1, result.Value);
             Assert.AreEqual("daily", result.Value[0].JobName);
             Assert.AreEqual(now, result.Value[0].JobEventTime);
             Assert.AreEqual(now.AddHours(1), result.Value[0].JobScheduledTime);
@@ -266,7 +266,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var result = await client.GetMessagesAsync(Guid.NewGuid());
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(1, result.Value.Items.Count);
+            Assert.HasCount(1, result.Value.Items);
             Assert.AreEqual("msg-1", result.Value.Items[0].QueueId);
             Assert.AreEqual(50, result.Value.TotalCount);
             Assert.AreEqual(0, result.Value.PageIndex);
@@ -388,7 +388,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var result = await client.GetMessageHeadersAsync(Guid.NewGuid(), "msg-1");
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(2, result.Value.Headers.Count);
+            Assert.HasCount(2, result.Value.Headers);
             Assert.AreEqual("val1", result.Value.Headers["key1"]);
         }
 
@@ -406,7 +406,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var result = await client.GetErrorRetriesAsync(Guid.NewGuid(), "msg-1");
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(1, result.Value.Count);
+            Assert.HasCount(1, result.Value);
             Assert.AreEqual(1, result.Value[0].ErrorTrackingId);
             Assert.AreEqual("System.Exception", result.Value[0].ExceptionType);
             Assert.AreEqual(3, result.Value[0].RetryCount);
@@ -429,7 +429,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var result = await client.GetStaleMessagesAsync(Guid.NewGuid());
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(1, result.Value.Items.Count);
+            Assert.HasCount(1, result.Value.Items);
             Assert.AreEqual("stale-1", result.Value.Items[0].QueueId);
             Assert.AreEqual(5, result.Value.TotalCount);
         }
@@ -451,7 +451,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
             var result = await client.GetErrorsAsync(Guid.NewGuid());
 
             Assert.IsTrue(result.Success);
-            Assert.AreEqual(1, result.Value.Items.Count);
+            Assert.HasCount(1, result.Value.Items);
             Assert.AreEqual("msg-1", result.Value.Items[0].QueueId);
             Assert.AreEqual("boom", result.Value.Items[0].LastException);
             Assert.AreEqual(10, result.Value.TotalCount);

--- a/Source/DotNetWorkQueue.Dashboard.Client.Tests/ModelTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Client.Tests/ModelTests.cs
@@ -150,7 +150,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 Headers = headers
             };
 
-            Assert.AreEqual(2, sut.Headers.Count);
+            Assert.HasCount(2, sut.Headers);
             Assert.AreEqual("v1", sut.Headers["h1"]);
         }
 
@@ -182,7 +182,7 @@ namespace DotNetWorkQueue.Dashboard.Client.Tests
                 PageSize = 25
             };
 
-            Assert.AreEqual(2, sut.Items.Count);
+            Assert.HasCount(2, sut.Items);
             Assert.AreEqual(100, sut.TotalCount);
             Assert.AreEqual(2, sut.PageIndex);
             Assert.AreEqual(25, sut.PageSize);

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/MainLayoutTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/MainLayoutTests.cs
@@ -69,7 +69,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Layout
 
             var cut = Render<MainLayout>();
 
-            Assert.IsFalse(cut.Markup.Contains("Sign out"));
+            Assert.DoesNotContain("Sign out", cut.Markup);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
@@ -58,7 +58,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             var cut = Render<Login>();
 
-            Assert.IsFalse(cut.Markup.Contains("Invalid username or password."));
+            Assert.DoesNotContain("Invalid username or password.", cut.Markup);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
@@ -53,7 +53,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
 
             var cut = RenderHistoryTab(api, snackbar, readOnly: true);
 
-            Assert.IsFalse(cut.Markup.Contains("Purge History"));
+            Assert.DoesNotContain("Purge History", cut.Markup);
         }
 
         [TestMethod]
@@ -64,7 +64,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
 
             var cut = RenderHistoryTab(api, snackbar);
 
-            Assert.IsFalse(cut.Markup.Contains("Purge History"));
+            Assert.DoesNotContain("Purge History", cut.Markup);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/ConfigValidationTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/ConfigValidationTests.cs
@@ -48,7 +48,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = DashboardConfigParser.ParseSources(config);
 
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
             Assert.AreEqual("Local", result[0].Name);
             Assert.AreEqual("http://localhost:5000", result[0].BaseUrl);
         }
@@ -66,7 +66,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = DashboardConfigParser.ParseSources(config);
 
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
         }
 
         [TestMethod]
@@ -81,7 +81,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = DashboardConfigParser.ParseSources(config);
 
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
             Assert.AreEqual("my-secret-key", result[0].ApiKey);
         }
 
@@ -96,7 +96,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = DashboardConfigParser.ParseSources(config);
 
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
             Assert.IsNull(result[0].ApiKey);
         }
 

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/MultiSourceDashboardApiClientTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/MultiSourceDashboardApiClientTests.cs
@@ -111,7 +111,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = sut.GetAllSources();
 
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
             Assert.AreEqual("Local", result[0].Name);
             Assert.AreEqual("Production", result[1].Name);
         }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceHealthMonitorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceHealthMonitorTests.cs
@@ -71,7 +71,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             var result = sut.GetAllHealth();
 
             Assert.IsNotNull(result);
-            Assert.IsFalse(result.Any());
+            Assert.IsEmpty(result);
         }
 
         [TestMethod]
@@ -89,7 +89,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = sut.GetHealth(source.Slug);
             Assert.AreEqual(SourceHealthStatus.Healthy, result.Status);
-            Assert.IsTrue(result.LastChecked >= before);
+            Assert.IsGreaterThanOrEqualTo(before, result.LastChecked);
             Assert.IsNull(result.ErrorMessage);
         }
 
@@ -175,7 +175,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             await sut.PollAllSourcesAsync(CancellationToken.None);
 
             var all = sut.GetAllHealth();
-            Assert.AreEqual(2, all.Count);
+            Assert.HasCount(2, all);
             Assert.AreEqual(SourceHealthStatus.Healthy, all[source1.Slug].Status);
             Assert.AreEqual(SourceHealthStatus.Unhealthy, all[source2.Slug].Status);
         }
@@ -203,24 +203,24 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             await sut.PollAllSourcesAsync(CancellationToken.None);
 
             // Verify no log call was made for same-state poll
-            Assert.IsFalse(logger.ReceivedCalls().Any());
+            Assert.IsEmpty(logger.ReceivedCalls());
 
             // Third poll: unhealthy (transition Healthy -> Unhealthy, should log)
             shouldThrow = true;
             await sut.PollAllSourcesAsync(CancellationToken.None);
 
             // Verify a log call was made for the transition
-            Assert.IsTrue(logger.ReceivedCalls().Any());
+            Assert.IsNotEmpty(logger.ReceivedCalls());
 
             // Fourth poll: still unhealthy (no transition, should NOT log)
             logger.ClearReceivedCalls();
             await sut.PollAllSourcesAsync(CancellationToken.None);
-            Assert.IsFalse(logger.ReceivedCalls().Any());
+            Assert.IsEmpty(logger.ReceivedCalls());
 
             // Fifth poll: recovery (Unhealthy -> Healthy, should log)
             shouldThrow = false;
             await sut.PollAllSourcesAsync(CancellationToken.None);
-            Assert.IsTrue(logger.ReceivedCalls().Any());
+            Assert.IsNotEmpty(logger.ReceivedCalls());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceRegistryTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceRegistryTests.cs
@@ -44,7 +44,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
 
             var result = registry.GetAll();
 
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/SimpleHistoryTest.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/SimpleHistoryTest.cs
@@ -101,16 +101,16 @@ namespace DotNetWorkQueue.IntegrationTests.Shared.History.Implementation
                             var historyQuery = adminContainer.GetInstance<IQueryMessageHistory>();
 
                             var totalCount = historyQuery.GetCount(null);
-                            Assert.IsTrue(totalCount >= messageCount,
+                            Assert.IsGreaterThanOrEqualTo(messageCount, totalCount,
                                 $"Expected at least {messageCount} history records, got {totalCount}");
 
                             var completeCount = historyQuery.GetCount(MessageHistoryStatus.Complete);
-                            Assert.IsTrue(completeCount >= messageCount,
+                            Assert.IsGreaterThanOrEqualTo(messageCount, completeCount,
                                 $"Expected at least {messageCount} completed records, got {completeCount}");
 
                             var records = historyQuery.Get(0, 100, null);
                             Assert.IsNotNull(records);
-                            Assert.IsTrue(records.Count >= messageCount);
+                            Assert.IsGreaterThanOrEqualTo(messageCount, records.Count);
 
                             foreach (var record in records)
                             {

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/Producer/Implementation/SimpleProducerWithTraceVerification.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/Producer/Implementation/SimpleProducerWithTraceVerification.cs
@@ -49,7 +49,7 @@ namespace DotNetWorkQueue.IntegrationTests.Shared.Producer.Implementation
                             }
 
                             // Verify trace activities were collected
-                            Assert.IsTrue(trace.CollectedActivities.Count > 0,
+                            Assert.IsNotEmpty(trace.CollectedActivities,
                                 "Expected at least one trace activity to be collected, but none were recorded.");
 
                             var activityNames = trace.CollectedActivities.Select(a => a.OperationName).ToList();

--- a/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/NodeDiscoveryTests.cs
+++ b/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/NodeDiscoveryTests.cs
@@ -80,7 +80,7 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.T
                 Assert.IsTrue(fired, "node B must receive RemoteCountChanged from node A within 10 seconds");
 
                 // Node B's aggregate count should reflect node A's bump.
-                Assert.IsTrue(nodeB.Sync.GetCurrentTaskCount() >= 1,
+                Assert.IsGreaterThanOrEqualTo(1, nodeB.Sync.GetCurrentTaskCount(),
                     "node B should see node A's remote task count");
             }
         }
@@ -109,7 +109,7 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.T
                     Assert.IsTrue(discovered, "node B must see node A's count before we test disposal");
 
                     var countBeforeDispose = nodeB.Sync.GetCurrentTaskCount();
-                    Assert.IsTrue(countBeforeDispose >= 1, "should have a remote count to decay");
+                    Assert.IsGreaterThanOrEqualTo(1, countBeforeDispose, "should have a remote count to decay");
 
                     // Dispose node A — node B should observe it drop off the remote list.
                     nodeA.Dispose();
@@ -125,7 +125,7 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.T
                         Thread.Sleep(100);
                     }
 
-                    Assert.IsTrue(countAfterDispose < countBeforeDispose,
+                    Assert.IsLessThan(countBeforeDispose, countAfterDispose,
                         "node B's aggregate count should drop after node A is disposed (RemovedNode decay)");
                 }
                 finally

--- a/Source/DotNetWorkQueue.Tests/ASendJobToQueueTests.cs
+++ b/Source/DotNetWorkQueue.Tests/ASendJobToQueueTests.cs
@@ -342,7 +342,7 @@ namespace DotNetWorkQueue.Tests
                     ((m, w) => Console.WriteLine()));
 
             // Should have deleted the errored job and retried
-            Assert.IsTrue(handler.DeleteJobCallCount >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, handler.DeleteJobCallCount);
             Assert.AreEqual(JobQueuedStatus.Success, result.Status);
         }
 

--- a/Source/DotNetWorkQueue.Tests/Admin/AdminApiTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Admin/AdminApiTests.cs
@@ -21,7 +21,7 @@ namespace DotNetWorkQueue.Tests.Admin
         public void Connections_Initially_Empty()
         {
             var api = Create();
-            Assert.AreEqual(0, api.Connections.Count);
+            Assert.IsEmpty(api.Connections);
         }
 
         [TestMethod]
@@ -42,7 +42,7 @@ namespace DotNetWorkQueue.Tests.Admin
             var connection = new QueueConnection("test", "connection");
             var id = api.AddQueueConnection(container, connection);
 
-            Assert.AreEqual(1, api.Connections.Count);
+            Assert.HasCount(1, api.Connections);
             Assert.IsTrue(api.Connections.ContainsKey(id));
             Assert.AreSame(connection, api.Connections[id].Item2);
             Assert.AreSame(container, api.Connections[id].Item1);
@@ -60,7 +60,7 @@ namespace DotNetWorkQueue.Tests.Admin
             var id2 = api.AddQueueConnection(container, connection2);
 
             Assert.AreNotEqual(id1, id2);
-            Assert.AreEqual(2, api.Connections.Count);
+            Assert.HasCount(2, api.Connections);
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace DotNetWorkQueue.Tests.Admin
             api.AddQueueConnection(container, connection);
             api.Dispose();
 
-            Assert.AreEqual(0, api.Connections.Count);
+            Assert.IsEmpty(api.Connections);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Tests/Configuration/QueueDelayTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Configuration/QueueDelayTests.cs
@@ -19,7 +19,7 @@ namespace DotNetWorkQueue.Tests.Configuration
         {
             var test = GetConfiguration();
             test.Add(TimeSpan.MaxValue);
-            Assert.AreEqual(1, test.Count());
+            Assert.HasCount(1, test);
         }
         [TestMethod]
         public void Test_DefaultNotReadOnly()

--- a/Source/DotNetWorkQueue.Tests/Configuration/QueueDelayTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Configuration/QueueDelayTests.cs
@@ -19,7 +19,7 @@ namespace DotNetWorkQueue.Tests.Configuration
         {
             var test = GetConfiguration();
             test.Add(TimeSpan.MaxValue);
-            Assert.IsTrue(test.Count() == 1);
+            Assert.AreEqual(1, test.Count());
         }
         [TestMethod]
         public void Test_DefaultNotReadOnly()

--- a/Source/DotNetWorkQueue.Tests/Factory/RetryInformationFactoryTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Factory/RetryInformationFactoryTests.cs
@@ -23,7 +23,7 @@ namespace DotNetWorkQueue.Tests.Factory
 
             Assert.AreEqual(info.ExceptionType, t);
             Assert.AreEqual(info.Times, times);
-            Assert.AreEqual(info.MaxRetries, times.Count);
+            Assert.HasCount(info.MaxRetries, times);
         }
         [TestMethod]
         public void Create_Null_Params_Fails()

--- a/Source/DotNetWorkQueue.Tests/Factory/WorkerNameFactoryTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Factory/WorkerNameFactoryTests.cs
@@ -37,7 +37,7 @@ namespace DotNetWorkQueue.Tests.Factory
                 }).Start();
             }
             resetEvent.WaitOne();
-            Assert.AreEqual(numThreads, names.Count);
+            Assert.HasCount(numThreads, names);
         }
         private IWorkerNameFactory Create()
         {

--- a/Source/DotNetWorkQueue.Tests/IoC/ContainerWrapperTests.cs
+++ b/Source/DotNetWorkQueue.Tests/IoC/ContainerWrapperTests.cs
@@ -77,7 +77,7 @@ namespace DotNetWorkQueue.Tests.IoC
         {
             using (var wrapper = new ContainerWrapper(new Container()))
             {
-                Assert.AreEqual(0, wrapper.TypesThatCanBeSuppressed.Count);
+                Assert.IsEmpty(wrapper.TypesThatCanBeSuppressed);
             }
         }
 
@@ -327,7 +327,7 @@ namespace DotNetWorkQueue.Tests.IoC
             using (var wrapper = new ContainerWrapper(new Container()))
             {
                 wrapper.AddTypeThatNeedsWarningSuppression(typeof(ITestService));
-                Assert.IsTrue(wrapper.TypesThatCanBeSuppressed.Contains(typeof(ITestService)));
+                Assert.Contains(typeof(ITestService), wrapper.TypesThatCanBeSuppressed);
             }
         }
 
@@ -338,7 +338,7 @@ namespace DotNetWorkQueue.Tests.IoC
             {
                 wrapper.AddTypeThatNeedsWarningSuppression(typeof(ITestService));
                 wrapper.AddTypeThatNeedsWarningSuppression(typeof(ITestService));
-                Assert.AreEqual(1, wrapper.TypesThatCanBeSuppressed.Count);
+                Assert.HasCount(1, wrapper.TypesThatCanBeSuppressed);
             }
         }
 

--- a/Source/DotNetWorkQueue.Tests/IoC/CreateContainerTest.cs
+++ b/Source/DotNetWorkQueue.Tests/IoC/CreateContainerTest.cs
@@ -28,7 +28,7 @@ namespace DotNetWorkQueue.Tests.IoC
             // Assert
             Container container = c.Container;
             var results = Analyzer.Analyze(container);
-            Assert.IsFalse(results.Any(), Environment.NewLine +
+            Assert.IsEmpty(results, Environment.NewLine +
                                         string.Join(Environment.NewLine,
                                             from result in results
                                             select result.Description));
@@ -43,7 +43,7 @@ namespace DotNetWorkQueue.Tests.IoC
             // Assert
             Container container = c.Container;
             var results = Analyzer.Analyze(container);
-            Assert.IsFalse(results.Any(), Environment.NewLine +
+            Assert.IsEmpty(results, Environment.NewLine +
                                         string.Join(Environment.NewLine,
                                             from result in results
                                             select result.Description));
@@ -62,7 +62,7 @@ namespace DotNetWorkQueue.Tests.IoC
             var results = Analyzer.Analyze(container)
                 .Where(r => r.DiagnosticType != DiagnosticType.SingleResponsibilityViolation)
                 .ToList();
-            Assert.IsFalse(results.Any(), Environment.NewLine +
+            Assert.IsEmpty(results, Environment.NewLine +
                                         string.Join(Environment.NewLine,
                                             from result in results
                                             select result.Description));

--- a/Source/DotNetWorkQueue.Tests/JobScheduler/JobScheduleTests.cs
+++ b/Source/DotNetWorkQueue.Tests/JobScheduler/JobScheduleTests.cs
@@ -98,7 +98,7 @@ namespace DotNetWorkQueue.Tests.JobScheduler
             var now = DateTimeOffset.UtcNow;
             var schedule = new JobSchedule("* * * * *", () => now);
             var next = schedule.Next();
-            Assert.IsTrue(next > now);
+            Assert.IsGreaterThan(now, next);
         }
 
         [TestMethod]
@@ -107,7 +107,7 @@ namespace DotNetWorkQueue.Tests.JobScheduler
             var now = DateTimeOffset.UtcNow;
             var schedule = new JobSchedule("*/10 * * * * *", () => now);
             var next = schedule.Next();
-            Assert.IsTrue(next > now);
+            Assert.IsGreaterThan(now, next);
         }
 
         [TestMethod]
@@ -116,7 +116,7 @@ namespace DotNetWorkQueue.Tests.JobScheduler
             var after = new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
             var schedule = new JobSchedule("*/5 * * * *", () => after);
             var next = schedule.Next(after);
-            Assert.IsTrue(next > after);
+            Assert.IsGreaterThan(after, next);
         }
 
         // --- Previous() behavior ---
@@ -128,7 +128,7 @@ namespace DotNetWorkQueue.Tests.JobScheduler
             var schedule = new JobSchedule("* * * * *", () => now);
             var prev = schedule.Previous();
             Assert.IsNotNull(prev);
-            Assert.IsTrue(prev.Value <= now);
+            Assert.IsLessThanOrEqualTo(now, prev.Value);
         }
 
         [TestMethod]
@@ -138,7 +138,7 @@ namespace DotNetWorkQueue.Tests.JobScheduler
             var schedule = new JobSchedule("* * * * *", () => before);
             var prev = schedule.Previous(before);
             Assert.IsNotNull(prev);
-            Assert.IsTrue(prev.Value <= before);
+            Assert.IsLessThanOrEqualTo(before, prev.Value);
         }
 
         // --- PR comment 4: configurable lookback window ---

--- a/Source/DotNetWorkQueue.Tests/Messages/MessageTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Messages/MessageTests.cs
@@ -29,7 +29,7 @@ namespace DotNetWorkQueue.Tests.Messages
             var headers = fixture.Create<Dictionary<string, object>>();
             var test = new Message(data, headers);
 
-            Assert.AreEqual(headers.Count, test.Headers.Count);
+            Assert.HasCount(headers.Count, test.Headers);
             CollectionAssert.AreEquivalent((System.Collections.ICollection)test.Headers, (System.Collections.ICollection)headers);
             Assert.AreNotSame(headers, test.Headers);
         }

--- a/Source/DotNetWorkQueue.Tests/Metrics/Net/MetricsNetTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Metrics/Net/MetricsNetTests.cs
@@ -239,8 +239,8 @@ namespace DotNetWorkQueue.Tests.Metrics.Net
             var test = Create();
             var snapshot = test.GetCollectedMetrics();
             Assert.IsNotNull(snapshot);
-            Assert.AreEqual(0, snapshot.Counters.Count);
-            Assert.AreEqual(0, snapshot.Meters.Count);
+            Assert.IsEmpty(snapshot.Counters);
+            Assert.IsEmpty(snapshot.Meters);
         }
 
         [TestMethod]
@@ -283,10 +283,10 @@ namespace DotNetWorkQueue.Tests.Metrics.Net
             meter1.Mark();
 
             var snapshot = test.GetCollectedMetrics();
-            Assert.AreEqual(2, snapshot.Counters.Count);
+            Assert.HasCount(2, snapshot.Counters);
             Assert.AreEqual(1, snapshot.Counters["counter-a"]);
             Assert.AreEqual(5, snapshot.Counters["counter-b"]);
-            Assert.AreEqual(1, snapshot.Meters.Count);
+            Assert.HasCount(1, snapshot.Meters);
             Assert.AreEqual(1, snapshot.Meters["meter-a"]);
         }
 

--- a/Source/DotNetWorkQueue.Tests/Metrics/NoOp/MetricsNoOpTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Metrics/NoOp/MetricsNoOpTests.cs
@@ -89,8 +89,8 @@ namespace DotNetWorkQueue.Tests.Metrics.NoOp
             var test = Create();
             var result = test.GetCollectedMetrics();
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Counters.Count);
-            Assert.AreEqual(0, result.Meters.Count);
+            Assert.IsEmpty(result.Counters);
+            Assert.IsEmpty(result.Meters);
         }
 
         private MetricsNoOp Create()

--- a/Source/DotNetWorkQueue.Tests/Queue/AddStandardMessageHeadersTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/AddStandardMessageHeadersTests.cs
@@ -49,9 +49,9 @@ namespace DotNetWorkQueue.Tests.Queue
             sut.AddHeaders(message, Substitute.For<IAdditionalMessageData>());
 
             var stamped = (string)message.Headers["Queue-MessageBodyType"];
-            Assert.IsFalse(stamped.Contains("Version="));
-            Assert.IsFalse(stamped.Contains("Culture="));
-            Assert.IsFalse(stamped.Contains("PublicKeyToken="));
+            Assert.DoesNotContain("Version=", stamped);
+            Assert.DoesNotContain("Culture=", stamped);
+            Assert.DoesNotContain("PublicKeyToken=", stamped);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Tests/Queue/BaseMonitorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/BaseMonitorTests.cs
@@ -69,7 +69,7 @@ namespace DotNetWorkQueue.Tests.Queue
                 test.Start();
                 Thread.Sleep(2000);
             }
-            Assert.AreEqual(2, action.ReceivedCalls().Count());
+            Assert.HasCount(2, action.ReceivedCalls());
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Tests/Queue/QueryMessageHistoryNoOpTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/QueryMessageHistoryNoOpTests.cs
@@ -13,7 +13,7 @@ namespace DotNetWorkQueue.Tests.Queue
         {
             var test = Create();
             var result = test.Get(0, 10, null);
-            Assert.AreEqual(0, result.Count);
+            Assert.IsEmpty(result);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Tests/TaskScheduling/SchedulerInitTests.cs
+++ b/Source/DotNetWorkQueue.Tests/TaskScheduling/SchedulerInitTests.cs
@@ -23,7 +23,7 @@ namespace DotNetWorkQueue.Tests.TaskScheduling
             // Assert
             Container container = c.Container;
             var results = Analyzer.Analyze(container);
-            Assert.IsFalse(results.Any(), Environment.NewLine +
+            Assert.IsEmpty(results, Environment.NewLine +
                                         string.Join(Environment.NewLine,
                                             from result in results
                                             select result.Description));

--- a/Source/DotNetWorkQueue.Tests/TaskScheduling/WorkGroupTests.cs
+++ b/Source/DotNetWorkQueue.Tests/TaskScheduling/WorkGroupTests.cs
@@ -118,7 +118,7 @@ namespace DotNetWorkQueue.Tests.TaskScheduling
             tests.Add(test, test);
             tests.Add(test2, test2);
 
-            Assert.AreEqual(2, tests.Count);
+            Assert.HasCount(2, tests);
             Assert.AreEqual(test, tests[test]);
             Assert.AreEqual(test2, tests[test2]);
             Assert.AreNotEqual(test, tests[test2]);
@@ -133,7 +133,7 @@ namespace DotNetWorkQueue.Tests.TaskScheduling
                 var test = new WorkGroup(string.Concat(Name, i.ToString()), i + 1);
                 tests.Add(test, test);
             }
-            Assert.AreEqual(100000, tests.Count);
+            Assert.HasCount(100000, tests);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Tests/Time/LocalMachineTimeTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Time/LocalMachineTimeTests.cs
@@ -32,7 +32,7 @@ namespace DotNetWorkQueue.Tests.Time
             var test = Create();
             test.GetCurrentUtcDate();
             var offSet = test.GetCurrentOffset;
-            Assert.IsTrue(offSet.Duration() < TimeSpan.FromMilliseconds(1),
+            Assert.IsLessThan(TimeSpan.FromMilliseconds(1), offSet.Duration(),
                 $"Expected offset near zero but was {offSet}");
         }
 

--- a/Source/DotNetWorkQueue.Tests/Time/SntpTimeTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Time/SntpTimeTests.cs
@@ -77,8 +77,8 @@ namespace DotNetWorkQueue.Tests.Time
 
             Assert.AreEqual(1, fake.GetTimeCallCount);
             Assert.AreEqual(DateTimeKind.Utc, result.Kind);
-            Assert.IsTrue(result >= before.AddSeconds(29));
-            Assert.IsTrue(result <= after.AddSeconds(31));
+            Assert.IsGreaterThanOrEqualTo(before.AddSeconds(29), result);
+            Assert.IsLessThanOrEqualTo(after.AddSeconds(31), result);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/CreationScopeTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/CreationScopeTests.cs
@@ -16,9 +16,9 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             using (var scope = Create())
             {
                 scope.AddScopedObject(CreateClear());
-                Assert.AreEqual(1, scope.ContainedClears.Count);
+                Assert.HasCount(1, scope.ContainedClears);
                 scope.AddScopedObject(CreateClear());
-                Assert.AreEqual(2, scope.ContainedClears.Count);
+                Assert.HasCount(2, scope.ContainedClears);
             }
         }
 
@@ -28,9 +28,9 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             using (var scope = Create())
             {
                 scope.AddScopedObject(createDisposable());
-                Assert.AreEqual(1, scope.ContainedDisposables.Count);
+                Assert.HasCount(1, scope.ContainedDisposables);
                 scope.AddScopedObject(createDisposable());
-                Assert.AreEqual(2, scope.ContainedDisposables.Count);
+                Assert.HasCount(2, scope.ContainedDisposables);
             }
         }
 

--- a/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/CreationScopeTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/CreationScopeTests.cs
@@ -16,9 +16,9 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             using (var scope = Create())
             {
                 scope.AddScopedObject(CreateClear());
-                Assert.IsTrue(scope.ContainedClears.Count == 1);
+                Assert.AreEqual(1, scope.ContainedClears.Count);
                 scope.AddScopedObject(CreateClear());
-                Assert.IsTrue(scope.ContainedClears.Count == 2);
+                Assert.AreEqual(2, scope.ContainedClears.Count);
             }
         }
 
@@ -28,9 +28,9 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             using (var scope = Create())
             {
                 scope.AddScopedObject(createDisposable());
-                Assert.IsTrue(scope.ContainedDisposables.Count == 1);
+                Assert.AreEqual(1, scope.ContainedDisposables.Count);
                 scope.AddScopedObject(createDisposable());
-                Assert.IsTrue(scope.ContainedDisposables.Count == 2);
+                Assert.AreEqual(2, scope.ContainedDisposables.Count);
             }
         }
 

--- a/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/WriteMessageHistoryHandlerTests.cs
@@ -44,7 +44,7 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             Assert.AreEqual("route", record.Route);
             Assert.AreEqual("MyType", record.MessageType);
             Assert.AreEqual(0, record.RetryCount);
-            Assert.IsTrue(record.EnqueuedUtc <= DateTime.UtcNow);
+            Assert.IsLessThanOrEqualTo(DateTime.UtcNow, record.EnqueuedUtc);
         }
 
         [TestMethod]
@@ -99,7 +99,7 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             var record = records["q1"];
             Assert.AreEqual(MessageHistoryStatus.Processing, record.Status);
             Assert.IsNotNull(record.StartedUtc);
-            Assert.IsTrue(record.StartedUtc.Value <= DateTime.UtcNow);
+            Assert.IsLessThanOrEqualTo(DateTime.UtcNow, record.StartedUtc.Value);
         }
 
         [TestMethod]
@@ -134,7 +134,7 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             Assert.AreEqual(MessageHistoryStatus.Complete, record.Status);
             Assert.IsNotNull(record.CompletedUtc);
             Assert.IsNotNull(record.DurationMs);
-            Assert.IsTrue(record.DurationMs.Value >= 0);
+            Assert.IsGreaterThanOrEqualTo(0, record.DurationMs.Value);
         }
 
         [TestMethod]
@@ -185,7 +185,7 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             Assert.AreEqual("NullReferenceException", record.ExceptionText);
             Assert.IsNotNull(record.CompletedUtc);
             Assert.IsNotNull(record.DurationMs);
-            Assert.IsTrue(record.DurationMs.Value >= 0);
+            Assert.IsGreaterThanOrEqualTo(0, record.DurationMs.Value);
         }
 
         [TestMethod]
@@ -342,7 +342,7 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             Assert.AreEqual("corr1", record.CorrelationId);
             Assert.AreEqual("routeA", record.Route);
             Assert.AreEqual("MyMessage", record.MessageType);
-            Assert.IsTrue(record.EnqueuedUtc > DateTime.MinValue);
+            Assert.IsGreaterThan(DateTime.MinValue, record.EnqueuedUtc);
             Assert.IsNotNull(record.StartedUtc);
             Assert.IsNotNull(record.CompletedUtc);
             Assert.IsNotNull(record.DurationMs);

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
@@ -58,7 +58,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.CommandHandler
             var col = db.GetCollection<JobsTable>(tableNameHelper.JobTableName);
             var all = col.FindAll().ToList();
 
-            Assert.AreEqual(1, all.Count);
+            Assert.HasCount(1, all);
             Assert.AreEqual("TestJob", all[0].JobName);
             Assert.AreEqual(scheduledTime, all[0].JobScheduledTime);
             Assert.AreEqual(eventTime, all[0].JobEventTime);
@@ -90,7 +90,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.CommandHandler
             handler.Handle(command);
 
             var all = col.FindAll().ToList();
-            Assert.AreEqual(1, all.Count, "existing job should be updated, not duplicated");
+            Assert.HasCount(1, all, "existing job should be updated, not duplicated");
             Assert.AreEqual("ExistingJob", all[0].JobName);
             Assert.AreEqual(newScheduled, all[0].JobScheduledTime);
             Assert.AreEqual(newEvent, all[0].JobEventTime);
@@ -122,7 +122,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.CommandHandler
             handler.Handle(command);
 
             var all = col.FindAll().OrderBy(j => j.JobName).ToList();
-            Assert.AreEqual(2, all.Count);
+            Assert.HasCount(2, all);
 
             var first = all.Single(j => j.JobName == "FirstJob");
             Assert.AreEqual(firstScheduled, first.JobScheduledTime);

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/LiteDbJobSchemaTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/LiteDbJobSchemaTests.cs
@@ -19,7 +19,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
         {
             var schema = new LiteDbJobSchema();
             var tables = schema.GetSchema();
-            Assert.IsTrue(tables.Count > 0);
+            Assert.IsNotEmpty(tables);
         }
 
         [TestMethod]
@@ -27,7 +27,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
         {
             var schema = new LiteDbJobSchema();
             var tables = schema.GetSchema();
-            Assert.IsTrue(tables.Any(t => t is JobsTable));
+            Assert.Contains(t => t is JobsTable, tables);
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
         {
             var schema = new LiteDbJobSchema();
             var tables = schema.GetSchema();
-            Assert.AreEqual(1, tables.Count);
+            Assert.HasCount(1, tables);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/WriteMessageHistoryHandlerTests.cs
@@ -54,14 +54,14 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                 {
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var records = col.FindAll().ToList();
-                    Assert.AreEqual(1, records.Count);
+                    Assert.HasCount(1, records);
                     Assert.AreEqual("q1", records[0].QueueId);
                     Assert.AreEqual("c1", records[0].CorrelationId);
                     Assert.AreEqual("routeA", records[0].Route);
                     Assert.AreEqual("MyType", records[0].MessageType);
                     Assert.AreEqual((int)MessageHistoryStatus.Enqueued, records[0].Status);
                     Assert.AreEqual(0, records[0].RetryCount);
-                    Assert.IsTrue(records[0].EnqueuedUtc > 0);
+                    Assert.IsGreaterThan(0, records[0].EnqueuedUtc);
                 }
             }
         }
@@ -120,7 +120,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
                     Assert.AreEqual((int)MessageHistoryStatus.Processing, record.Status);
-                    Assert.IsTrue(record.StartedUtc > 0);
+                    Assert.IsGreaterThan(0, record.StartedUtc);
                 }
             }
         }
@@ -153,8 +153,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
                     Assert.AreEqual((int)MessageHistoryStatus.Complete, record.Status);
-                    Assert.IsTrue(record.CompletedUtc > 0);
-                    Assert.IsTrue(record.DurationMs >= 0);
+                    Assert.IsGreaterThan(0, record.CompletedUtc);
+                    Assert.IsGreaterThanOrEqualTo(0, record.DurationMs);
                 }
             }
         }
@@ -239,8 +239,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                     var record = col.FindAll().First();
                     Assert.AreEqual((int)MessageHistoryStatus.Error, record.Status);
                     Assert.AreEqual("Something went wrong", record.ExceptionText);
-                    Assert.IsTrue(record.CompletedUtc > 0);
-                    Assert.IsTrue(record.DurationMs >= 0);
+                    Assert.IsGreaterThan(0, record.CompletedUtc);
+                    Assert.IsGreaterThanOrEqualTo(0, record.DurationMs);
                 }
             }
         }
@@ -348,7 +348,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
                     Assert.AreEqual((int)MessageHistoryStatus.Deleted, record.Status);
-                    Assert.IsTrue(record.CompletedUtc > 0);
+                    Assert.IsGreaterThan(0, record.CompletedUtc);
                 }
             }
         }
@@ -380,7 +380,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                     var col = db.Database.GetCollection<HistoryTable>(tnh.HistoryName);
                     var record = col.FindAll().First();
                     Assert.AreEqual((int)MessageHistoryStatus.Expired, record.Status);
-                    Assert.IsTrue(record.CompletedUtc > 0);
+                    Assert.IsGreaterThan(0, record.CompletedUtc);
                 }
             }
         }

--- a/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Consumer/ConsumerRollBack.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Consumer/ConsumerRollBack.cs
@@ -141,7 +141,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Consumer
                             // Consumer disposed -- no crash
                         }
 
-                        Assert.IsTrue(processedCount >= 1,
+                        Assert.IsGreaterThanOrEqualTo(1, processedCount,
                             "at least one message should have been processed before stop");
                     }
                 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Dashboard/DashboardQueries.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Dashboard/DashboardQueries.cs
@@ -221,7 +221,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
 
-                Assert.AreEqual(3, result.Count);
+                Assert.HasCount(3, result);
                 foreach (var msg in result)
                 {
                     Assert.IsFalse(string.IsNullOrEmpty(msg.QueueId));
@@ -242,7 +242,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessagesQuery(0, 100, 0))
                     .GetAwaiter().GetResult();
 
-                Assert.AreEqual(2, result.Count);
+                Assert.HasCount(2, result);
                 foreach (var msg in result)
                 {
                     Assert.AreEqual(0, msg.Status);
@@ -262,7 +262,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessagesQuery(0, 100, 1))
                     .GetAwaiter().GetResult();
 
-                Assert.AreEqual(1, result.Count);
+                Assert.HasCount(1, result);
                 Assert.AreEqual(1, result[0].Status);
             });
         }
@@ -279,7 +279,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardMessagesQuery(0, 100, 2))
                     .GetAwaiter().GetResult();
 
-                Assert.AreEqual(0, result.Count);
+                Assert.IsEmpty(result);
             });
         }
 
@@ -300,7 +300,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var messages = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
-                Assert.AreEqual(1, messages.Count);
+                Assert.HasCount(1, messages);
 
                 var detailHandler =
                     container
@@ -347,7 +347,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var messages = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
-                Assert.AreEqual(1, messages.Count);
+                Assert.HasCount(1, messages);
 
                 var bodyHandler =
                     container
@@ -375,7 +375,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var messages = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
-                Assert.AreEqual(1, messages.Count);
+                Assert.HasCount(1, messages);
 
                 var headerHandler =
                     container
@@ -406,7 +406,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardJobsQuery())
                     .GetAwaiter().GetResult();
 
-                Assert.AreEqual(0, result.Count);
+                Assert.IsEmpty(result);
             });
         }
 
@@ -427,7 +427,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var messages = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, null))
                     .GetAwaiter().GetResult();
-                Assert.AreEqual(1, messages.Count);
+                Assert.HasCount(1, messages);
 
                 var deleteHandler =
                     container
@@ -479,7 +479,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var processing = listHandler
                     .HandleAsync(new GetDashboardMessagesQuery(0, 100, 1))
                     .GetAwaiter().GetResult();
-                Assert.AreEqual(1, processing.Count);
+                Assert.HasCount(1, processing);
 
                 var deleteHandler =
                     container
@@ -519,7 +519,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardStaleMessagesQuery(60, 0, 100))
                     .GetAwaiter().GetResult();
 
-                Assert.AreEqual(0, result.Count);
+                Assert.IsEmpty(result);
             });
         }
 
@@ -535,7 +535,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                 var result = handler.HandleAsync(new GetDashboardErrorMessagesQuery(0, 100))
                     .GetAwaiter().GetResult();
 
-                Assert.AreEqual(0, result.Count);
+                Assert.IsEmpty(result);
             });
         }
 
@@ -567,7 +567,7 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Dashboard
                     .HandleAsync(new GetDashboardErrorRetriesQuery(Guid.NewGuid().ToString()))
                     .GetAwaiter().GetResult();
 
-                Assert.AreEqual(0, result.Count);
+                Assert.IsEmpty(result);
             });
         }
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Inbox/PostgreSqlInboxBatchSendTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Inbox/PostgreSqlInboxBatchSendTests.cs
@@ -193,17 +193,17 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Inbox
             {
                 var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
                 Assert.IsFalse(result.HasErrors, "batch send reported errors");
-                Assert.AreEqual(batchSize, result.Count, "one result per message");
+                Assert.HasCount(batchSize, result, "one result per message");
 
                 var ids = new HashSet<long>();
                 for (var i = 0; i < result.Count; i++)
                 {
                     Assert.IsTrue(result[i].SentMessage.MessageId.HasValue, "each result must carry a message id");
                     var id = (long)result[i].SentMessage.MessageId.Id.Value;
-                    Assert.IsTrue(id > 0, "message id must be a positive value");
+                    Assert.IsGreaterThan(0, id, "message id must be a positive value");
                     ids.Add(id);
                 }
-                Assert.AreEqual(batchSize, ids.Count, "message ids must be distinct");
+                Assert.HasCount(batchSize, ids, "message ids must be distinct");
 
                 transaction.Commit();
             }
@@ -230,13 +230,13 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Inbox
             {
                 var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
                 Assert.IsFalse(result.HasErrors, "batch send reported errors");
-                Assert.AreEqual(batchSize, result.Count, "one result per message");
+                Assert.HasCount(batchSize, result, "one result per message");
 
                 long previous = 0;
                 for (var i = 0; i < result.Count; i++)
                 {
                     var id = (long)result[i].SentMessage.MessageId.Id.Value;
-                    Assert.IsTrue(id > previous,
+                    Assert.IsGreaterThan(previous, id,
                         $"recovered ids must be strictly increasing in input order across chunks (index {i}: {id} <= {previous})");
                     previous = id;
                 }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Outbox/PostgreSqlOutboxRetryBypassTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Outbox/PostgreSqlOutboxRetryBypassTests.cs
@@ -74,7 +74,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Outbox
             // slow CI hosts. If this proves flaky raise to 3000ms; DO NOT remove the
             // timing assertion -- it is the only integration-level pin against the
             // "retry decorator silently regressed" failure mode.
-            Assert.IsTrue(sw.ElapsedMilliseconds < 2000,
+            Assert.IsLessThan(2000, sw.ElapsedMilliseconds,
                 $"Caller-transaction Send took {sw.ElapsedMilliseconds}ms -- expected < 2000ms " +
                 "for single-attempt failure (3x retry chain would exceed this).");
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Outbox/PostgreSqlOutboxValidationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Outbox/PostgreSqlOutboxValidationTests.cs
@@ -56,7 +56,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Outbox
                 () => producer.RelationalProducer.Send(msg, wrongTx));
 
             // Validator's exception message must include the wrong DB name (PROJECT.md §Diagnostics).
-            Assert.IsTrue(ex.Message.IndexOf("postgres", StringComparison.Ordinal) >= 0,
+            Assert.IsGreaterThanOrEqualTo(0, ex.Message.IndexOf("postgres", StringComparison.Ordinal),
                 $"Expected exception message to mention 'postgres': {ex.Message}");
 
             // No partial write — queue MetaData table count must be 0.

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Producer/BatchSendCriteria.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Producer/BatchSendCriteria.cs
@@ -78,8 +78,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Producer
                         Assert.IsFalse(output.HasErrors, "batch send reported errors");
 
                         var ids = output.Select(m => Convert.ToInt64(m.SentMessage.MessageId.Id.Value)).ToList();
-                        Assert.AreEqual(count, ids.Count);
-                        Assert.AreEqual(count, ids.Distinct().Count(), "generated ids are not unique");
+                        Assert.HasCount(count, ids);
+                        Assert.HasCount(count, ids.Distinct(), "generated ids are not unique");
 
                         // Definitive id-order check: the OrderID stored for result[i].id must equal i.
                         // Load the whole QueueID -> OrderID map in one query rather than per-row.
@@ -167,7 +167,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Producer
 
                         var output = producer.Send(messages);
                         Assert.IsFalse(output.HasErrors);
-                        Assert.AreEqual(count, output.Count);
+                        Assert.HasCount(count, output);
                     }
                     new VerifyQueueData(queueName, oCreation.Options).Verify(count, null);
                 }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/BatchSizeSelectionTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/BatchSizeSelectionTests.cs
@@ -35,7 +35,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic.CommandHandler
         [TestMethod]
         public void SafeMax_IsPositive()
         {
-            Assert.IsTrue(SendMessageBatch.SafeMaxBatchSize >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, SendMessageBatch.SafeMaxBatchSize);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/SendMessageCommandHandlerAsyncForkSmokeTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/SendMessageCommandHandlerAsyncForkSmokeTests.cs
@@ -84,21 +84,21 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic.CommandHandler
             // to one of them.
             var forkStart = content.IndexOf("private async Task<long> HandleExternalTransactionAsync",
                 StringComparison.Ordinal);
-            Assert.IsTrue(forkStart >= 0, "HandleExternalTransactionAsync not found in source.");
+            Assert.IsGreaterThanOrEqualTo(0, forkStart, "HandleExternalTransactionAsync not found in source.");
             var forkEnd = content.IndexOf("\n        }\n", forkStart, StringComparison.Ordinal);
-            Assert.IsTrue(forkEnd >= 0,
+            Assert.IsGreaterThanOrEqualTo(0, forkEnd,
                 "Closing brace of HandleExternalTransactionAsync (column-8 '}' on its own line) not found.");
             var forkBody = content.Substring(forkStart, forkEnd - forkStart);
 
-            Assert.IsFalse(forkBody.Contains(".Commit()"),   "HandleExternalTransactionAsync must not call .Commit() on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".Rollback()"), "HandleExternalTransactionAsync must not call .Rollback() on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".Close()"),    "HandleExternalTransactionAsync must not call .Close() on the caller's connection.");
-            Assert.IsFalse(forkBody.Contains(".Dispose()"),  "HandleExternalTransactionAsync must not call .Dispose() on the caller's connection or transaction.");
+            Assert.DoesNotContain(".Commit()", forkBody,   "HandleExternalTransactionAsync must not call .Commit() on the caller's transaction.");
+            Assert.DoesNotContain(".Rollback()", forkBody, "HandleExternalTransactionAsync must not call .Rollback() on the caller's transaction.");
+            Assert.DoesNotContain(".Close()", forkBody,    "HandleExternalTransactionAsync must not call .Close() on the caller's connection.");
+            Assert.DoesNotContain(".Dispose()", forkBody,  "HandleExternalTransactionAsync must not call .Dispose() on the caller's connection or transaction.");
             // Async-specific lifecycle calls:
-            Assert.IsFalse(forkBody.Contains(".CommitAsync"),   "HandleExternalTransactionAsync must not call .CommitAsync on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".RollbackAsync"), "HandleExternalTransactionAsync must not call .RollbackAsync on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".CloseAsync"),    "HandleExternalTransactionAsync must not call .CloseAsync on the caller's connection.");
-            Assert.IsFalse(forkBody.Contains(".DisposeAsync"),  "HandleExternalTransactionAsync must not call .DisposeAsync on the caller's connection or transaction.");
+            Assert.DoesNotContain(".CommitAsync", forkBody,   "HandleExternalTransactionAsync must not call .CommitAsync on the caller's transaction.");
+            Assert.DoesNotContain(".RollbackAsync", forkBody, "HandleExternalTransactionAsync must not call .RollbackAsync on the caller's transaction.");
+            Assert.DoesNotContain(".CloseAsync", forkBody,    "HandleExternalTransactionAsync must not call .CloseAsync on the caller's connection.");
+            Assert.DoesNotContain(".DisposeAsync", forkBody,  "HandleExternalTransactionAsync must not call .DisposeAsync on the caller's connection or transaction.");
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/SendMessageCommandHandlerForkSmokeTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/SendMessageCommandHandlerForkSmokeTests.cs
@@ -98,16 +98,16 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic.CommandHandler
             // helpers, masking the actual call site if a future edit added a Commit /
             // Rollback / Close / Dispose call to one of them.
             var forkStart = content.IndexOf("private long HandleExternalTransaction", StringComparison.Ordinal);
-            Assert.IsTrue(forkStart >= 0, "HandleExternalTransaction not found in source.");
+            Assert.IsGreaterThanOrEqualTo(0, forkStart, "HandleExternalTransaction not found in source.");
             var forkEnd = content.IndexOf("\n        }\n", forkStart, StringComparison.Ordinal);
-            Assert.IsTrue(forkEnd >= 0,
+            Assert.IsGreaterThanOrEqualTo(0, forkEnd,
                 "Closing brace of HandleExternalTransaction (column-8 '}' on its own line) not found.");
             var forkBody = content.Substring(forkStart, forkEnd - forkStart);
 
-            Assert.IsFalse(forkBody.Contains(".Commit()"), "HandleExternalTransaction must not call .Commit() on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".Rollback()"), "HandleExternalTransaction must not call .Rollback() on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".Close()"), "HandleExternalTransaction must not call .Close() on the caller's connection.");
-            Assert.IsFalse(forkBody.Contains(".Dispose()"), "HandleExternalTransaction must not call .Dispose() on the caller's connection or transaction.");
+            Assert.DoesNotContain(".Commit()", forkBody, "HandleExternalTransaction must not call .Commit() on the caller's transaction.");
+            Assert.DoesNotContain(".Rollback()", forkBody, "HandleExternalTransaction must not call .Rollback() on the caller's transaction.");
+            Assert.DoesNotContain(".Close()", forkBody, "HandleExternalTransaction must not call .Close() on the caller's connection.");
+            Assert.DoesNotContain(".Dispose()", forkBody, "HandleExternalTransaction must not call .Dispose() on the caller's connection or transaction.");
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
@@ -94,7 +94,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic.CommandHandler
 
             fixture.Handler.Handle(command);
 
-            Assert.AreEqual(3, fixture.Parameters.Count);
+            Assert.HasCount(3, fixture.Parameters);
             // @JobName: AnsiString with the supplied name
             Assert.AreEqual("@JobName", fixture.Parameters[0].ParameterName);
             Assert.AreEqual(DbType.AnsiString, fixture.Parameters[0].DbType);

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/PostgreSqlJobSchemaTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/PostgreSqlJobSchemaTests.cs
@@ -17,7 +17,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var test = Create();
             var tables = test.GetSchema();
             Assert.IsNotNull(tables);
-            Assert.AreEqual(1, tables.Count);
+            Assert.HasCount(1, tables);
         }
 
         [TestMethod]
@@ -26,7 +26,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var test = Create();
             var table = (Table)test.GetSchema().Single();
 
-            Assert.AreEqual(3, table.Columns.Items.Count);
+            Assert.HasCount(3, table.Columns.Items);
 
             var jobEventTime = table.Columns.Items.FirstOrDefault(c => c.Name == "JobEventTime");
             Assert.IsNotNull(jobEventTime);
@@ -55,7 +55,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var pk = table.Constraints.FirstOrDefault(c => c.Type == ConstraintType.PrimaryKey);
             Assert.IsNotNull(pk);
             Assert.AreEqual("PK_" + tableNameHelper.JobTableName, pk.Name);
-            Assert.IsTrue(pk.Columns.Contains("JobName"));
+            Assert.Contains("JobName", pk.Columns);
             Assert.IsNotNull(table.PrimaryKey);
             Assert.IsTrue(table.PrimaryKey.Unique);
         }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/PostgreSqlRelationalProducerQueueTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/PostgreSqlRelationalProducerQueueTests.cs
@@ -174,7 +174,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             // so the message must NOT mention NpgsqlTransaction.
             StringAssert.Contains(ex.Message, "MyDb");
             StringAssert.Contains(ex.Message, "mydb");
-            Assert.IsFalse(ex.Message.Contains("NpgsqlTransaction"),
+            Assert.DoesNotContain("NpgsqlTransaction", ex.Message,
                 "Validator must fire before the NpgsqlTransaction cast guard.");
         }
 
@@ -262,7 +262,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
 
             Assert.IsInstanceOfType(captured, typeof(RelationalSendMessageCommandBatch));
             Assert.AreSame(transaction, ((RelationalSendMessageCommandBatch)captured).ExternalTransaction);
-            Assert.AreEqual(2, captured.Messages.Count);
+            Assert.HasCount(2, captured.Messages);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/QueueQueueConsumerConfigurationExtensionsTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/QueueQueueConsumerConfigurationExtensionsTests.cs
@@ -37,7 +37,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
 
             var result = config.GetUserParameters();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
             Assert.AreEqual("@p1", result[0].ParameterName);
         }
 
@@ -52,7 +52,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             config.SetUserParameters(parameters2);
 
             var result = config.GetUserParameters();
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
         }
 
         [TestMethod]
@@ -63,7 +63,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
 
             var result = config.GetUserParameters();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
         }
 
         [TestMethod]
@@ -74,7 +74,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             config.AddUserParameter(CreateParam("@p2"));
 
             var result = config.GetUserParameters();
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
         }
 
         [TestMethod]
@@ -99,7 +99,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
 
             var resultParams = config.GetUserParameters();
             Assert.IsNotNull(resultParams);
-            Assert.AreEqual(1, resultParams.Count);
+            Assert.HasCount(1, resultParams);
 
             var resultClause = config.GetUserClause();
             Assert.AreEqual("AND Col = @p1", resultClause);
@@ -120,7 +120,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
 
             // Factory should take precedence
             var resultParams = config.GetUserParameters();
-            Assert.AreEqual(1, resultParams.Count);
+            Assert.HasCount(1, resultParams);
             Assert.AreEqual("@factory", resultParams[0].ParameterName);
 
             var resultClause = config.GetUserClause();

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/RetrySqlPolicyCreationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/RetrySqlPolicyCreationTests.cs
@@ -42,7 +42,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var (container, policies) = CreateMocks();
             RetrySqlPolicyCreation.Register(container);
             // RetryCommandHandler and RetryCommandHandlerAsync map to the same key
-            Assert.AreEqual(2, policies.TransportDefinition.Count);
+            Assert.HasCount(2, policies.TransportDefinition);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/SqlServerMessageQueueSchemaTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/SqlServerMessageQueueSchemaTests.cs
@@ -28,7 +28,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             factory.Create().Returns(options);
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
-            Assert.IsTrue(tables.Any(item => item.Name == tableName.StatusName));
+            Assert.Contains(item => item.Name == tableName.StatusName, tables);
         }
 
         [TestMethod]
@@ -42,7 +42,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.StatusName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "testing"));
+            Assert.Contains(item => item.Name == "testing", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -57,7 +57,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.StatusName);
-            Assert.IsTrue(statusTable.Constraints.Any(item => item.Name == "ix_testing"));
+            Assert.Contains(item => item.Name == "ix_testing", statusTable.Constraints);
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "Priority"));
+            Assert.Contains(item => item.Name == "Priority", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -83,7 +83,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "Status"));
+            Assert.Contains(item => item.Name == "Status", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -96,7 +96,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "QueueProcessTime"));
+            Assert.Contains(item => item.Name == "QueueProcessTime", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -109,7 +109,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "HeartBeat"));
+            Assert.Contains(item => item.Name == "HeartBeat", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -122,7 +122,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "ExpirationTime"));
+            Assert.Contains(item => item.Name == "ExpirationTime", statusTable.Columns.Items);
         }
 
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Schema/ColumnsTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Schema/ColumnsTests.cs
@@ -16,7 +16,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Schema
         {
             var test = new Columns();
             test.Add(new Column("testing", ColumnTypes.Bigint, true));
-            Assert.IsTrue(test.Items.Any(item => item.Name == "testing"));
+            Assert.Contains(item => item.Name == "testing", test.Items);
         }
         [TestMethod]
         public void Remove_Column()
@@ -25,7 +25,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Schema
             var column = new Column("testing", ColumnTypes.Bigint, true);
             test.Add(column);
             test.Remove(column);
-            Assert.IsFalse(test.Items.Any(item => item.Name == "testing"));
+            Assert.DoesNotContain(item => item.Name == "testing", test.Items);
         }
         [TestMethod]
         public void Script()

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Schema/TableTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Schema/TableTests.cs
@@ -51,7 +51,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Schema
             var c = new Column("testing", ColumnTypes.Bigint, true);
             var test = new Table("test");
             test.Columns.Add(c);
-            Assert.IsTrue(test.Columns.Items.Any(item => item.Name == "testing"));
+            Assert.Contains(item => item.Name == "testing", test.Columns.Items);
         }
         [TestMethod]
         public void Create_Script()

--- a/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Basic/Time/SntpUnixTimeTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Basic/Time/SntpUnixTimeTests.cs
@@ -14,7 +14,7 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
         {
             var test = Create();
             var result = test.GetCurrentUnixTimestampMilliseconds();
-            Assert.IsTrue(result > 0);
+            Assert.IsGreaterThan(0, result);
         }
 
         [TestMethod]
@@ -27,7 +27,7 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
             var localUnixMs = (long)(DateTime.UtcNow - epoch).TotalMilliseconds;
 
             // NTP time should be within 5 seconds of local time
-            Assert.IsTrue(Math.Abs(result - localUnixMs) < 5000,
+            Assert.IsLessThan(5000, Math.Abs(result - localUnixMs),
                 $"NTP time {result} differs from local time {localUnixMs} by more than 5 seconds");
         }
 
@@ -39,7 +39,7 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
             var second = test.GetCurrentUnixTimestampMilliseconds();
 
             // Second call should use cached offset, so results should be very close
-            Assert.IsTrue(Math.Abs(second - first) < 1000,
+            Assert.IsLessThan(1000, Math.Abs(second - first),
                 $"First call {first} and second call {second} differ by more than 1 second");
         }
 
@@ -53,7 +53,7 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
 
             var expectedDifferenceMs = (long)difference.TotalMilliseconds;
             // Allow small tolerance for elapsed time between calls
-            Assert.IsTrue(Math.Abs(result - current - expectedDifferenceMs) < 1000,
+            Assert.IsLessThan(1000, Math.Abs(result - current - expectedDifferenceMs),
                 $"Expected ~{expectedDifferenceMs}ms difference, got {result - current}ms");
         }
 
@@ -67,7 +67,7 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
 
             var expectedDifferenceMs = (long)difference.TotalMilliseconds;
             // Allow small tolerance for elapsed time between calls
-            Assert.IsTrue(Math.Abs(current - result - expectedDifferenceMs) < 1000,
+            Assert.IsLessThan(1000, Math.Abs(current - result - expectedDifferenceMs),
                 $"Expected ~{expectedDifferenceMs}ms difference, got {current - result}ms");
         }
 
@@ -79,7 +79,7 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
 
             // Should be within 5 seconds of local UTC time
             var diff = Math.Abs((result - DateTime.UtcNow).TotalSeconds);
-            Assert.IsTrue(diff < 5,
+            Assert.IsLessThan(5, diff,
                 $"NTP date differs from local UTC by {diff} seconds");
         }
 

--- a/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/Lua/DashboardUpdateMessageBodyLuaTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/Lua/DashboardUpdateMessageBodyLuaTests.cs
@@ -40,13 +40,13 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic.Lua
             var sut = CreateSut();
 
             Assert.IsNotNull(sut.Script);
-            Assert.IsTrue(sut.Script.Contains("HEXISTS"));
-            Assert.IsTrue(sut.Script.Contains("HSET"));
-            Assert.IsTrue(sut.Script.Contains("@valueskey"));
-            Assert.IsTrue(sut.Script.Contains("@headerskey"));
-            Assert.IsTrue(sut.Script.Contains("@uuid"));
-            Assert.IsTrue(sut.Script.Contains("@body"));
-            Assert.IsTrue(sut.Script.Contains("@headers"));
+            Assert.Contains("HEXISTS", sut.Script);
+            Assert.Contains("HSET", sut.Script);
+            Assert.Contains("@valueskey", sut.Script);
+            Assert.Contains("@headerskey", sut.Script);
+            Assert.Contains("@uuid", sut.Script);
+            Assert.Contains("@body", sut.Script);
+            Assert.Contains("@headers", sut.Script);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.Redis.Tests/HelpersTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.Tests/HelpersTests.cs
@@ -13,8 +13,8 @@ namespace DotNetWorkQueue.Transport.Redis.Tests
             var jobs = Enumerable.Range(0, 100)
                   .Select(x => "test");
             var enumerable = jobs as IList<string> ?? jobs.ToList();
-            Assert.AreEqual(2, enumerable.Partition(50).Count());
-            Assert.AreEqual(10, enumerable.Partition(10).Count());
+            Assert.HasCount(2, enumerable.Partition(50));
+            Assert.HasCount(10, enumerable.Partition(10));
 
             jobs = Enumerable.Range(0, 87)
                  .Select(x => "test");
@@ -24,7 +24,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests
             var i = 0;
             foreach (var p in part)
             {
-                Assert.AreEqual(i == 4 ? 7 : 20, p.Count());
+                Assert.HasCount(i == 4 ? 7 : 20, p);
                 i++;
             }
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/BatchPartitionExtensionsTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/BatchPartitionExtensionsTests.cs
@@ -34,10 +34,10 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
             var chunks = source.Partition(1000).ToList();
 
-            Assert.AreEqual(3, chunks.Count);
-            Assert.AreEqual(1000, chunks[0].Count);
-            Assert.AreEqual(1000, chunks[1].Count);
-            Assert.AreEqual(500, chunks[2].Count);
+            Assert.HasCount(3, chunks);
+            Assert.HasCount(1000, chunks[0]);
+            Assert.HasCount(1000, chunks[1]);
+            Assert.HasCount(500, chunks[2]);
         }
 
         [TestMethod]
@@ -47,9 +47,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
             var chunks = source.Partition(1000).ToList();
 
-            Assert.AreEqual(2, chunks.Count);
-            Assert.AreEqual(1000, chunks[0].Count);
-            Assert.AreEqual(1000, chunks[1].Count);
+            Assert.HasCount(2, chunks);
+            Assert.HasCount(1000, chunks[0]);
+            Assert.HasCount(1000, chunks[1]);
         }
 
         [TestMethod]
@@ -59,8 +59,8 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
             var chunks = source.Partition(1000).ToList();
 
-            Assert.AreEqual(1, chunks.Count);
-            Assert.AreEqual(10, chunks[0].Count);
+            Assert.HasCount(1, chunks);
+            Assert.HasCount(10, chunks[0]);
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
             var chunks = source.Partition(1000).ToList();
 
-            Assert.AreEqual(0, chunks.Count);
+            Assert.IsEmpty(chunks);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardErrorRetriesQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardErrorRetriesQueryHandlerAsyncTests.cs
@@ -74,7 +74,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
 
             var result = await handler.HandleAsync(new GetDashboardErrorRetriesQuery("100"));
 
-            Assert.AreEqual(3, result.Count);
+            Assert.HasCount(3, result);
             Assert.AreEqual(10L, result[0].ErrorTrackingId);
             Assert.AreEqual("100", result[0].QueueId);
             Assert.AreEqual(30L, result[2].ErrorTrackingId);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardErrorRetriesQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardErrorRetriesQueryHandlerTests.cs
@@ -55,7 +55,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
 
             var result = handler.Handle(new GetDashboardErrorRetriesQuery("100"));
 
-            Assert.AreEqual(3, result.Count);
+            Assert.HasCount(3, result);
             Assert.AreEqual(10L, result[0].ErrorTrackingId);
             Assert.AreEqual("100", result[0].QueueId);
             Assert.AreEqual("ExA", result[0].ExceptionType);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardJobsQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardJobsQueryHandlerAsyncTests.cs
@@ -72,7 +72,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
 
             var result = await handler.HandleAsync(new GetDashboardJobsQuery());
 
-            Assert.AreEqual(3, result.Count);
+            Assert.HasCount(3, result);
             Assert.AreEqual("JobA", result[0].JobName);
             Assert.AreEqual("JobB", result[1].JobName);
             Assert.AreEqual("JobC", result[2].JobName);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardJobsQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardJobsQueryHandlerTests.cs
@@ -53,7 +53,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
 
             var result = handler.Handle(new GetDashboardJobsQuery());
 
-            Assert.AreEqual(3, result.Count);
+            Assert.HasCount(3, result);
             Assert.AreEqual("JobA", result[0].JobName);
             Assert.AreEqual("JobB", result[1].JobName);
             Assert.AreEqual("JobC", result[2].JobName);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessagesQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessagesQueryHandlerAsyncTests.cs
@@ -46,7 +46,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
 
             var result = await handler.HandleAsync(new GetDashboardMessagesQuery(0, 25, null));
 
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
             Assert.AreEqual("1", result[0].QueueId);
             Assert.AreEqual("corr-1", result[0].CorrelationId);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessagesQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessagesQueryHandlerTests.cs
@@ -27,7 +27,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
 
             var result = handler.Handle(new GetDashboardMessagesQuery(0, 25, null));
 
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
             Assert.AreEqual("1", result[0].QueueId);
             Assert.AreEqual("corr-1", result[0].CorrelationId);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryMessageHistoryHandlerTests.cs
@@ -23,7 +23,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
             var result = handler.Get(0, 10, null);
 
-            Assert.AreEqual(0, result.Count);
+            Assert.IsEmpty(result);
         }
 
         [TestMethod]
@@ -88,7 +88,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
             var result = handler.Get(0, 10, null);
 
-            Assert.AreEqual(0, result.Count);
+            Assert.IsEmpty(result);
             connection.Received(1).Open();
             command.Received(1).ExecuteReader();
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/IRelationalWorkerNotificationContractTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/IRelationalWorkerNotificationContractTests.cs
@@ -81,7 +81,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests
             var declared = typeof(IRelationalWorkerNotification).GetProperties(
                 BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-            Assert.AreEqual(1, declared.Length,
+            Assert.HasCount(1, declared,
                 "IRelationalWorkerNotification must declare exactly one new property (Transaction).");
             Assert.AreEqual("Transaction", declared[0].Name);
         }

--- a/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/Producer/BatchSendCriteria.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/Producer/BatchSendCriteria.cs
@@ -79,8 +79,8 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Producer
                             Assert.IsFalse(output.HasErrors, "batch send reported errors");
 
                             var ids = output.Select(m => Convert.ToInt64(m.SentMessage.MessageId.Id.Value)).ToList();
-                            Assert.AreEqual(count, ids.Count);
-                            Assert.AreEqual(count, ids.Distinct().Count(), "generated ids are not unique");
+                            Assert.HasCount(count, ids);
+                            Assert.HasCount(count, ids.Distinct(), "generated ids are not unique");
 
                             // Definitive id-order check: the OrderID stored for result[i].id must equal i,
                             // i.e. each returned id maps to the input message at that position. Load the
@@ -178,7 +178,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Producer
 
                             var output = producer.Send(messages);
                             Assert.IsFalse(output.HasErrors);
-                            Assert.AreEqual(count, output.Count);
+                            Assert.HasCount(count, output);
                         }
                         new VerifyQueueData(queueConnection, oCreation.Options).Verify(count, null);
                     }

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/CommandHandler/BatchSizeSelectionTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/CommandHandler/BatchSizeSelectionTests.cs
@@ -36,10 +36,9 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic.CommandHandler
         [TestMethod]
         public void SafeMax_IsConservativeAndPositive()
         {
-            Assert.IsTrue(SendMessageBatch.SafeMaxBatchSize >= 1);
+            Assert.IsGreaterThanOrEqualTo(1, SendMessageBatch.SafeMaxBatchSize);
             // Stays under the conservative SQLite parameter ceiling (2 params per row).
-            Assert.IsTrue(SendMessageBatch.SafeMaxBatchSize
-                <= (SendMessageBatch.SqliteSafeMaxParameters / SendMessageBatch.BodyParametersPerMessage));
+            Assert.IsLessThanOrEqualTo(SendMessageBatch.SqliteSafeMaxParameters / SendMessageBatch.BodyParametersPerMessage, SendMessageBatch.SafeMaxBatchSize);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/QueueQueueConsumerConfigurationExtensionsTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/QueueQueueConsumerConfigurationExtensionsTests.cs
@@ -36,7 +36,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
 
             var result = config.GetUserParameters();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
             Assert.AreEqual("@p1", result[0].ParameterName);
         }
 
@@ -51,7 +51,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             config.SetUserParameters(parameters2);
 
             var result = config.GetUserParameters();
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
         }
 
         [TestMethod]
@@ -62,7 +62,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
 
             var result = config.GetUserParameters();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
         }
 
         [TestMethod]
@@ -73,7 +73,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             config.AddUserParameter(new SQLiteParameter("@p2", 2));
 
             var result = config.GetUserParameters();
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
         }
 
         [TestMethod]
@@ -98,7 +98,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
 
             var resultParams = config.GetUserParameters();
             Assert.IsNotNull(resultParams);
-            Assert.AreEqual(1, resultParams.Count);
+            Assert.HasCount(1, resultParams);
 
             var resultClause = config.GetUserClause();
             Assert.AreEqual("AND Col = @p1", resultClause);
@@ -119,7 +119,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
 
             // Factory should take precedence
             var resultParams = config.GetUserParameters();
-            Assert.AreEqual(1, resultParams.Count);
+            Assert.HasCount(1, resultParams);
             Assert.AreEqual("@factory", resultParams[0].ParameterName);
 
             var resultClause = config.GetUserClause();

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/RetryTransactionPolicyCreationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/RetryTransactionPolicyCreationTests.cs
@@ -51,7 +51,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var (container, policies) = CreateMocks();
             RetryTransactionPolicyCreation.Register(container);
             // RetryCommandHandler and RetryCommandHandlerAsync map to the same key
-            Assert.AreEqual(3, policies.TransportDefinition.Count);
+            Assert.HasCount(3, policies.TransportDefinition);
         }
 
         [TestMethod]
@@ -160,7 +160,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             }
 
             if (shouldRetry)
-                Assert.IsTrue(callCount > 1, $"Error code {errorCode} should have triggered retries but was called only {callCount} time(s)");
+                Assert.IsGreaterThan(1, callCount, $"Error code {errorCode} should have triggered retries but was called only {callCount} time(s)");
             else
                 Assert.AreEqual(1, callCount, $"Error code {errorCode} should not have triggered retries");
         }

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/SQLiteMessageQueueSchemaTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/SQLiteMessageQueueSchemaTests.cs
@@ -27,7 +27,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             factory.Create().Returns(options);
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
-            Assert.IsTrue(tables.Any(item => item.Name == tableName.StatusName));
+            Assert.Contains(item => item.Name == tableName.StatusName, tables);
         }
 
         [TestMethod]
@@ -41,7 +41,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.StatusName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "testing"));
+            Assert.Contains(item => item.Name == "testing", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -56,7 +56,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.StatusName);
-            Assert.IsTrue(statusTable.Constraints.Any(item => item.Name == "ix_testing"));
+            Assert.Contains(item => item.Name == "ix_testing", statusTable.Constraints);
         }
 
         [TestMethod]
@@ -69,7 +69,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "Priority"));
+            Assert.Contains(item => item.Name == "Priority", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -82,7 +82,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "Status"));
+            Assert.Contains(item => item.Name == "Status", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -95,7 +95,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "QueueProcessTime"));
+            Assert.Contains(item => item.Name == "QueueProcessTime", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -108,7 +108,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "HeartBeat"));
+            Assert.Contains(item => item.Name == "HeartBeat", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -121,7 +121,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "ExpirationTime"));
+            Assert.Contains(item => item.Name == "ExpirationTime", statusTable.Columns.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/SqliteJobSchemaTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/SqliteJobSchemaTests.cs
@@ -39,7 +39,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var tables = schema.GetSchema();
 
             Assert.IsNotNull(tables);
-            Assert.AreEqual(1, tables.Count);
+            Assert.HasCount(1, tables);
         }
 
         [TestMethod]
@@ -49,7 +49,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
 
             var table = (Table)schema.GetSchema().Single();
 
-            Assert.AreEqual(3, table.Columns.Items.Count);
+            Assert.HasCount(3, table.Columns.Items);
 
             var jobEventTime = table.Columns.Items.Single(c => c.Name == "JobEventTime");
             Assert.AreEqual(ColumnTypes.Text, jobEventTime.Type);

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Schema/ColumnsTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Schema/ColumnsTests.cs
@@ -15,7 +15,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Schema
         {
             var test = new Columns();
             test.Add(new Column("testing", ColumnTypes.Integer, true, null));
-            Assert.IsTrue(test.Items.Any(item => item.Name == "testing"));
+            Assert.Contains(item => item.Name == "testing", test.Items);
         }
         [TestMethod]
         public void Remove_Column()
@@ -24,7 +24,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Schema
             var column = new Column("testing", ColumnTypes.Integer, true, null);
             test.Add(column);
             test.Remove(column);
-            Assert.IsFalse(test.Items.Any(item => item.Name == "testing"));
+            Assert.DoesNotContain(item => item.Name == "testing", test.Items);
         }
         [TestMethod]
         public void Script()

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Schema/TableTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Schema/TableTests.cs
@@ -50,7 +50,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Schema
             var c = new Column("testing", ColumnTypes.Integer, true, null);
             var test = new Table("test");
             test.Columns.Add(c);
-            Assert.IsTrue(test.Columns.Items.Any(item => item.Name == "testing"));
+            Assert.Contains(item => item.Name == "testing", test.Columns.Items);
         }
         [TestMethod]
         public void Create_Script()

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Inbox/SqlServerInboxBatchSendTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Inbox/SqlServerInboxBatchSendTests.cs
@@ -193,17 +193,17 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Inbox
             {
                 var result = producer.RelationalProducer.Send(BuildBatch(batchSize), transaction);
                 Assert.IsFalse(result.HasErrors, "batch send reported errors");
-                Assert.AreEqual(batchSize, result.Count, "one result per message");
+                Assert.HasCount(batchSize, result, "one result per message");
 
                 var ids = new HashSet<long>();
                 for (var i = 0; i < result.Count; i++)
                 {
                     Assert.IsTrue(result[i].SentMessage.MessageId.HasValue, "each result must carry a message id");
                     var id = (long)result[i].SentMessage.MessageId.Id.Value;
-                    Assert.IsTrue(id > 0, "message id must be a positive value");
+                    Assert.IsGreaterThan(0, id, "message id must be a positive value");
                     ids.Add(id);
                 }
-                Assert.AreEqual(batchSize, ids.Count, "message ids must be distinct");
+                Assert.HasCount(batchSize, ids, "message ids must be distinct");
 
                 transaction.Commit();
             }

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Outbox/SqlServerOutboxRetryBypassTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Outbox/SqlServerOutboxRetryBypassTests.cs
@@ -75,7 +75,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Outbox
             // slow CI hosts. If this proves flaky raise to 3000ms; DO NOT remove the
             // timing assertion -- it is the only integration-level pin against the
             // "retry decorator silently regressed" failure mode.
-            Assert.IsTrue(sw.ElapsedMilliseconds < 2000,
+            Assert.IsLessThan(2000, sw.ElapsedMilliseconds,
                 $"Caller-transaction Send took {sw.ElapsedMilliseconds}ms -- expected < 2000ms " +
                 "for single-attempt failure (3x retry chain would exceed this).");
 

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Outbox/SqlServerOutboxValidationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Outbox/SqlServerOutboxValidationTests.cs
@@ -61,7 +61,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Outbox
             // Validator's check-4 message includes both DB names for diagnostics
             // (PROJECT.md §Non-Functional "Diagnostics"). Assert at minimum the wrong
             // database name appears.
-            Assert.IsTrue(ex.Message.IndexOf("master", StringComparison.OrdinalIgnoreCase) >= 0,
+            Assert.IsGreaterThanOrEqualTo(0, ex.Message.IndexOf("master", StringComparison.OrdinalIgnoreCase),
                 $"Expected exception message to mention 'master': {ex.Message}");
 
             // No partial write — queue MetaData table count must be 0.

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Producer/BatchSendCriteria.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Producer/BatchSendCriteria.cs
@@ -75,8 +75,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Producer
                         Assert.IsFalse(output.HasErrors, "batch send reported errors");
 
                         var ids = output.Select(m => Convert.ToInt64(m.SentMessage.MessageId.Id.Value)).ToList();
-                        Assert.AreEqual(count, ids.Count);
-                        Assert.AreEqual(count, ids.Distinct().Count(), "generated ids are not unique");
+                        Assert.HasCount(count, ids);
+                        Assert.HasCount(count, ids.Distinct(), "generated ids are not unique");
 
                         // Definitive id-order check: the OrderID stored for result[i].id must equal i,
                         // i.e. each returned id maps to the input message at that position.
@@ -164,7 +164,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Producer
 
                         var output = producer.Send(messages);
                         Assert.IsFalse(output.HasErrors);
-                        Assert.AreEqual(count, output.Count);
+                        Assert.HasCount(count, output);
                     }
                     new VerifyQueueData(queueConnection, oCreation.Options).Verify(count);
                 }

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/CommandHandler/SendMessageCommandHandlerAsyncForkSmokeTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/CommandHandler/SendMessageCommandHandlerAsyncForkSmokeTests.cs
@@ -81,21 +81,21 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic.CommandHandler
             // to one of them.
             var forkStart = content.IndexOf("private async Task<long> HandleExternalTransactionAsync",
                 StringComparison.Ordinal);
-            Assert.IsTrue(forkStart >= 0, "HandleExternalTransactionAsync not found in source.");
+            Assert.IsGreaterThanOrEqualTo(0, forkStart, "HandleExternalTransactionAsync not found in source.");
             var forkEnd = content.IndexOf("\n        }\n", forkStart, StringComparison.Ordinal);
-            Assert.IsTrue(forkEnd >= 0,
+            Assert.IsGreaterThanOrEqualTo(0, forkEnd,
                 "Closing brace of HandleExternalTransactionAsync (column-8 '}' on its own line) not found.");
             var forkBody = content.Substring(forkStart, forkEnd - forkStart);
 
-            Assert.IsFalse(forkBody.Contains(".Commit()"),   "HandleExternalTransactionAsync must not call .Commit() on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".Rollback()"), "HandleExternalTransactionAsync must not call .Rollback() on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".Close()"),    "HandleExternalTransactionAsync must not call .Close() on the caller's connection.");
-            Assert.IsFalse(forkBody.Contains(".Dispose()"),  "HandleExternalTransactionAsync must not call .Dispose() on the caller's connection or transaction.");
+            Assert.DoesNotContain(".Commit()", forkBody,   "HandleExternalTransactionAsync must not call .Commit() on the caller's transaction.");
+            Assert.DoesNotContain(".Rollback()", forkBody, "HandleExternalTransactionAsync must not call .Rollback() on the caller's transaction.");
+            Assert.DoesNotContain(".Close()", forkBody,    "HandleExternalTransactionAsync must not call .Close() on the caller's connection.");
+            Assert.DoesNotContain(".Dispose()", forkBody,  "HandleExternalTransactionAsync must not call .Dispose() on the caller's connection or transaction.");
             // Async-specific lifecycle calls:
-            Assert.IsFalse(forkBody.Contains(".CommitAsync"),   "HandleExternalTransactionAsync must not call .CommitAsync on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".RollbackAsync"), "HandleExternalTransactionAsync must not call .RollbackAsync on the caller's transaction.");
-            Assert.IsFalse(forkBody.Contains(".CloseAsync"),    "HandleExternalTransactionAsync must not call .CloseAsync on the caller's connection.");
-            Assert.IsFalse(forkBody.Contains(".DisposeAsync"),  "HandleExternalTransactionAsync must not call .DisposeAsync on the caller's connection or transaction.");
+            Assert.DoesNotContain(".CommitAsync", forkBody,   "HandleExternalTransactionAsync must not call .CommitAsync on the caller's transaction.");
+            Assert.DoesNotContain(".RollbackAsync", forkBody, "HandleExternalTransactionAsync must not call .RollbackAsync on the caller's transaction.");
+            Assert.DoesNotContain(".CloseAsync", forkBody,    "HandleExternalTransactionAsync must not call .CloseAsync on the caller's connection.");
+            Assert.DoesNotContain(".DisposeAsync", forkBody,  "HandleExternalTransactionAsync must not call .DisposeAsync on the caller's connection or transaction.");
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/CommandHandler/SendMessageCommandHandlerForkSmokeTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/CommandHandler/SendMessageCommandHandlerForkSmokeTests.cs
@@ -82,9 +82,9 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic.CommandHandler
             // helpers like CreateStatusRecord, masking the actual call site if a future
             // edit added a Commit/Rollback/Close/Dispose call to one of them.
             var forkStart = content.IndexOf("private long HandleExternalTransaction", StringComparison.Ordinal);
-            Assert.IsTrue(forkStart >= 0, "HandleExternalTransaction not found in source.");
+            Assert.IsGreaterThanOrEqualTo(0, forkStart, "HandleExternalTransaction not found in source.");
             var forkEnd = content.IndexOf("\n        }\n", forkStart, StringComparison.Ordinal);
-            Assert.IsTrue(forkEnd >= 0,
+            Assert.IsGreaterThanOrEqualTo(0, forkEnd,
                 "Closing brace of HandleExternalTransaction (column-8 '}' on its own line) not found.");
             var forkBody = content.Substring(forkStart, forkEnd - forkStart);
 
@@ -105,13 +105,13 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic.CommandHandler
             }
             var forkCode = codeOnly.ToString();
 
-            Assert.IsFalse(forkCode.Contains(".Commit()"),    "HandleExternalTransaction must not call .Commit() on the caller's transaction.");
-            Assert.IsFalse(forkCode.Contains(".Rollback()"),  "HandleExternalTransaction must not call .Rollback() on the caller's transaction.");
+            Assert.DoesNotContain(".Commit()", forkCode,    "HandleExternalTransaction must not call .Commit() on the caller's transaction.");
+            Assert.DoesNotContain(".Rollback()", forkCode,  "HandleExternalTransaction must not call .Rollback() on the caller's transaction.");
             // Close and Dispose are looked for as method invocations on conn/transaction — broad enough
             // to catch sqlConn.Close(), sqlTransaction.Dispose(), etc. False-positives unlikely because
             // the fork body has no other Close/Dispose surface.
-            Assert.IsFalse(forkCode.Contains(".Close()"),     "HandleExternalTransaction must not call .Close() on the caller's connection.");
-            Assert.IsFalse(forkCode.Contains(".Dispose()"),   "HandleExternalTransaction must not call .Dispose() on the caller's connection or transaction.");
+            Assert.DoesNotContain(".Close()", forkCode,     "HandleExternalTransaction must not call .Close() on the caller's connection.");
+            Assert.DoesNotContain(".Dispose()", forkCode,   "HandleExternalTransaction must not call .Dispose() on the caller's connection or transaction.");
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/QueueQueueConsumerConfigurationExtensionsTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/QueueQueueConsumerConfigurationExtensionsTests.cs
@@ -36,7 +36,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
 
             var result = config.GetUserParameters();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
             Assert.AreEqual("@p1", result[0].ParameterName);
         }
 
@@ -51,7 +51,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             config.SetUserParameters(parameters2);
 
             var result = config.GetUserParameters();
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
         }
 
         [TestMethod]
@@ -62,7 +62,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
 
             var result = config.GetUserParameters();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
         }
 
         [TestMethod]
@@ -73,7 +73,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             config.AddUserParameter(new SqlParameter("@p2", 2));
 
             var result = config.GetUserParameters();
-            Assert.AreEqual(2, result.Count);
+            Assert.HasCount(2, result);
         }
 
         [TestMethod]
@@ -98,7 +98,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
 
             var resultParams = config.GetUserParameters();
             Assert.IsNotNull(resultParams);
-            Assert.AreEqual(1, resultParams.Count);
+            Assert.HasCount(1, resultParams);
 
             var resultClause = config.GetUserClause();
             Assert.AreEqual("AND Col = @p1", resultClause);
@@ -119,7 +119,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
 
             // Factory should take precedence
             var resultParams = config.GetUserParameters();
-            Assert.AreEqual(1, resultParams.Count);
+            Assert.HasCount(1, resultParams);
             Assert.AreEqual("@factory", resultParams[0].ParameterName);
 
             var resultClause = config.GetUserClause();

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/RetrySqlPolicyCreationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/RetrySqlPolicyCreationTests.cs
@@ -42,7 +42,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             var (container, policies) = CreateMocks();
             RetrySqlPolicyCreation.Register(container);
             // RetryCommandHandler and RetryCommandHandlerAsync map to the same key
-            Assert.AreEqual(2, policies.TransportDefinition.Count);
+            Assert.HasCount(2, policies.TransportDefinition);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/SqlServerJobSchemaTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/SqlServerJobSchemaTests.cs
@@ -20,7 +20,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             var tables = fixture.Schema.GetSchema();
 
             Assert.IsNotNull(tables);
-            Assert.AreEqual(1, tables.Count);
+            Assert.HasCount(1, tables);
         }
 
         [TestMethod]
@@ -30,7 +30,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
 
             var table = (Table)fixture.Schema.GetSchema().Single();
 
-            Assert.AreEqual(3, table.Columns.Items.Count);
+            Assert.HasCount(3, table.Columns.Items);
 
             var jobEventTime = table.Columns.Items.SingleOrDefault(c => c.Name == "JobEventTime");
             Assert.IsNotNull(jobEventTime);
@@ -61,7 +61,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             Assert.AreEqual(ConstraintType.PrimaryKey, table.PrimaryKey.Type);
             Assert.IsTrue(table.PrimaryKey.Clustered);
             Assert.IsTrue(table.PrimaryKey.Unique);
-            Assert.AreEqual(1, table.PrimaryKey.Columns.Count);
+            Assert.HasCount(1, table.PrimaryKey.Columns);
             Assert.AreEqual("JobName", table.PrimaryKey.Columns.Single());
         }
 

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/SqlServerMessageQueueSchemaTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/SqlServerMessageQueueSchemaTests.cs
@@ -29,7 +29,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             factory.Create().Returns(options);
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
-            Assert.IsTrue(tables.Any(item => item.Name == tableName.StatusName));
+            Assert.Contains(item => item.Name == tableName.StatusName, tables);
         }
 
         [TestMethod]
@@ -43,7 +43,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.StatusName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "testing"));
+            Assert.Contains(item => item.Name == "testing", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -58,7 +58,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.StatusName);
-            Assert.IsTrue(statusTable.Constraints.Any(item => item.Name == "ix_testing"));
+            Assert.Contains(item => item.Name == "ix_testing", statusTable.Constraints);
         }
 
         [TestMethod]
@@ -71,7 +71,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "Priority"));
+            Assert.Contains(item => item.Name == "Priority", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "Status"));
+            Assert.Contains(item => item.Name == "Status", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "QueueProcessTime"));
+            Assert.Contains(item => item.Name == "QueueProcessTime", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "HeartBeat"));
+            Assert.Contains(item => item.Name == "HeartBeat", statusTable.Columns.Items);
         }
 
         [TestMethod]
@@ -123,7 +123,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             var test = Create(factory, tableName);
             var tables = test.GetSchema().ConvertAll(o => (Table)o);
             var statusTable = tables.Find(item => item.Name == tableName.MetaDataName);
-            Assert.IsTrue(statusTable.Columns.Items.Any(item => item.Name == "ExpirationTime"));
+            Assert.Contains(item => item.Name == "ExpirationTime", statusTable.Columns.Items);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/SqlServerRelationalProducerQueueTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/SqlServerRelationalProducerQueueTests.cs
@@ -165,7 +165,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
             // (proves the validator fires before the cast guard).
             StringAssert.Contains(ex.Message, "WRONGDB");
             StringAssert.Contains(ex.Message, QueueDb);
-            Assert.IsFalse(ex.Message.Contains("SqlTransaction"),
+            Assert.DoesNotContain("SqlTransaction", ex.Message,
                 "Validator must fire before the SqlTransaction cast guard.");
         }
 
@@ -254,7 +254,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
 
             Assert.IsInstanceOfType(captured, typeof(RelationalSendMessageCommandBatch));
             Assert.AreSame(transaction, ((RelationalSendMessageCommandBatch)captured).ExternalTransaction);
-            Assert.AreEqual(2, captured.Messages.Count);
+            Assert.HasCount(2, captured.Messages);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Schema/ColumnsTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Schema/ColumnsTests.cs
@@ -16,7 +16,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Schema
         {
             var test = new Columns();
             test.Add(new Column("testing", ColumnTypes.Bigint, true, null));
-            Assert.IsTrue(test.Items.Any(item => item.Name == "testing"));
+            Assert.Contains(item => item.Name == "testing", test.Items);
         }
         [TestMethod]
         public void Remove_Column()
@@ -25,7 +25,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Schema
             var column = new Column("testing", ColumnTypes.Bigint, true, null);
             test.Add(column);
             test.Remove(column);
-            Assert.IsFalse(test.Items.Any(item => item.Name == "testing"));
+            Assert.DoesNotContain(item => item.Name == "testing", test.Items);
         }
         [TestMethod]
         public void Script()

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Schema/TableTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Schema/TableTests.cs
@@ -58,7 +58,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Schema
             var c = new Column("testing", ColumnTypes.Bigint, true, null);
             var test = new Table("dbo", "test");
             test.Columns.Add(c);
-            Assert.IsTrue(test.Columns.Items.Any(item => item.Name == "testing"));
+            Assert.Contains(item => item.Name == "testing", test.Columns.Items);
         }
         [TestMethod]
         public void Create_Script()


### PR DESCRIPTION
## What

Auto-applied the **MSTEST0037** Roslyn code fixer across the test suite:

```
dotnet format analyzers Source/DotNetWorkQueue.sln --diagnostics MSTEST0037 --severity info
```

It rewrites generic `Assert.IsTrue` / `Assert.AreEqual` shapes — a byproduct of the FluentAssertions → MSTest migration where `AssertHelper` emitted `Assert.IsTrue(x == y)` / `Assert.AreEqual(n, coll.Count)` — into the specific asserts that give better failure diagnostics:

| Rewrite | Count |
|---|---:|
| `Assert.HasCount` ← `Assert.AreEqual(n, x.Count)` | 212 |
| `Assert.IsGreaterThanOrEqualTo` ← `Assert.IsTrue` | 75 |
| `Assert.IsNotEmpty` ← `Assert.IsTrue` | 70 |
| `Assert.IsEmpty` ← `Assert.AreEqual(0, …)` | 68 |
| `Assert.Contains` / `DoesNotContain` / `IsGreaterThan` / `IsLessThan(OrEqualTo)` / `AreEqual` | rest |

`Assert.HasCount(3, x)` fails with *"expected 3, actual 5"* where `Assert.IsTrue` gave a bare *"expected true"*.

## Scope

- **579 rewrites across 141 test files.** Test-only — no production code, no version bump.
- Clears the single largest SonarCloud code-smell driver (MSTEST0037 = 36% of the badge; ~1590 → ~1011).
- Line endings preserved (CRLF per `.gitattributes`); `--ignore-space-at-eol` shows pure content changes.

## Validation

- `Source/DotNetWorkQueue.sln` builds clean (0 errors).
- Unit projects green (net10.0 + net8.0): core Tests 914, RelationalDatabase 247, SQLite 146, Memory 39, SqlServer 170, PostgreSQL 161, Redis 187, LiteDb 168, Dashboard.Api 222.
- Local integration: Dashboard.Api.Integration (Memory/Sqlite/LiteDb) 219 both TFMs; Memory.Integration 57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized many integration and unit tests to use clearer MSTest helpers for collection size, emptiness/non-emptiness, and numeric comparisons (e.g., “greater than or equal,” “less than,” “contains/does not contain”).
  * Improved assertions around dashboard/history/error/stale/processing scenarios, pagination counts, timestamps, and message/batch ID expectations across multiple providers.
  * Updated a CORS header assertion to use a more direct “contains” check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->