### PR TITLE
Sonar Bucket D: make-static, dedup-literals, unused fields (S2325/S1192/S4487)

### DIFF
--- a/Source/DotNetWorkQueue.Tests/Queue/MessageHandlerCancellationDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/MessageHandlerCancellationDecoratorTests.cs
@@ -20,8 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using DotNetWorkQueue.Queue;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
@@ -35,7 +33,7 @@ namespace DotNetWorkQueue.Tests.Queue
         {
             var tracker = new MessageCancellationTracker();
             var innerHandler = Substitute.For<IMessageHandler>();
-            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker, NullLogger.Instance);
+            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker);
 
             var message = CreateMessage("set-cancel-1");
             var notification = CreateNotification();
@@ -55,7 +53,7 @@ namespace DotNetWorkQueue.Tests.Queue
         {
             var tracker = new MessageCancellationTracker();
             var innerHandler = Substitute.For<IMessageHandler>();
-            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker, NullLogger.Instance);
+            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker);
 
             var message = CreateMessage("unregister-success-1");
             var notification = CreateNotification();
@@ -73,7 +71,7 @@ namespace DotNetWorkQueue.Tests.Queue
             innerHandler.When(x => x.Handle(Arg.Any<IReceivedMessageInternal>(), Arg.Any<IWorkerNotification>()))
                 .Do(_ => throw new InvalidOperationException("test"));
 
-            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker, NullLogger.Instance);
+            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker);
             var message = CreateMessage("unregister-error-1");
             var notification = CreateNotification();
 
@@ -88,7 +86,7 @@ namespace DotNetWorkQueue.Tests.Queue
         {
             var tracker = new MessageCancellationTracker();
             var innerHandler = Substitute.For<IMessageHandler>();
-            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker, NullLogger.Instance);
+            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker);
 
             var message = CreateMessage("clear-after-1");
             var notification = CreateNotification();
@@ -103,7 +101,7 @@ namespace DotNetWorkQueue.Tests.Queue
         {
             var tracker = new MessageCancellationTracker();
             var innerHandler = Substitute.For<IMessageHandler>();
-            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker, NullLogger.Instance);
+            var decorator = new MessageHandlerCancellationDecorator(innerHandler, tracker);
 
             var message = Substitute.For<IReceivedMessageInternal>();
             message.MessageId.Returns((IMessageId)null);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/RollbackMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/RollbackMessageCommandHandler.cs
@@ -149,7 +149,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             }
         }
 
-        private DateTime? TrimMilliseconds(DateTime? dt)
+        private static DateTime? TrimMilliseconds(DateTime? dt)
         {
             if (!dt.HasValue)
                 return null;

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandler.cs
@@ -43,7 +43,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         private bool? _messageExpirationEnabled;
         private readonly IHeaders _headers;
         private readonly Lazy<LiteDbMessageQueueTransportOptions> _options;
-        private readonly TransportConfigurationSend _configurationSend;
         private readonly ICommandHandler<SetJobLastKnownEventCommand> _sendJobStatus;
 
         private readonly IQueryHandler<DoesJobExistQuery, QueueStatuses>
@@ -60,7 +59,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         /// <param name="serializer">The serializer.</param>
         /// <param name="optionsFactory">The options factory.</param>
         /// <param name="headers">The headers.</param>
-        /// <param name="configurationSend">The configuration send.</param>
         /// <param name="sendJobStatus">The send job status.</param>
         /// <param name="jobExistsHandler">The job exists handler.</param>
         /// <param name="jobSchedulerMetaData">The job scheduler meta data.</param>
@@ -71,7 +69,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             ICompositeSerialization serializer,
             ILiteDbMessageQueueTransportOptionsFactory optionsFactory,
             IHeaders headers,
-            TransportConfigurationSend configurationSend,
             ICommandHandler<SetJobLastKnownEventCommand> sendJobStatus,
             IQueryHandler<DoesJobExistQuery, QueueStatuses> jobExistsHandler,
             IJobSchedulerMetaData jobSchedulerMetaData,
@@ -82,7 +79,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             Guard.NotNull(() => serializer, serializer);
             Guard.NotNull(() => optionsFactory, optionsFactory);
             Guard.NotNull(() => headers, headers);
-            Guard.NotNull(() => configurationSend, configurationSend);
             Guard.NotNull(() => sendJobStatus, sendJobStatus);
             Guard.NotNull(() => jobExistsHandler, jobExistsHandler);
             Guard.NotNull(() => databaseExists, databaseExists);
@@ -92,7 +88,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             _serializer = serializer;
             _options = new Lazy<LiteDbMessageQueueTransportOptions>(optionsFactory.Create);
             _headers = headers;
-            _configurationSend = configurationSend;
             _sendJobStatus = sendJobStatus;
             _jobExistsHandler = jobExistsHandler;
             _jobSchedulerMetaData = jobSchedulerMetaData;

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -44,7 +44,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         private bool? _messageExpirationEnabled;
         private readonly IHeaders _headers;
         private readonly Lazy<LiteDbMessageQueueTransportOptions> _options;
-        private readonly TransportConfigurationSend _configurationSend;
         private readonly ICommandHandler<SetJobLastKnownEventCommand> _sendJobStatus;
         private readonly IQueryHandler<DoesJobExistQuery, QueueStatuses> _jobExistsHandler;
         private readonly IJobSchedulerMetaData _jobSchedulerMetaData;
@@ -58,7 +57,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         /// <param name="serializer">The serializer.</param>
         /// <param name="optionsFactory">The options factory.</param>
         /// <param name="headers">The headers.</param>
-        /// <param name="configurationSend">The configuration send.</param>
         /// <param name="sendJobStatus">The send job status.</param>
         /// <param name="jobExistsHandler">The job exists handler.</param>
         /// <param name="jobSchedulerMetaData">The job scheduler meta data.</param>
@@ -69,7 +67,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             ICompositeSerialization serializer,
             ILiteDbMessageQueueTransportOptionsFactory optionsFactory,
             IHeaders headers,
-            TransportConfigurationSend configurationSend,
             ICommandHandler<SetJobLastKnownEventCommand> sendJobStatus, IQueryHandler<DoesJobExistQuery, QueueStatuses> jobExistsHandler,
             IJobSchedulerMetaData jobSchedulerMetaData,
             DatabaseExists databaseExists)
@@ -79,7 +76,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             Guard.NotNull(() => serializer, serializer);
             Guard.NotNull(() => optionsFactory, optionsFactory);
             Guard.NotNull(() => headers, headers);
-            Guard.NotNull(() => configurationSend, configurationSend);
             Guard.NotNull(() => sendJobStatus, sendJobStatus);
             Guard.NotNull(() => jobExistsHandler, jobExistsHandler);
             Guard.NotNull(() => jobSchedulerMetaData, jobSchedulerMetaData);
@@ -90,7 +86,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             _serializer = serializer;
             _options = new Lazy<LiteDbMessageQueueTransportOptions>(optionsFactory.Create);
             _headers = headers;
-            _configurationSend = configurationSend;
             _sendJobStatus = sendJobStatus;
             _jobExistsHandler = jobExistsHandler;
             _jobSchedulerMetaData = jobSchedulerMetaData;

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbJobSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbJobSchema.cs
@@ -43,7 +43,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Creates the main table schema
         /// </summary>
         /// <returns></returns>
-        private ITable CreateMainTable()
+        private static ITable CreateMainTable()
         {
             return new JobsTable();
         }

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbMessageQueueInit.cs
@@ -275,7 +275,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Gets the default fatal exception delay time spans
         /// </summary>
         /// <returns></returns>
-        private IEnumerable<TimeSpan> ExceptionDelay()
+        private static IEnumerable<TimeSpan> ExceptionDelay()
         {
             var rc = new List<TimeSpan>(10)
             {
@@ -297,7 +297,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Gets the default queue delay time spans
         /// </summary>
         /// <returns></returns>
-        private IEnumerable<TimeSpan> DefaultQueueDelay()
+        private static IEnumerable<TimeSpan> DefaultQueueDelay()
         {
             var rc = new List<TimeSpan>(21)
             {
@@ -330,7 +330,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Setup the heart beat.
         /// </summary>
         /// <param name="container">The container.</param>
-        private void SetupHeartBeat(IContainer container)
+        private static void SetupHeartBeat(IContainer container)
         {
             var heartBeatConfiguration = container.GetInstance<IHeartBeatConfiguration>();
             heartBeatConfiguration.Time = TimeSpan.FromSeconds(30);
@@ -343,7 +343,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Setup the message expiration.
         /// </summary>
         /// <param name="container">The container.</param>
-        private void SetupMessageExpiration(IContainer container)
+        private static void SetupMessageExpiration(IContainer container)
         {
             var configuration = container.GetInstance<IMessageExpirationConfiguration>();
             configuration.MonitorTime = TimeSpan.FromMinutes(1);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbMessageQueueSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbMessageQueueSchema.cs
@@ -72,7 +72,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Creates the main table schema
         /// </summary>
         /// <returns></returns>
-        private Schema.QueueTable CreateMainTable()
+        private static Schema.QueueTable CreateMainTable()
         {
             return new Schema.QueueTable();
         }
@@ -80,12 +80,12 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Creates the configuration table schema.
         /// </summary>
         /// <returns></returns>
-        private Schema.ConfigurationTable CreateConfigurationTable()
+        private static Schema.ConfigurationTable CreateConfigurationTable()
         {
             return new Schema.ConfigurationTable();
         }
 
-        private Schema.StatusTable CreateStatusTable()
+        private static Schema.StatusTable CreateStatusTable()
         {
             return new StatusTable();
         }
@@ -93,7 +93,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Creates the meta data table schema.
         /// </summary>
         /// <returns></returns>
-        private Schema.MetaDataTable CreateMetaDataTable()
+        private static Schema.MetaDataTable CreateMetaDataTable()
         {
             return new MetaDataTable();
         }
@@ -101,7 +101,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Creates the error tracking table schema.
         /// </summary>
         /// <returns></returns>
-        private Schema.ErrorTrackingTable CreateErrorTrackingTable()
+        private static Schema.ErrorTrackingTable CreateErrorTrackingTable()
         {
             return new ErrorTrackingTable();
         }
@@ -109,7 +109,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// Creates the error table schema. This is a copy of the meta table, but with an exception column added. 
         /// </summary>
         /// <returns></returns>
-        private Schema.MetaDataErrorsTable CreateErrorTable()
+        private static Schema.MetaDataErrorsTable CreateErrorTable()
         {
             return new MetaDataErrorsTable();
         }

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
@@ -30,17 +30,14 @@ namespace DotNetWorkQueue.Transport.LiteDb.Trace.Decorator
     public class RollbackMessageCommandHandlerDecorator : ICommandHandler<RollbackMessageCommand<int>>
     {
         private readonly ICommandHandler<RollbackMessageCommand<int>> _handler;
-        private readonly ActivitySource _tracer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RollbackMessageCommandHandlerDecorator"/> class.
         /// </summary>
         /// <param name="handler">The handler.</param>
-        /// <param name="tracer">The tracer.</param>
-        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<int>> handler, ActivitySource tracer)
+        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<int>> handler)
         {
             _handler = handler;
-            _tracer = tracer;
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/CommandHandler/DashboardDeleteAllErrorMessagesCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/CommandHandler/DashboardDeleteAllErrorMessagesCommandHandlerTests.cs
@@ -1,7 +1,4 @@
-using System;
-using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic.CommandHandler;
-using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.CommandHandler
@@ -12,13 +9,7 @@ namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.CommandHandler
         [TestMethod]
         public void Create_Default()
         {
-            Assert.IsNotNull(new DashboardDeleteAllErrorMessagesCommandHandler(Substitute.For<IDataStorage>()));
-        }
-
-        [TestMethod]
-        public void Create_NullDataStorage_Throws()
-        {
-            Assert.ThrowsExactly<ArgumentNullException>(() => new DashboardDeleteAllErrorMessagesCommandHandler(null));
+            Assert.IsNotNull(new DashboardDeleteAllErrorMessagesCommandHandler());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/CommandHandler/DashboardRequeueErrorMessageCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/CommandHandler/DashboardRequeueErrorMessageCommandHandlerTests.cs
@@ -1,7 +1,4 @@
-using System;
-using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic.CommandHandler;
-using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.CommandHandler
@@ -12,13 +9,7 @@ namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.CommandHandler
         [TestMethod]
         public void Create_Default()
         {
-            Assert.IsNotNull(new DashboardRequeueErrorMessageCommandHandler(Substitute.For<IDataStorage>()));
-        }
-
-        [TestMethod]
-        public void Create_NullDataStorage_Throws()
-        {
-            Assert.ThrowsExactly<ArgumentNullException>(() => new DashboardRequeueErrorMessageCommandHandler(null));
+            Assert.IsNotNull(new DashboardRequeueErrorMessageCommandHandler());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/CommandHandler/DashboardResetStaleMessageCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/CommandHandler/DashboardResetStaleMessageCommandHandlerTests.cs
@@ -1,7 +1,4 @@
-using System;
-using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic.CommandHandler;
-using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.CommandHandler
@@ -12,13 +9,7 @@ namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.CommandHandler
         [TestMethod]
         public void Create_Default()
         {
-            Assert.IsNotNull(new DashboardResetStaleMessageCommandHandler(Substitute.For<IDataStorage>()));
-        }
-
-        [TestMethod]
-        public void Create_NullDataStorage_Throws()
-        {
-            Assert.ThrowsExactly<ArgumentNullException>(() => new DashboardResetStaleMessageCommandHandler(null));
+            Assert.IsNotNull(new DashboardResetStaleMessageCommandHandler());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/CommandHandler/DashboardUpdateMessageBodyCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/CommandHandler/DashboardUpdateMessageBodyCommandHandlerTests.cs
@@ -1,7 +1,4 @@
-using System;
-using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic.CommandHandler;
-using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.CommandHandler
@@ -12,13 +9,7 @@ namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.CommandHandler
         [TestMethod]
         public void Create_Default()
         {
-            Assert.IsNotNull(new DashboardUpdateMessageBodyCommandHandler(Substitute.For<IDataStorage>()));
-        }
-
-        [TestMethod]
-        public void Create_NullDataStorage_Throws()
-        {
-            Assert.ThrowsExactly<ArgumentNullException>(() => new DashboardUpdateMessageBodyCommandHandler(null));
+            Assert.IsNotNull(new DashboardUpdateMessageBodyCommandHandler());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardConfigurationQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardConfigurationQueryHandlerAsyncTests.cs
@@ -1,7 +1,4 @@
-using System;
-using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic.QueryHandler;
-using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
@@ -12,13 +9,7 @@ namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
         [TestMethod]
         public void Create_Default()
         {
-            Assert.IsNotNull(new GetDashboardConfigurationQueryHandlerAsync(Substitute.For<IDataStorage>()));
-        }
-
-        [TestMethod]
-        public void Create_NullDataStorage_Throws()
-        {
-            Assert.ThrowsExactly<ArgumentNullException>(() => new GetDashboardConfigurationQueryHandlerAsync(null));
+            Assert.IsNotNull(new GetDashboardConfigurationQueryHandlerAsync());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardErrorMessageCountQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardErrorMessageCountQueryHandlerAsyncTests.cs
@@ -1,7 +1,4 @@
-using System;
-using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic.QueryHandler;
-using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
@@ -12,13 +9,7 @@ namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
         [TestMethod]
         public void Create_Default()
         {
-            Assert.IsNotNull(new GetDashboardErrorMessageCountQueryHandlerAsync(Substitute.For<IDataStorage>()));
-        }
-
-        [TestMethod]
-        public void Create_NullDataStorage_Throws()
-        {
-            Assert.ThrowsExactly<ArgumentNullException>(() => new GetDashboardErrorMessageCountQueryHandlerAsync(null));
+            Assert.IsNotNull(new GetDashboardErrorMessageCountQueryHandlerAsync());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardErrorMessagesQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardErrorMessagesQueryHandlerAsyncTests.cs
@@ -1,7 +1,4 @@
-using System;
-using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic.QueryHandler;
-using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
@@ -12,13 +9,7 @@ namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
         [TestMethod]
         public void Create_Default()
         {
-            Assert.IsNotNull(new GetDashboardErrorMessagesQueryHandlerAsync(Substitute.For<IDataStorage>()));
-        }
-
-        [TestMethod]
-        public void Create_NullDataStorage_Throws()
-        {
-            Assert.ThrowsExactly<ArgumentNullException>(() => new GetDashboardErrorMessagesQueryHandlerAsync(null));
+            Assert.IsNotNull(new GetDashboardErrorMessagesQueryHandlerAsync());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardErrorRetriesQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardErrorRetriesQueryHandlerAsyncTests.cs
@@ -1,7 +1,4 @@
-using System;
-using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic.QueryHandler;
-using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
@@ -12,13 +9,7 @@ namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
         [TestMethod]
         public void Create_Default()
         {
-            Assert.IsNotNull(new GetDashboardErrorRetriesQueryHandlerAsync(Substitute.For<IDataStorage>()));
-        }
-
-        [TestMethod]
-        public void Create_NullDataStorage_Throws()
-        {
-            Assert.ThrowsExactly<ArgumentNullException>(() => new GetDashboardErrorRetriesQueryHandlerAsync(null));
+            Assert.IsNotNull(new GetDashboardErrorRetriesQueryHandlerAsync());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsyncTests.cs
@@ -1,7 +1,4 @@
-using System;
-using DotNetWorkQueue.Transport.Memory;
 using DotNetWorkQueue.Transport.Memory.Basic.QueryHandler;
-using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
@@ -12,13 +9,7 @@ namespace DotNetWorkQueue.Transport.Memory.Tests.Basic.QueryHandler
         [TestMethod]
         public void Create_Default()
         {
-            Assert.IsNotNull(new GetDashboardStaleMessagesQueryHandlerAsync(Substitute.For<IDataStorage>()));
-        }
-
-        [TestMethod]
-        public void Create_NullDataStorage_Throws()
-        {
-            Assert.ThrowsExactly<ArgumentNullException>(() => new GetDashboardStaleMessagesQueryHandlerAsync(null));
+            Assert.IsNotNull(new GetDashboardStaleMessagesQueryHandlerAsync());
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardDeleteAllErrorMessagesCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardDeleteAllErrorMessagesCommandHandler.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
 {
@@ -27,14 +26,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
     /// </summary>
     internal class DashboardDeleteAllErrorMessagesCommandHandler : ICommandHandlerWithOutput<DashboardDeleteAllErrorMessagesCommand, long>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public DashboardDeleteAllErrorMessagesCommandHandler(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public long Handle(DashboardDeleteAllErrorMessagesCommand command)
         {
             return 0;

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardRequeueAllErrorMessagesCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardRequeueAllErrorMessagesCommandHandler.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
 {
@@ -27,14 +26,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
     /// </summary>
     internal class DashboardRequeueAllErrorMessagesCommandHandler : ICommandHandlerWithOutput<DashboardRequeueAllErrorMessagesCommand, long>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public DashboardRequeueAllErrorMessagesCommandHandler(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public long Handle(DashboardRequeueAllErrorMessagesCommand command)
         {
             return 0;

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardRequeueErrorMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardRequeueErrorMessageCommandHandler.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
 {
@@ -27,14 +26,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
     /// </summary>
     internal class DashboardRequeueErrorMessageCommandHandler : ICommandHandlerWithOutput<DashboardRequeueErrorMessageCommand, long>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public DashboardRequeueErrorMessageCommandHandler(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public long Handle(DashboardRequeueErrorMessageCommand command)
         {
             return 0;

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardResetAllStaleMessagesCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardResetAllStaleMessagesCommandHandler.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
 {
@@ -27,14 +26,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
     /// </summary>
     internal class DashboardResetAllStaleMessagesCommandHandler : ICommandHandlerWithOutput<DashboardResetAllStaleMessagesCommand, long>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public DashboardResetAllStaleMessagesCommandHandler(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public long Handle(DashboardResetAllStaleMessagesCommand command)
         {
             return 0;

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardResetStaleMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardResetStaleMessageCommandHandler.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
 {
@@ -27,14 +26,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
     /// </summary>
     internal class DashboardResetStaleMessageCommandHandler : ICommandHandlerWithOutput<DashboardResetStaleMessageCommand, long>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public DashboardResetStaleMessageCommandHandler(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public long Handle(DashboardResetStaleMessageCommand command)
         {
             return 0;

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardUpdateMessageBodyCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/CommandHandler/DashboardUpdateMessageBodyCommandHandler.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
 {
@@ -28,14 +27,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.CommandHandler
     /// </summary>
     internal class DashboardUpdateMessageBodyCommandHandler : ICommandHandlerWithOutput<DashboardUpdateMessageBodyCommand, long>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public DashboardUpdateMessageBodyCommandHandler(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public long Handle(DashboardUpdateMessageBodyCommand command)
         {
             return 0;

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardConfigurationQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardConfigurationQueryHandlerAsync.cs
@@ -19,7 +19,6 @@
 using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
 {
@@ -28,14 +27,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
     /// </summary>
     internal class GetDashboardConfigurationQueryHandlerAsync : IQueryHandlerAsync<GetDashboardConfigurationQuery, byte[]>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public GetDashboardConfigurationQueryHandlerAsync(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public Task<byte[]> HandleAsync(GetDashboardConfigurationQuery query)
         {
             return Task.FromResult<byte[]>(null);

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardErrorMessageCountQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardErrorMessageCountQueryHandlerAsync.cs
@@ -19,7 +19,6 @@
 using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
 {
@@ -28,14 +27,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
     /// </summary>
     internal class GetDashboardErrorMessageCountQueryHandlerAsync : IQueryHandlerAsync<GetDashboardErrorMessageCountQuery, long>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public GetDashboardErrorMessageCountQueryHandlerAsync(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public Task<long> HandleAsync(GetDashboardErrorMessageCountQuery query)
         {
             return Task.FromResult(0L);

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardErrorMessagesQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardErrorMessagesQueryHandlerAsync.cs
@@ -21,7 +21,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
 {
@@ -30,14 +29,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
     /// </summary>
     internal class GetDashboardErrorMessagesQueryHandlerAsync : IQueryHandlerAsync<GetDashboardErrorMessagesQuery, IReadOnlyList<DashboardErrorMessage>>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public GetDashboardErrorMessagesQueryHandlerAsync(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public Task<IReadOnlyList<DashboardErrorMessage>> HandleAsync(GetDashboardErrorMessagesQuery query)
         {
             return Task.FromResult<IReadOnlyList<DashboardErrorMessage>>(new List<DashboardErrorMessage>());

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardErrorRetriesQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardErrorRetriesQueryHandlerAsync.cs
@@ -21,7 +21,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
 {
@@ -30,14 +29,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
     /// </summary>
     internal class GetDashboardErrorRetriesQueryHandlerAsync : IQueryHandlerAsync<GetDashboardErrorRetriesQuery, IReadOnlyList<DashboardErrorRetry>>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public GetDashboardErrorRetriesQueryHandlerAsync(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public Task<IReadOnlyList<DashboardErrorRetry>> HandleAsync(GetDashboardErrorRetriesQuery query)
         {
             return Task.FromResult<IReadOnlyList<DashboardErrorRetry>>(new List<DashboardErrorRetry>());

--- a/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
@@ -21,7 +21,6 @@ using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
 {
@@ -30,14 +29,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.QueryHandler
     /// </summary>
     internal class GetDashboardStaleMessagesQueryHandlerAsync : IQueryHandlerAsync<GetDashboardStaleMessagesQuery, IReadOnlyList<DashboardMessage>>
     {
-        private readonly IDataStorage _dataStorage;
-
-        public GetDashboardStaleMessagesQueryHandlerAsync(IDataStorage dataStorage)
-        {
-            Guard.NotNull(() => dataStorage, dataStorage);
-            _dataStorage = dataStorage;
-        }
-
         public Task<IReadOnlyList<DashboardMessage>> HandleAsync(GetDashboardStaleMessagesQuery query)
         {
             return Task.FromResult<IReadOnlyList<DashboardMessage>>(new List<DashboardMessage>());

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/RollbackMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/RollbackMessageCommandHandler.cs
@@ -32,6 +32,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
     /// <inheritdoc />
     internal class RollbackMessageCommandHandler : ICommandHandler<RollbackMessageCommand<long>>
     {
+        private const string QueueIdParameter = "@QueueID";
+        private const string HeartBeatParameter = "@HeartBeat";
         private readonly IGetTimeFactory _getUtcDateQuery;
         private readonly Lazy<PostgreSqlMessageQueueTransportOptions> _options;
         private readonly IConnectionInformation _connectionInformation;
@@ -73,16 +75,16 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                     using (var command = connection.CreateCommand())
                     {
                         command.Transaction = trans;
-                        command.Parameters.Add("@QueueID", NpgsqlDbType.Bigint);
-                        command.Parameters["@QueueID"].Value = rollBackCommand.QueueId;
+                        command.Parameters.Add(QueueIdParameter, NpgsqlDbType.Bigint);
+                        command.Parameters[QueueIdParameter].Value = rollBackCommand.QueueId;
 
                         if (_options.Value.EnableDelayedProcessing && rollBackCommand.IncreaseQueueDelay.HasValue)
                         {
                             if (rollBackCommand.LastHeartBeat.HasValue)
                             {
                                 command.CommandText = GetRollbackSql(false, true);
-                                command.Parameters.Add("@HeartBeat", NpgsqlDbType.Bigint);
-                                command.Parameters["@HeartBeat"].Value = rollBackCommand.LastHeartBeat.Value.Ticks;
+                                command.Parameters.Add(HeartBeatParameter, NpgsqlDbType.Bigint);
+                                command.Parameters[HeartBeatParameter].Value = rollBackCommand.LastHeartBeat.Value.Ticks;
                             }
                             else
                             {
@@ -99,8 +101,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                             if (rollBackCommand.LastHeartBeat.HasValue)
                             {
                                 command.CommandText = GetRollbackSql(false, true);
-                                command.Parameters.Add("@HeartBeat", NpgsqlDbType.Bigint);
-                                command.Parameters["@HeartBeat"].Value = rollBackCommand.LastHeartBeat.Value.Ticks;
+                                command.Parameters.Add(HeartBeatParameter, NpgsqlDbType.Bigint);
+                                command.Parameters[HeartBeatParameter].Value = rollBackCommand.LastHeartBeat.Value.Ticks;
                             }
                             else
                             {
@@ -118,8 +120,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                         using (var command = connection.CreateCommand())
                         {
                             command.Transaction = trans;
-                            command.Parameters.Add("@QueueID", NpgsqlDbType.Bigint);
-                            command.Parameters["@QueueID"].Value = rollBackCommand.QueueId;
+                            command.Parameters.Add(QueueIdParameter, NpgsqlDbType.Bigint);
+                            command.Parameters[QueueIdParameter].Value = rollBackCommand.QueueId;
                             command.Parameters.Add("@status", NpgsqlDbType.Integer);
                             command.Parameters["@status"].Value = Convert.ToInt16(QueueStatuses.Waiting);
                             command.CommandText =

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandHandler.cs
@@ -36,6 +36,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
     /// <inheritdoc />
     internal class SendMessageCommandHandler : ICommandHandlerWithOutput<SendMessageCommand, long>
     {
+        private const string BodyParameter = "@body";
+        private const string HeadersParameter = "@headers";
         private readonly ITableNameHelper _tableNameHelper;
         private readonly ICompositeSerialization _serializer;
         private bool? _messageExpirationEnabled;
@@ -133,14 +135,14 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                                     Body = commandSend.MessageToSend.Body
                                 }, commandSend.MessageToSend.Headers);
 
-                            command.Parameters.Add("@body", NpgsqlDbType.Bytea, -1);
-                            command.Parameters["@body"].Value = serialization.Output;
+                            command.Parameters.Add(BodyParameter, NpgsqlDbType.Bytea, -1);
+                            command.Parameters[BodyParameter].Value = serialization.Output;
 
                             commandSend.MessageToSend.SetHeader(_headers.StandardHeaders.MessageInterceptorGraph,
                                 serialization.Graph);
 
-                            command.Parameters.Add("@headers", NpgsqlDbType.Bytea, -1);
-                            command.Parameters["@headers"].Value =
+                            command.Parameters.Add(HeadersParameter, NpgsqlDbType.Bytea, -1);
+                            command.Parameters[HeadersParameter].Value =
                                 _serializer.InternalSerializer.ConvertToBytes(commandSend.MessageToSend.Headers);
 
                             var id = Convert.ToInt64(command.ExecuteScalar());
@@ -234,14 +236,14 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                     new MessageBody { Body = commandSend.MessageToSend.Body },
                     commandSend.MessageToSend.Headers);
 
-                command.Parameters.Add("@body", NpgsqlDbType.Bytea, -1);
-                command.Parameters["@body"].Value = serialization.Output;
+                command.Parameters.Add(BodyParameter, NpgsqlDbType.Bytea, -1);
+                command.Parameters[BodyParameter].Value = serialization.Output;
 
                 commandSend.MessageToSend.SetHeader(
                     _headers.StandardHeaders.MessageInterceptorGraph, serialization.Graph);
 
-                command.Parameters.Add("@headers", NpgsqlDbType.Bytea, -1);
-                command.Parameters["@headers"].Value =
+                command.Parameters.Add(HeadersParameter, NpgsqlDbType.Bytea, -1);
+                command.Parameters[HeadersParameter].Value =
                     _serializer.InternalSerializer.ConvertToBytes(commandSend.MessageToSend.Headers);
 
                 id = Convert.ToInt64(command.ExecuteScalar());

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -39,6 +39,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
     /// </summary>
     internal class SendMessageCommandHandlerAsync : ICommandHandlerWithOutputAsync<SendMessageCommand, long>
     {
+        private const string BodyParameter = "@body";
+        private const string HeadersParameter = "@headers";
         private readonly ITableNameHelper _tableNameHelper;
         private readonly ICompositeSerialization _serializer;
         private bool? _messageExpirationEnabled;
@@ -135,14 +137,14 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                                     Body = commandSend.MessageToSend.Body
                                 }, commandSend.MessageToSend.Headers);
 
-                            command.Parameters.Add("@body", NpgsqlDbType.Bytea, -1);
-                            command.Parameters["@body"].Value = serialization.Output;
+                            command.Parameters.Add(BodyParameter, NpgsqlDbType.Bytea, -1);
+                            command.Parameters[BodyParameter].Value = serialization.Output;
 
                             commandSend.MessageToSend.SetHeader(_headers.StandardHeaders.MessageInterceptorGraph,
                                 serialization.Graph);
 
-                            command.Parameters.Add("@headers", NpgsqlDbType.Bytea, -1);
-                            command.Parameters["@headers"].Value =
+                            command.Parameters.Add(HeadersParameter, NpgsqlDbType.Bytea, -1);
+                            command.Parameters[HeadersParameter].Value =
                                 _serializer.InternalSerializer.ConvertToBytes(commandSend.MessageToSend.Headers);
 
                             var id = Convert.ToInt64(await command.ExecuteScalarAsync().ConfigureAwait(false));
@@ -240,14 +242,14 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                     new MessageBody { Body = commandSend.MessageToSend.Body },
                     commandSend.MessageToSend.Headers);
 
-                command.Parameters.Add("@body", NpgsqlDbType.Bytea, -1);
-                command.Parameters["@body"].Value = serialization.Output;
+                command.Parameters.Add(BodyParameter, NpgsqlDbType.Bytea, -1);
+                command.Parameters[BodyParameter].Value = serialization.Output;
 
                 commandSend.MessageToSend.SetHeader(
                     _headers.StandardHeaders.MessageInterceptorGraph, serialization.Graph);
 
-                command.Parameters.Add("@headers", NpgsqlDbType.Bytea, -1);
-                command.Parameters["@headers"].Value =
+                command.Parameters.Add(HeadersParameter, NpgsqlDbType.Bytea, -1);
+                command.Parameters[HeadersParameter].Value =
                     _serializer.InternalSerializer.ConvertToBytes(commandSend.MessageToSend.Headers);
 
                 id = Convert.ToInt64(await command.ExecuteScalarAsync().ConfigureAwait(false));

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueInit.cs
@@ -280,7 +280,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             SetupPolicy(container);
         }
 
-        private void SetupPolicy(IContainer container)
+        private static void SetupPolicy(IContainer container)
         {
             RetrySqlPolicyCreation.Register(container);
         }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueSchema.cs
@@ -30,6 +30,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
     /// </summary>
     public class PostgreSqlMessageQueueSchema
     {
+        private const string ColumnQueueId = "QueueID";
+        private const string ColumnStatus = "Status";
         private readonly ITableNameHelper _tableNameHelper;
         private readonly Lazy<PostgreSqlMessageQueueTransportOptions> _options;
 
@@ -83,14 +85,14 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
         {
             //--main data table--
             var main = new Table(_tableNameHelper.QueueName);
-            var mainPrimaryKey = new Column("QueueID", ColumnTypes.Bigint, false) { Identity = true };
+            var mainPrimaryKey = new Column(ColumnQueueId, ColumnTypes.Bigint, false) { Identity = true };
 
             main.Columns.Add(mainPrimaryKey);
             main.Columns.Add(new Column("Body", ColumnTypes.Bytea, -1, false));
             main.Columns.Add(new Column("Headers", ColumnTypes.Bytea, -1, false));
 
             //add primary key constraint
-            main.Constraints.Add(new Constraint("PK_" + _tableNameHelper.QueueName, ConstraintType.PrimaryKey, "QueueID"));
+            main.Constraints.Add(new Constraint("PK_" + _tableNameHelper.QueueName, ConstraintType.PrimaryKey, ColumnQueueId));
             main.PrimaryKey.Unique = true;
             return main;
         }
@@ -114,14 +116,14 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
         {
             //--Status Table --
             var status = new Table(_tableNameHelper.StatusName);
-            var mainPrimaryKey = new Column("QueueID", ColumnTypes.Bigint, false);
+            var mainPrimaryKey = new Column(ColumnQueueId, ColumnTypes.Bigint, false);
             status.Columns.Add(mainPrimaryKey);
 
             //add primary key constraint
-            status.Constraints.Add(new Constraint("PK_" + _tableNameHelper.StatusName, ConstraintType.PrimaryKey, "QueueID"));
+            status.Constraints.Add(new Constraint("PK_" + _tableNameHelper.StatusName, ConstraintType.PrimaryKey, ColumnQueueId));
             status.PrimaryKey.Unique = true;
 
-            status.Columns.Add(new Column("Status", ColumnTypes.Integer, false));
+            status.Columns.Add(new Column(ColumnStatus, ColumnTypes.Integer, false));
             status.Columns.Add(new Column("CorrelationID", ColumnTypes.Uuid, false));
 
             //add extra user columns
@@ -155,11 +157,11 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
         {
             //--Meta Data Table --
             var meta = new Table(_tableNameHelper.MetaDataName);
-            var mainPrimaryKey = new Column("QueueID", ColumnTypes.Bigint, false);
+            var mainPrimaryKey = new Column(ColumnQueueId, ColumnTypes.Bigint, false);
             meta.Columns.Add(mainPrimaryKey);
 
             //add primary key constraint
-            meta.Constraints.Add(new Constraint("PK_" + _tableNameHelper.MetaDataName, ConstraintType.PrimaryKey, "QueueID"));
+            meta.Constraints.Add(new Constraint("PK_" + _tableNameHelper.MetaDataName, ConstraintType.PrimaryKey, ColumnQueueId));
             meta.PrimaryKey.Unique = true;
 
             if (_options.Value.EnablePriority)
@@ -171,7 +173,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
 
             if (_options.Value.EnableStatus)
             {
-                meta.Columns.Add(new Column("Status", ColumnTypes.Integer, false));
+                meta.Columns.Add(new Column(ColumnStatus, ColumnTypes.Integer, false));
             }
             if (_options.Value.EnableDelayedProcessing)
             {
@@ -213,7 +215,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             var clusterIndex = new List<string>();
             if (_options.Value.EnableStatus)
             {
-                clusterIndex.Add("Status");
+                clusterIndex.Add(ColumnStatus);
             }
             if (_options.Value.EnablePriority)
             {
@@ -235,7 +237,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
 
             if (clusterIndex.Count > 0)
             {
-                clusterIndex.Add("QueueID");
+                clusterIndex.Add(ColumnQueueId);
             }
 
             if (clusterIndex.Count > 0)
@@ -275,7 +277,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             };
             errorTracking.Columns.Add(errorTrackingPrimaryKey);
 
-            errorTracking.Columns.Add(new Column("QueueID", ColumnTypes.Bigint, false));
+            errorTracking.Columns.Add(new Column(ColumnQueueId, ColumnTypes.Bigint, false));
             errorTracking.Columns.Add(new Column("ExceptionType", ColumnTypes.Varchar, 500, false));
             errorTracking.Columns.Add(new Column("RetryCount", ColumnTypes.Integer, false));
 
@@ -283,7 +285,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             errorTracking.Constraints.Add(new Constraint("PK_" + _tableNameHelper.ErrorTrackingName, ConstraintType.PrimaryKey, "ErrorTrackingID"));
             errorTracking.PrimaryKey.Unique = true;
 
-            errorTracking.Constraints.Add(new Constraint($"IX_QueueID{_tableNameHelper.ErrorTrackingName}", ConstraintType.Index, "QueueID"));
+            errorTracking.Constraints.Add(new Constraint($"IX_QueueID{_tableNameHelper.ErrorTrackingName}", ConstraintType.Index, ColumnQueueId));
 
             foreach (var c in errorTracking.Constraints)
             {
@@ -331,9 +333,9 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             var primaryKey = new Column("HistoryID", ColumnTypes.Bigint, false) { Identity = true };
             history.Columns.Add(primaryKey);
 
-            history.Columns.Add(new Column("QueueID", ColumnTypes.Varchar, 100, false));
+            history.Columns.Add(new Column(ColumnQueueId, ColumnTypes.Varchar, 100, false));
             history.Columns.Add(new Column("CorrelationID", ColumnTypes.Varchar, 38, true));
-            history.Columns.Add(new Column("Status", ColumnTypes.Integer, false));
+            history.Columns.Add(new Column(ColumnStatus, ColumnTypes.Integer, false));
             history.Columns.Add(new Column("EnqueuedUtc", ColumnTypes.Timestamp, false));
             history.Columns.Add(new Column("StartedUtc", ColumnTypes.Timestamp, true));
             history.Columns.Add(new Column("CompletedUtc", ColumnTypes.Timestamp, true));
@@ -350,10 +352,10 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             history.PrimaryKey.Unique = true;
 
             // Index on QueueID for lookups by message — name must be unique per schema in PostgreSQL
-            history.Constraints.Add(new Constraint($"IX_{_tableNameHelper.HistoryName}_QueueID", ConstraintType.Index, "QueueID"));
+            history.Constraints.Add(new Constraint($"IX_{_tableNameHelper.HistoryName}_QueueID", ConstraintType.Index, ColumnQueueId));
             // Index on Status + CompletedUtc for purge queries and status filtering
             history.Constraints.Add(new Constraint($"IX_{_tableNameHelper.HistoryName}_Status_Completed", ConstraintType.Index,
-                new List<string> { "Status", "CompletedUtc" }));
+                new List<string> { ColumnStatus, "CompletedUtc" }));
 
             foreach (var c in history.Constraints)
             {

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/ConfigurationExtensions.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/ConfigurationExtensions.cs
@@ -144,6 +144,9 @@ namespace DotNetWorkQueue.Transport.PostgreSQL
     /// </summary>
     public static class QueueQueueConsumerConfigurationExtensions
     {
+        private const string UserDequeueParamsFactoryKey = "userdequeueparamsfactory";
+        private const string UserDequeueParamsKey = "userdequeueparams";
+        private const string UserDequeueFactoryKey = "userdequeuefactory";
         /// <summary>
         /// Gets the user parameters for de-queue
         /// </summary>
@@ -152,11 +155,11 @@ namespace DotNetWorkQueue.Transport.PostgreSQL
         /// <remarks>The factory method will always be returned if set, even if the non-factory method is also set</remarks>
         public static List<NpgsqlParameter> GetUserParameters(this QueueConsumerConfiguration configuration)
         {
-            if (configuration.AdditionalSettings.TryGetValue("userdequeueparamsfactory", out var dequeueParamsFactory))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueParamsFactoryKey, out var dequeueParamsFactory))
             {
                 return ((Func<List<NpgsqlParameter>>)dequeueParamsFactory).Invoke();
             }
-            if (configuration.AdditionalSettings.TryGetValue("userdequeueparams", out var dequeueParams))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueParamsKey, out var dequeueParams))
             {
                 return (List<NpgsqlParameter>)dequeueParams;
             }
@@ -170,7 +173,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL
         /// <remarks>The factory method will always be returned if set, even if the non-factory method is also set</remarks>
         public static string GetUserClause(this QueueConsumerConfiguration configuration)
         {
-            if (configuration.AdditionalSettings.TryGetValue("userdequeuefactory", out var dequeueClauseFactory))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueFactoryKey, out var dequeueClauseFactory))
             {
                 return ((Func<string>)dequeueClauseFactory).Invoke();
             }
@@ -190,22 +193,22 @@ namespace DotNetWorkQueue.Transport.PostgreSQL
         /// <remarks>The delegate will fire every time the queue begins to look for an item to de-queue</remarks>
         public static void SetUserParametersAndClause(this QueueConsumerConfiguration configuration, Func<List<NpgsqlParameter>> parameters, Func<string> whereClause)
         {
-            if (configuration.AdditionalSettings.ContainsKey("userdequeueparamsfactory"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueParamsFactoryKey))
             {
-                configuration.AdditionalSettings["userdequeueparamsfactory"] = parameters;
+                configuration.AdditionalSettings[UserDequeueParamsFactoryKey] = parameters;
             }
             else
             {
-                configuration.AdditionalSettings.Add("userdequeueparamsfactory", parameters);
+                configuration.AdditionalSettings.Add(UserDequeueParamsFactoryKey, parameters);
             }
 
-            if (configuration.AdditionalSettings.ContainsKey("userdequeuefactory"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueFactoryKey))
             {
-                configuration.AdditionalSettings["userdequeuefactory"] = whereClause;
+                configuration.AdditionalSettings[UserDequeueFactoryKey] = whereClause;
             }
             else
             {
-                configuration.AdditionalSettings.Add("userdequeuefactory", whereClause);
+                configuration.AdditionalSettings.Add(UserDequeueFactoryKey, whereClause);
             }
         }
 
@@ -216,14 +219,14 @@ namespace DotNetWorkQueue.Transport.PostgreSQL
         /// <param name="parameter">The parameter.</param>
         public static void AddUserParameter(this QueueConsumerConfiguration configuration, NpgsqlParameter parameter)
         {
-            if (configuration.AdditionalSettings.TryGetValue("userdequeueparams", out var dequeueParams))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueParamsKey, out var dequeueParams))
             {
                 ((List<NpgsqlParameter>)dequeueParams).Add(parameter);
             }
             else
             {
                 var data = new List<NpgsqlParameter> { parameter };
-                configuration.AdditionalSettings.Add("userdequeueparams", data);
+                configuration.AdditionalSettings.Add(UserDequeueParamsKey, data);
             }
         }
 
@@ -234,13 +237,13 @@ namespace DotNetWorkQueue.Transport.PostgreSQL
         /// <param name="parameters">The parameters.</param>
         public static void SetUserParameters(this QueueConsumerConfiguration configuration, List<NpgsqlParameter> parameters)
         {
-            if (configuration.AdditionalSettings.ContainsKey("userdequeueparams"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueParamsKey))
             {
-                configuration.AdditionalSettings["userdequeueparams"] = parameters;
+                configuration.AdditionalSettings[UserDequeueParamsKey] = parameters;
             }
             else
             {
-                configuration.AdditionalSettings.Add("userdequeueparams", parameters);
+                configuration.AdditionalSettings.Add(UserDequeueParamsKey, parameters);
             }
         }
 
@@ -251,7 +254,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL
         /// <param name="whereClause">The where clause.</param>
         public static void SetUserWhereClause(this QueueConsumerConfiguration configuration, string whereClause)
         {
-            if (configuration.AdditionalSettings.ContainsKey("userdequeueparams"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueParamsKey))
             {
                 configuration.AdditionalSettings["userdequeue"] = whereClause;
             }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
@@ -30,17 +30,14 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Trace.Decorator
     public class RollbackMessageCommandHandlerDecorator : ICommandHandler<RollbackMessageCommand<long>>
     {
         private readonly ICommandHandler<RollbackMessageCommand<long>> _handler;
-        private readonly ActivitySource _tracer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RollbackMessageCommandHandlerDecorator"/> class.
         /// </summary>
         /// <param name="handler">The handler.</param>
-        /// <param name="tracer">The tracer.</param>
-        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<long>> handler, ActivitySource tracer)
+        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<long>> handler)
         {
             _handler = handler;
-            _tracer = tracer;
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/PurgeMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/PurgeMessageHistoryHandlerTests.cs
@@ -18,8 +18,8 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
         {
             private readonly IDatabase _db;
 
-            public TestablePurgeMessageHistoryHandler(IRedisConnection connection, RedisNames redisNames, IBaseTransportOptions options, IDatabase db)
-                : base(connection, redisNames, options)
+            public TestablePurgeMessageHistoryHandler(IRedisConnection connection, RedisNames redisNames, IDatabase db)
+                : base(connection, redisNames)
             {
                 _db = db;
             }
@@ -35,10 +35,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             redisNames.Values.Returns("queue:test");
 
-            var options = Substitute.For<IBaseTransportOptions>();
-            options.EnableHistory.Returns(true);
-
-            return (new TestablePurgeMessageHistoryHandler(connection, redisNames, options, db), db);
+            return (new TestablePurgeMessageHistoryHandler(connection, redisNames, db), db);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/QueryMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/QueryMessageHistoryHandlerTests.cs
@@ -21,9 +21,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var connection = Substitute.For<IRedisConnection>();
             var connInfo = Substitute.For<IConnectionInformation>();
             var redisNames = Substitute.For<RedisNames>(connInfo);
-            var options = Substitute.For<IBaseTransportOptions>();
-            options.EnableHistory.Returns(true);
-            var handler = new QueryMessageHistoryHandler(connection, redisNames, options);
+            var handler = new QueryMessageHistoryHandler(connection, redisNames);
 
             try { handler.Get(0, 10, null); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -35,9 +33,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var connection = Substitute.For<IRedisConnection>();
             var connInfo = Substitute.For<IConnectionInformation>();
             var redisNames = Substitute.For<RedisNames>(connInfo);
-            var options = Substitute.For<IBaseTransportOptions>();
-            options.EnableHistory.Returns(true);
-            var handler = new QueryMessageHistoryHandler(connection, redisNames, options);
+            var handler = new QueryMessageHistoryHandler(connection, redisNames);
 
             try { handler.Get(0, 10, MessageHistoryStatus.Complete); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -49,9 +45,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var connection = Substitute.For<IRedisConnection>();
             var connInfo = Substitute.For<IConnectionInformation>();
             var redisNames = Substitute.For<RedisNames>(connInfo);
-            var options = Substitute.For<IBaseTransportOptions>();
-            options.EnableHistory.Returns(true);
-            var handler = new QueryMessageHistoryHandler(connection, redisNames, options);
+            var handler = new QueryMessageHistoryHandler(connection, redisNames);
 
             try { handler.GetByQueueId("q1"); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -63,9 +57,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var connection = Substitute.For<IRedisConnection>();
             var connInfo = Substitute.For<IConnectionInformation>();
             var redisNames = Substitute.For<RedisNames>(connInfo);
-            var options = Substitute.For<IBaseTransportOptions>();
-            options.EnableHistory.Returns(true);
-            var handler = new QueryMessageHistoryHandler(connection, redisNames, options);
+            var handler = new QueryMessageHistoryHandler(connection, redisNames);
 
             try { handler.GetCount(null); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -77,9 +69,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var connection = Substitute.For<IRedisConnection>();
             var connInfo = Substitute.For<IConnectionInformation>();
             var redisNames = Substitute.For<RedisNames>(connInfo);
-            var options = Substitute.For<IBaseTransportOptions>();
-            options.EnableHistory.Returns(true);
-            var handler = new QueryMessageHistoryHandler(connection, redisNames, options);
+            var handler = new QueryMessageHistoryHandler(connection, redisNames);
 
             try { handler.GetCount(MessageHistoryStatus.Error); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -91,8 +81,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var connection = Substitute.For<IRedisConnection>();
             var connInfo = Substitute.For<IConnectionInformation>();
             var redisNames = Substitute.For<RedisNames>(connInfo);
-            var options = Substitute.For<IBaseTransportOptions>();
-            var handler = new QueryMessageHistoryHandler(connection, redisNames, options);
+            var handler = new QueryMessageHistoryHandler(connection, redisNames);
             Assert.IsNotNull(handler);
         }
 
@@ -102,8 +91,8 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
         private class TestableQueryHandler : QueryMessageHistoryHandler
         {
             private readonly IDatabase _db;
-            public TestableQueryHandler(IRedisConnection connection, RedisNames redisNames, IBaseTransportOptions options, IDatabase db)
-                : base(connection, redisNames, options) { _db = db; }
+            public TestableQueryHandler(IRedisConnection connection, RedisNames redisNames, IDatabase db)
+                : base(connection, redisNames) { _db = db; }
             protected override IDatabase GetDb() => _db;
         }
 
@@ -114,10 +103,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             redisNames.Values.Returns("queue:test");
 
-            var options = Substitute.For<IBaseTransportOptions>();
-            options.EnableHistory.Returns(true);
-
-            return new TestableQueryHandler(connection, redisNames, options, db);
+            return new TestableQueryHandler(connection, redisNames, db);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/CommandHandler/SendMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/CommandHandler/SendMessageCommandHandler.cs
@@ -30,6 +30,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
     /// <inheritdoc />
     internal class SendMessageCommandHandler : ICommandHandlerWithOutput<SendMessageCommand, string>
     {
+        private const string EnqueueFailedError = "Failed to enqueue a record. The LUA enqueue script returned null";
         private readonly ICompositeSerialization _serializer;
         private readonly IHeaders _headers;
         private readonly EnqueueLua _enqueueLua;
@@ -158,7 +159,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
 
             if (string.IsNullOrWhiteSpace(result))
             {
-                throw new DotNetWorkQueueException("Failed to enqueue a record. The LUA enqueue script returned null");
+                throw new DotNetWorkQueueException(EnqueueFailedError);
             }
             messageId = result;
             return messageId;
@@ -184,7 +185,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
 
             if (string.IsNullOrWhiteSpace(result))
             {
-                throw new DotNetWorkQueueException("Failed to enqueue a record. The LUA enqueue script returned null");
+                throw new DotNetWorkQueueException(EnqueueFailedError);
             }
             messageId = result;
             return messageId;
@@ -212,7 +213,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
 
             if (string.IsNullOrWhiteSpace(result))
             {
-                throw new DotNetWorkQueueException("Failed to enqueue a record. The LUA enqueue script returned null");
+                throw new DotNetWorkQueueException(EnqueueFailedError);
             }
             messageId = result;
             return messageId;
@@ -238,7 +239,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
 
             if (string.IsNullOrWhiteSpace(result))
             {
-                throw new DotNetWorkQueueException("Failed to enqueue a record. The LUA enqueue script returned null");
+                throw new DotNetWorkQueueException(EnqueueFailedError);
             }
             messageId = result;
             return messageId;

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -31,6 +31,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
     /// <inheritdoc />
     internal class SendMessageCommandHandlerAsync : ICommandHandlerWithOutput<SendMessageCommand, Task<string>>
     {
+        private const string EnqueueFailedError = "Failed to enqueue a record. The LUA enqueue script returned null";
         private readonly ICompositeSerialization _serializer;
         private readonly IHeaders _headers;
         private readonly EnqueueLua _enqueueLua;
@@ -163,7 +164,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
 
             if (string.IsNullOrWhiteSpace(result))
             {
-                throw new DotNetWorkQueueException("Failed to enqueue a record. The LUA enqueue script returned null");
+                throw new DotNetWorkQueueException(EnqueueFailedError);
             }
             messageId = result;
             return messageId;
@@ -188,7 +189,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
 
             if (string.IsNullOrWhiteSpace(result))
             {
-                throw new DotNetWorkQueueException("Failed to enqueue a record. The LUA enqueue script returned null");
+                throw new DotNetWorkQueueException(EnqueueFailedError);
             }
             messageId = result;
             return messageId;
@@ -217,7 +218,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
 
             if (string.IsNullOrWhiteSpace(result))
             {
-                throw new DotNetWorkQueueException("Failed to enqueue a record. The LUA enqueue script returned null");
+                throw new DotNetWorkQueueException(EnqueueFailedError);
             }
             messageId = result;
             return messageId;
@@ -242,7 +243,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
 
             if (string.IsNullOrWhiteSpace(result))
             {
-                throw new DotNetWorkQueueException("Failed to enqueue a record. The LUA enqueue script returned null");
+                throw new DotNetWorkQueueException(EnqueueFailedError);
             }
             messageId = result;
             return messageId;

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/PurgeMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/PurgeMessageHistoryHandler.cs
@@ -27,17 +27,15 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
     {
         private readonly IRedisConnection _connection;
         private readonly RedisNames _redisNames;
-        private readonly IBaseTransportOptions _options;
 
         private string HistoryHashKey(string queueId) => $"{_redisNames.Values}:history:{queueId}";
         private string HistoryIndexKey => $"{_redisNames.Values}:history:index";
 
         /// <inheritdoc />
-        public PurgeMessageHistoryHandler(IRedisConnection connection, RedisNames redisNames, IBaseTransportOptions options)
+        public PurgeMessageHistoryHandler(IRedisConnection connection, RedisNames redisNames)
         {
             _connection = connection;
             _redisNames = redisNames;
-            _options = options;
         }
 
         /// <summary>Returns the Redis database to use. Protected virtual to allow test seam injection.</summary>

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryMessageHistoryHandler.cs
@@ -29,17 +29,15 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
     {
         private readonly IRedisConnection _connection;
         private readonly RedisNames _redisNames;
-        private readonly IBaseTransportOptions _options;
 
         private string HistoryHashKey(string queueId) => $"{_redisNames.Values}:history:{queueId}";
         private string HistoryIndexKey => $"{_redisNames.Values}:history:index";
 
         /// <inheritdoc />
-        public QueryMessageHistoryHandler(IRedisConnection connection, RedisNames redisNames, IBaseTransportOptions options)
+        public QueryMessageHistoryHandler(IRedisConnection connection, RedisNames redisNames)
         {
             _connection = connection;
             _redisNames = redisNames;
-            _options = options;
         }
 
         /// <summary>Returns the Redis database to use. Protected virtual to allow test seam injection.</summary>

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueInit.cs
@@ -281,7 +281,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// Gets the default fatal exception delay time spans
         /// </summary>
         /// <returns></returns>
-        private IEnumerable<TimeSpan> ExceptionDelay()
+        private static IEnumerable<TimeSpan> ExceptionDelay()
         {
             var rc = new List<TimeSpan>(10)
             {
@@ -303,7 +303,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// Gets the default queue delay time spans
         /// </summary>
         /// <returns></returns>
-        private IEnumerable<TimeSpan> DefaultQueueDelay()
+        private static IEnumerable<TimeSpan> DefaultQueueDelay()
         {
             //we use pub/sub to determine if work needs to be done - no delay here is fine
             return new List<TimeSpan>(0);
@@ -313,7 +313,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// Setup the heart beat.
         /// </summary>
         /// <param name="container">The container.</param>
-        private void SetupHeartBeat(IContainer container)
+        private static void SetupHeartBeat(IContainer container)
         {
             var heartBeatConfiguration = container.GetInstance<IHeartBeatConfiguration>();
             heartBeatConfiguration.Time = TimeSpan.FromSeconds(30);
@@ -326,7 +326,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// Setup the message expiration.
         /// </summary>
         /// <param name="container">The container.</param>
-        private void SetupMessageExpiration(IContainer container)
+        private static void SetupMessageExpiration(IContainer container)
         {
             var configuration = container.GetInstance<IMessageExpirationConfiguration>();
             configuration.MonitorTime = TimeSpan.FromMinutes(1);
@@ -337,7 +337,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// Pre-compiles all LUA scripts
         /// </summary>
         /// <param name="container">The container.</param>
-        private void SetupScripts(IContainer container)
+        private static void SetupScripts(IContainer container)
         {
             container.GetInstance<LuaScripts>().Setup();
         }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
@@ -25,6 +25,10 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
     /// <inheritdoc />
     public class WriteMessageHistoryHandler : IWriteMessageHistory
     {
+        private const string FieldStatus = "Status";
+        private const string FieldStartedUtc = "StartedUtc";
+        private const string FieldCompletedUtc = "CompletedUtc";
+        private const string FieldDurationMs = "DurationMs";
         private readonly IRedisConnection _connection;
         private readonly RedisNames _redisNames;
         private readonly IBaseTransportOptions _options;
@@ -52,8 +56,8 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             db.HashSet(HistoryHashKey(queueId), new[]
             {
                 new HashEntry("QueueID", queueId), new HashEntry("CorrelationID", correlationId ?? ""),
-                new HashEntry("Status", (int)MessageHistoryStatus.Enqueued), new HashEntry("EnqueuedUtc", now.Ticks),
-                new HashEntry("StartedUtc", 0L), new HashEntry("CompletedUtc", 0L), new HashEntry("DurationMs", 0L),
+                new HashEntry(FieldStatus, (int)MessageHistoryStatus.Enqueued), new HashEntry("EnqueuedUtc", now.Ticks),
+                new HashEntry(FieldStartedUtc, 0L), new HashEntry(FieldCompletedUtc, 0L), new HashEntry(FieldDurationMs, 0L),
                 new HashEntry("ExceptionText", ""), new HashEntry("RetryCount", 0),
                 new HashEntry("Route", route ?? ""), new HashEntry("MessageType", messageType ?? ""),
             });
@@ -65,9 +69,9 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            var rawStatus = db.HashGet(HistoryHashKey(queueId), "Status");
+            var rawStatus = db.HashGet(HistoryHashKey(queueId), FieldStatus);
             if (!rawStatus.HasValue || (int)rawStatus != (int)MessageHistoryStatus.Enqueued) return;
-            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry("Status", (int)MessageHistoryStatus.Processing), new HashEntry("StartedUtc", DateTime.UtcNow.Ticks) });
+            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Processing), new HashEntry(FieldStartedUtc, DateTime.UtcNow.Ticks) });
         }
 
         /// <inheritdoc />
@@ -76,10 +80,10 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             if (!_options.EnableHistory) return;
             var db = GetDb();
             var now = DateTime.UtcNow;
-            var rawStarted = db.HashGet(HistoryHashKey(queueId), "StartedUtc");
+            var rawStarted = db.HashGet(HistoryHashKey(queueId), FieldStartedUtc);
             var startedTicks = rawStarted.HasValue ? (long)rawStarted : 0L;
             var durationMs = startedTicks > 0 ? (long)(now - new DateTime(startedTicks, DateTimeKind.Utc)).TotalMilliseconds : 0L;
-            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry("Status", (int)MessageHistoryStatus.Complete), new HashEntry("CompletedUtc", now.Ticks), new HashEntry("DurationMs", durationMs) });
+            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Complete), new HashEntry(FieldCompletedUtc, now.Ticks), new HashEntry(FieldDurationMs, durationMs) });
         }
 
         /// <inheritdoc />
@@ -88,10 +92,10 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             if (!_options.EnableHistory) return;
             var db = GetDb();
             var now = DateTime.UtcNow;
-            var rawStarted = db.HashGet(HistoryHashKey(queueId), "StartedUtc");
+            var rawStarted = db.HashGet(HistoryHashKey(queueId), FieldStartedUtc);
             var startedTicks = rawStarted.HasValue ? (long)rawStarted : 0L;
             var durationMs = startedTicks > 0 ? (long)(now - new DateTime(startedTicks, DateTimeKind.Utc)).TotalMilliseconds : 0L;
-            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry("Status", (int)MessageHistoryStatus.Error), new HashEntry("CompletedUtc", now.Ticks), new HashEntry("DurationMs", durationMs), new HashEntry("ExceptionText", exception ?? "") });
+            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Error), new HashEntry(FieldCompletedUtc, now.Ticks), new HashEntry(FieldDurationMs, durationMs), new HashEntry("ExceptionText", exception ?? "") });
         }
 
         /// <inheritdoc />
@@ -100,7 +104,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             if (!_options.EnableHistory) return;
             var db = GetDb();
             db.HashIncrement(HistoryHashKey(queueId), "RetryCount", 1);
-            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry("Status", (int)MessageHistoryStatus.Enqueued), new HashEntry("StartedUtc", 0L), new HashEntry("CompletedUtc", 0L), new HashEntry("DurationMs", 0L) });
+            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Enqueued), new HashEntry(FieldStartedUtc, 0L), new HashEntry(FieldCompletedUtc, 0L), new HashEntry(FieldDurationMs, 0L) });
         }
 
         /// <inheritdoc />
@@ -108,7 +112,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry("Status", (int)MessageHistoryStatus.Deleted), new HashEntry("CompletedUtc", DateTime.UtcNow.Ticks) });
+            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Deleted), new HashEntry(FieldCompletedUtc, DateTime.UtcNow.Ticks) });
         }
 
         /// <inheritdoc />
@@ -116,7 +120,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry("Status", (int)MessageHistoryStatus.Expired), new HashEntry("CompletedUtc", DateTime.UtcNow.Ticks) });
+            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Expired), new HashEntry(FieldCompletedUtc, DateTime.UtcNow.Ticks) });
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Redis/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
@@ -31,17 +31,14 @@ namespace DotNetWorkQueue.Transport.Redis.Trace.Decorator
     public class RollbackMessageCommandHandlerDecorator : ICommandHandler<RollbackMessageCommand<string>>
     {
         private readonly ICommandHandler<RollbackMessageCommand<string>> _handler;
-        private readonly ActivitySource _tracer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RollbackMessageCommandHandlerDecorator"/> class.
         /// </summary>
         /// <param name="handler">The handler.</param>
-        /// <param name="tracer">The tracer.</param>
-        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<string>> handler, ActivitySource tracer)
+        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<string>> handler)
         {
             _handler = handler;
-            _tracer = tracer;
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.Redis/Trace/Decorator/SendMessagesDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Trace/Decorator/SendMessagesDecorator.cs
@@ -33,6 +33,8 @@ namespace DotNetWorkQueue.Transport.Redis.Trace.Decorator
     /// <seealso cref="DotNetWorkQueue.ISendMessages" />
     public class SendMessagesDecorator : ISendMessages
     {
+        private const string SendMessageSpanName = "SendMessage";
+        private const string IsBatchTagName = "IsBatch";
         private readonly ISendMessages _handler;
         private readonly ActivitySource _tracer;
         private readonly IHeaders _headers;
@@ -62,11 +64,11 @@ namespace DotNetWorkQueue.Transport.Redis.Trace.Decorator
         /// <returns></returns>
         public IQueueOutputMessage Send(IMessage messageToSend, IAdditionalMessageData data)
         {
-            using (var scope = _tracer.StartActivity("SendMessage"))
+            using (var scope = _tracer.StartActivity(SendMessageSpanName))
             {
                 scope?.AddCommonTags(data, _connectionInformation);
                 scope?.Add(data);
-                scope?.SetTag("IsBatch", false);
+                scope?.SetTag(IsBatchTagName, false);
                 if (scope != null)
                     messageToSend.Inject(_tracer, scope.Context, _headers.StandardHeaders);
                 try
@@ -99,11 +101,11 @@ namespace DotNetWorkQueue.Transport.Redis.Trace.Decorator
         {
             foreach (var message in messages)
             {
-                using (var scope = _tracer.StartActivity("SendMessage"))
+                using (var scope = _tracer.StartActivity(SendMessageSpanName))
                 {
                     scope?.AddCommonTags(message.MessageData, _connectionInformation);
                     scope?.Add(message.MessageData);
-                    scope?.SetTag("IsBatch", true);
+                    scope?.SetTag(IsBatchTagName, true);
                     if (scope != null)
                         message.Message.Inject(_tracer, scope.Context, _headers.StandardHeaders);
                 }
@@ -120,11 +122,11 @@ namespace DotNetWorkQueue.Transport.Redis.Trace.Decorator
         public async Task<IQueueOutputMessage> SendAsync(IMessage messageToSend, IAdditionalMessageData data)
         {
             //lets add a bit more information to the active span if possible
-            using (var scope = _tracer.StartActivity("SendMessage"))
+            using (var scope = _tracer.StartActivity(SendMessageSpanName))
             {
                 scope?.AddCommonTags(data, _connectionInformation);
                 scope?.Add(data);
-                scope?.SetTag("IsBatch", false);
+                scope?.SetTag(IsBatchTagName, false);
                 if (scope?.Context != null)
                     messageToSend.Inject(_tracer, scope.Context, _headers.StandardHeaders);
                 try
@@ -157,11 +159,11 @@ namespace DotNetWorkQueue.Transport.Redis.Trace.Decorator
         {
             foreach (var message in messages)
             {
-                using (var scope = _tracer.StartActivity("SendMessage"))
+                using (var scope = _tracer.StartActivity(SendMessageSpanName))
                 {
                     scope?.AddCommonTags(message.MessageData, _connectionInformation);
                     scope?.Add(message.MessageData);
-                    scope?.SetTag("IsBatch", true);
+                    scope?.SetTag(IsBatchTagName, true);
                     if (scope?.Context != null)
                         message.Message.Inject(_tracer, scope.Context, _headers.StandardHeaders);
                 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/PurgeMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/PurgeMessageHistoryHandlerTests.cs
@@ -60,7 +60,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             tableNameHelper.HistoryName.Returns("TestHistory");
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(enabled);
-            return (new PurgeMessageHistoryHandler(factory, tableNameHelper, options), factory, options);
+            return (new PurgeMessageHistoryHandler(factory, tableNameHelper), factory, options);
         }
 
         private static (IDbConnection connection, IDbCommand command) SetupConnection(IDbConnectionFactory factory)

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryMessageHistoryHandlerTests.cs
@@ -121,7 +121,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             options.EnableHistory.Returns(enabled);
             options.HistoryOptions.Returns(historyOptions);
             var pagination = new LimitOffsetPaginationSyntax();
-            return (new QueryMessageHistoryHandler(factory, tableNameHelper, options, pagination), factory, options);
+            return (new QueryMessageHistoryHandler(factory, tableNameHelper, pagination), factory, options);
         }
 
         private static (IDbConnection connection, IDbCommand command) SetupConnection(IDbConnectionFactory factory)

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/PurgeMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/PurgeMessageHistoryHandler.cs
@@ -34,18 +34,15 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
     {
         private readonly IDbConnectionFactory _connectionFactory;
         private readonly ITableNameHelper _tableNameHelper;
-        private readonly IBaseTransportOptions _options;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PurgeMessageHistoryHandler"/> class.
         /// </summary>
         public PurgeMessageHistoryHandler(IDbConnectionFactory connectionFactory,
-            ITableNameHelper tableNameHelper,
-            IBaseTransportOptions options)
+            ITableNameHelper tableNameHelper)
         {
             _connectionFactory = connectionFactory;
             _tableNameHelper = tableNameHelper;
-            _options = options;
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryMessageHistoryHandler.cs
@@ -37,7 +37,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
     {
         private readonly IDbConnectionFactory _connectionFactory;
         private readonly ITableNameHelper _tableNameHelper;
-        private readonly IBaseTransportOptions _options;
         private readonly IDbPaginationSyntax _paginationSyntax;
 
         /// <summary>
@@ -45,12 +44,10 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         /// </summary>
         public QueryMessageHistoryHandler(IDbConnectionFactory connectionFactory,
             ITableNameHelper tableNameHelper,
-            IBaseTransportOptions options,
             IDbPaginationSyntax paginationSyntax)
         {
             _connectionFactory = connectionFactory;
             _tableNameHelper = tableNameHelper;
-            _options = options;
             _paginationSyntax = paginationSyntax;
         }
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/RelationalDatabaseMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/RelationalDatabaseMessageQueueInit.cs
@@ -167,7 +167,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
             configuration.Enabled = true;
         }
 
-        private void RegisterCommandsExplicit(IContainer container)
+        private static void RegisterCommandsExplicit(IContainer container)
         {
             container
                 .Register<IQueryHandler<GetQueueCountQuery, long>,
@@ -421,7 +421,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     DashboardUpdateMessageBodyPrepareHandler>(LifeStyles.Singleton);
         }
 
-        private void RegisterCommands(IContainer container, params Assembly[] target)
+        private static void RegisterCommands(IContainer container, params Assembly[] target)
         {
             //commands and decorators
             // Go look in all assemblies and register all implementations

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
@@ -27,6 +27,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
     /// </summary>
     public class WriteMessageHistoryHandler : IWriteMessageHistory
     {
+        private const string QueueIdParameter = "@QueueID";
+        private const string StatusParameter = "@Status";
+        private const string CompletedUtcParameter = "@CompletedUtc";
         private readonly IDbConnectionFactory _connectionFactory;
         private readonly ITableNameHelper _tableNameHelper;
         private readonly IBaseTransportOptions _options;
@@ -57,9 +60,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         (QueueID, CorrelationID, Status, EnqueuedUtc, RetryCount, Route, MessageType, Body, Headers)
                         VALUES (@QueueID, @CorrelationID, @Status, @EnqueuedUtc, 0, @Route, @MessageType, @Body, @Headers)";
 
-                    AddParameter(command, "@QueueID", DbType.String, queueId);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
                     AddParameter(command, "@CorrelationID", DbType.String, (object)correlationId ?? DBNull.Value);
-                    AddParameter(command, "@Status", DbType.Int32, (int)MessageHistoryStatus.Enqueued);
+                    AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Enqueued);
                     AddParameter(command, "@EnqueuedUtc", DbType.DateTime, DateTime.UtcNow);
                     AddParameter(command, "@Route", DbType.String, (object)route ?? DBNull.Value);
                     AddParameter(command, "@MessageType", DbType.String, (object)messageType ?? DBNull.Value);
@@ -84,9 +87,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         SET Status = @Status, StartedUtc = @StartedUtc
                         WHERE QueueID = @QueueID AND Status = @PrevStatus";
 
-                    AddParameter(command, "@Status", DbType.Int32, (int)MessageHistoryStatus.Processing);
+                    AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Processing);
                     AddParameter(command, "@StartedUtc", DbType.DateTime, DateTime.UtcNow);
-                    AddParameter(command, "@QueueID", DbType.String, queueId);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
                     AddParameter(command, "@PrevStatus", DbType.Int32, (int)MessageHistoryStatus.Enqueued);
 
                     command.ExecuteNonQuery();
@@ -108,9 +111,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         SET Status = @Status, CompletedUtc = @CompletedUtc
                         WHERE QueueID = @QueueID AND Status = @PrevStatus";
 
-                    AddParameter(command, "@Status", DbType.Int32, (int)MessageHistoryStatus.Complete);
-                    AddParameter(command, "@CompletedUtc", DbType.DateTime, now);
-                    AddParameter(command, "@QueueID", DbType.String, queueId);
+                    AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Complete);
+                    AddParameter(command, CompletedUtcParameter, DbType.DateTime, now);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
                     AddParameter(command, "@PrevStatus", DbType.Int32, (int)MessageHistoryStatus.Processing);
 
                     command.ExecuteNonQuery();
@@ -128,7 +131,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     var durationMs = startTime.HasValue ? (long)(now - startTime.Value).TotalMilliseconds : 0L;
 
                     AddParameter(command, "@DurationMs", DbType.Int64, durationMs);
-                    AddParameter(command, "@QueueID", DbType.String, queueId);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
 
                     command.ExecuteNonQuery();
                 }
@@ -153,11 +156,11 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         SET Status = @Status, CompletedUtc = @CompletedUtc, DurationMs = @DurationMs, ExceptionText = @ExceptionText
                         WHERE QueueID = @QueueID AND (Status = @PrevStatus1 OR Status = @PrevStatus2)";
 
-                    AddParameter(command, "@Status", DbType.Int32, (int)MessageHistoryStatus.Error);
-                    AddParameter(command, "@CompletedUtc", DbType.DateTime, now);
+                    AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Error);
+                    AddParameter(command, CompletedUtcParameter, DbType.DateTime, now);
                     AddParameter(command, "@DurationMs", DbType.Int64, durationMs);
                     AddParameter(command, "@ExceptionText", DbType.String, (object)exception ?? DBNull.Value);
-                    AddParameter(command, "@QueueID", DbType.String, queueId);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
                     AddParameter(command, "@PrevStatus1", DbType.Int32, (int)MessageHistoryStatus.Processing);
                     AddParameter(command, "@PrevStatus2", DbType.Int32, (int)MessageHistoryStatus.Enqueued);
 
@@ -179,8 +182,8 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         SET Status = @Status, RetryCount = RetryCount + 1, StartedUtc = NULL, CompletedUtc = NULL, DurationMs = NULL
                         WHERE QueueID = @QueueID";
 
-                    AddParameter(command, "@Status", DbType.Int32, (int)MessageHistoryStatus.Enqueued);
-                    AddParameter(command, "@QueueID", DbType.String, queueId);
+                    AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Enqueued);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
 
                     command.ExecuteNonQuery();
                 }
@@ -200,9 +203,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         SET Status = @Status, CompletedUtc = @CompletedUtc
                         WHERE QueueID = @QueueID";
 
-                    AddParameter(command, "@Status", DbType.Int32, (int)MessageHistoryStatus.Deleted);
-                    AddParameter(command, "@CompletedUtc", DbType.DateTime, DateTime.UtcNow);
-                    AddParameter(command, "@QueueID", DbType.String, queueId);
+                    AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Deleted);
+                    AddParameter(command, CompletedUtcParameter, DbType.DateTime, DateTime.UtcNow);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
 
                     command.ExecuteNonQuery();
                 }
@@ -222,9 +225,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         SET Status = @Status, CompletedUtc = @CompletedUtc
                         WHERE QueueID = @QueueID";
 
-                    AddParameter(command, "@Status", DbType.Int32, (int)MessageHistoryStatus.Expired);
-                    AddParameter(command, "@CompletedUtc", DbType.DateTime, DateTime.UtcNow);
-                    AddParameter(command, "@QueueID", DbType.String, queueId);
+                    AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Expired);
+                    AddParameter(command, CompletedUtcParameter, DbType.DateTime, DateTime.UtcNow);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
 
                     command.ExecuteNonQuery();
                 }
@@ -236,7 +239,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = $"SELECT StartedUtc FROM {_tableNameHelper.HistoryName} WHERE QueueID = @QueueID";
-                AddParameter(command, "@QueueID", DbType.String, queueId);
+                AddParameter(command, QueueIdParameter, DbType.String, queueId);
 
                 var result = command.ExecuteScalar();
                 if (result == null || result == DBNull.Value)

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSchema.cs
@@ -30,6 +30,8 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
     /// </summary>
     public class SqLiteMessageQueueSchema
     {
+        private const string ColumnQueueId = "QueueID";
+        private const string ColumnStatus = "Status";
         private readonly ITableNameHelper _tableNameHelper;
         private readonly Lazy<SqLiteMessageQueueTransportOptions> _options;
 
@@ -83,7 +85,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         {
             //--main data table--
             var main = new Table(_tableNameHelper.QueueName);
-            var mainPrimaryKey = new Column("QueueID", ColumnTypes.Integer, false, null) { Identity = new Identity() };
+            var mainPrimaryKey = new Column(ColumnQueueId, ColumnTypes.Integer, false, null) { Identity = new Identity() };
 
             main.Columns.Add(mainPrimaryKey);
             main.Columns.Add(new Column("Body", ColumnTypes.Blob, -1, false, null));
@@ -109,14 +111,14 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         {
             //--Status Table --
             var status = new Table(_tableNameHelper.StatusName);
-            var mainPrimaryKey = new Column("QueueID", ColumnTypes.Integer, false, null);
+            var mainPrimaryKey = new Column(ColumnQueueId, ColumnTypes.Integer, false, null);
             status.Columns.Add(mainPrimaryKey);
 
             //add primary key constraint
-            status.Constraints.Add(new Constraint("PK_" + _tableNameHelper.StatusName, ConstraintType.PrimaryKey, "QueueID"));
+            status.Constraints.Add(new Constraint("PK_" + _tableNameHelper.StatusName, ConstraintType.PrimaryKey, ColumnQueueId));
             status.PrimaryKey.Unique = true;
 
-            status.Columns.Add(new Column("Status", ColumnTypes.Integer, false, null));
+            status.Columns.Add(new Column(ColumnStatus, ColumnTypes.Integer, false, null));
             status.Columns.Add(new Column("CorrelationID", ColumnTypes.Text, 38, false, null));
 
             if (!_options.Value.AdditionalColumnsOnMetaData)
@@ -150,11 +152,11 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         {
             //--Meta Data Table --
             var meta = new Table(_tableNameHelper.MetaDataName);
-            var mainPrimaryKey = new Column("QueueID", ColumnTypes.Integer, false, null);
+            var mainPrimaryKey = new Column(ColumnQueueId, ColumnTypes.Integer, false, null);
             meta.Columns.Add(mainPrimaryKey);
 
             //add primary key constraint
-            meta.Constraints.Add(new Constraint("PK_" + _tableNameHelper.MetaDataName, ConstraintType.PrimaryKey, "QueueID"));
+            meta.Constraints.Add(new Constraint("PK_" + _tableNameHelper.MetaDataName, ConstraintType.PrimaryKey, ColumnQueueId));
             meta.PrimaryKey.Unique = true;
 
             if (_options.Value.EnablePriority)
@@ -166,7 +168,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
 
             if (_options.Value.EnableStatus)
             {
-                meta.Columns.Add(new Column("Status", ColumnTypes.Integer, false, null));
+                meta.Columns.Add(new Column(ColumnStatus, ColumnTypes.Integer, false, null));
             }
             if (_options.Value.EnableDelayedProcessing)
             {
@@ -208,7 +210,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             var clusterIndex = new List<string>();
             if (_options.Value.EnableStatus)
             {
-                clusterIndex.Add("Status");
+                clusterIndex.Add(ColumnStatus);
             }
             if (_options.Value.EnablePriority)
             {
@@ -230,7 +232,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
 
             if (clusterIndex.Count > 0)
             {
-                clusterIndex.Add("QueueID");
+                clusterIndex.Add(ColumnQueueId);
             }
 
             if (clusterIndex.Count > 0)
@@ -270,7 +272,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             };
             errorTracking.Columns.Add(errorTrackingPrimaryKey);
 
-            errorTracking.Columns.Add(new Column("QueueID", ColumnTypes.Integer, false, null));
+            errorTracking.Columns.Add(new Column(ColumnQueueId, ColumnTypes.Integer, false, null));
             errorTracking.Columns.Add(new Column("ExceptionType", ColumnTypes.Text, 500, false, null));
             errorTracking.Columns.Add(new Column("RetryCount", ColumnTypes.Integer, false, null));
 
@@ -278,7 +280,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             //errorTracking.Constraints.Add(new Constraint("PK_" + _tableNameHelper.ErrorTrackingName, ConstraintType.PrimaryKey, "ErrorTrackingID"));
             //errorTracking.PrimaryKey.Unique = true;
 
-            errorTracking.Constraints.Add(new Constraint("IX_QueueID", ConstraintType.Index, "QueueID"));
+            errorTracking.Constraints.Add(new Constraint("IX_QueueID", ConstraintType.Index, ColumnQueueId));
 
             foreach (var c in errorTracking.Constraints)
             {
@@ -327,9 +329,9 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             var primaryKey = new Column("HistoryID", ColumnTypes.Integer, false, null) { Identity = new Identity() };
             history.Columns.Add(primaryKey);
 
-            history.Columns.Add(new Column("QueueID", ColumnTypes.Text, 100, false, null));
+            history.Columns.Add(new Column(ColumnQueueId, ColumnTypes.Text, 100, false, null));
             history.Columns.Add(new Column("CorrelationID", ColumnTypes.Text, 38, true, null));
-            history.Columns.Add(new Column("Status", ColumnTypes.Integer, false, null));
+            history.Columns.Add(new Column(ColumnStatus, ColumnTypes.Integer, false, null));
             history.Columns.Add(new Column("EnqueuedUtc", ColumnTypes.Integer, false, null));
             history.Columns.Add(new Column("StartedUtc", ColumnTypes.Integer, true, null));
             history.Columns.Add(new Column("CompletedUtc", ColumnTypes.Integer, true, null));
@@ -342,10 +344,10 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             history.Columns.Add(new Column("Headers", ColumnTypes.Blob, -1, true, null));
 
             // Index on QueueID for lookups by message — name must be unique per schema
-            history.Constraints.Add(new Constraint($"IX_{_tableNameHelper.HistoryName}_QueueID", ConstraintType.Index, "QueueID"));
+            history.Constraints.Add(new Constraint($"IX_{_tableNameHelper.HistoryName}_QueueID", ConstraintType.Index, ColumnQueueId));
             // Index on Status + CompletedUtc for purge queries and status filtering
             history.Constraints.Add(new Constraint($"IX_{_tableNameHelper.HistoryName}_Status_Completed", ConstraintType.Index,
-                new List<string> { "Status", "CompletedUtc" }));
+                new List<string> { ColumnStatus, "CompletedUtc" }));
 
             foreach (var c in history.Constraints)
             {

--- a/Source/DotNetWorkQueue.Transport.SQLite/ConfigurationExtensions.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/ConfigurationExtensions.cs
@@ -144,6 +144,9 @@ namespace DotNetWorkQueue.Transport.SQLite
     /// </summary>
     public static class QueueQueueConsumerConfigurationExtensions
     {
+        private const string UserDequeueParamsFactoryKey = "userdequeueparamsfactory";
+        private const string UserDequeueParamsKey = "userdequeueparams";
+        private const string UserDequeueFactoryKey = "userdequeuefactory";
         /// <summary>
         /// Gets the user parameters for de-queue
         /// </summary>
@@ -152,11 +155,11 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// <remarks>The factory method will always be returned if set, even if the non-factory method is also set</remarks>
         public static List<SQLiteParameter> GetUserParameters(this QueueConsumerConfiguration configuration)
         {
-            if (configuration.AdditionalSettings.TryGetValue("userdequeueparamsfactory", out var dequeueParamsFactory))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueParamsFactoryKey, out var dequeueParamsFactory))
             {
                 return ((Func<List<SQLiteParameter>>)dequeueParamsFactory).Invoke();
             }
-            if (configuration.AdditionalSettings.TryGetValue("userdequeueparams", out var dequeueParams))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueParamsKey, out var dequeueParams))
             {
                 return (List<SQLiteParameter>)dequeueParams;
             }
@@ -170,7 +173,7 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// <remarks>The factory method will always be returned if set, even if the non-factory method is also set</remarks>
         public static string GetUserClause(this QueueConsumerConfiguration configuration)
         {
-            if (configuration.AdditionalSettings.TryGetValue("userdequeuefactory", out var dequeueClauseFactory))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueFactoryKey, out var dequeueClauseFactory))
             {
                 return ((Func<string>)dequeueClauseFactory).Invoke();
             }
@@ -191,22 +194,22 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// 
         public static void SetUserParametersAndClause(this QueueConsumerConfiguration configuration, Func<List<SQLiteParameter>> parameters, Func<string> whereClause)
         {
-            if (configuration.AdditionalSettings.ContainsKey("userdequeueparamsfactory"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueParamsFactoryKey))
             {
-                configuration.AdditionalSettings["userdequeueparamsfactory"] = parameters;
+                configuration.AdditionalSettings[UserDequeueParamsFactoryKey] = parameters;
             }
             else
             {
-                configuration.AdditionalSettings.Add("userdequeueparamsfactory", parameters);
+                configuration.AdditionalSettings.Add(UserDequeueParamsFactoryKey, parameters);
             }
 
-            if (configuration.AdditionalSettings.ContainsKey("userdequeuefactory"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueFactoryKey))
             {
-                configuration.AdditionalSettings["userdequeuefactory"] = whereClause;
+                configuration.AdditionalSettings[UserDequeueFactoryKey] = whereClause;
             }
             else
             {
-                configuration.AdditionalSettings.Add("userdequeuefactory", whereClause);
+                configuration.AdditionalSettings.Add(UserDequeueFactoryKey, whereClause);
             }
         }
 
@@ -217,14 +220,14 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// <param name="parameter">The parameter.</param>
         public static void AddUserParameter(this QueueConsumerConfiguration configuration, SQLiteParameter parameter)
         {
-            if (configuration.AdditionalSettings.TryGetValue("userdequeueparams", out var dequeueParams))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueParamsKey, out var dequeueParams))
             {
                 ((List<SQLiteParameter>)dequeueParams).Add(parameter);
             }
             else
             {
                 var data = new List<SQLiteParameter> { parameter };
-                configuration.AdditionalSettings.Add("userdequeueparams", data);
+                configuration.AdditionalSettings.Add(UserDequeueParamsKey, data);
             }
         }
 
@@ -235,13 +238,13 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// <param name="parameters">The parameters.</param>
         public static void SetUserParameters(this QueueConsumerConfiguration configuration, List<SQLiteParameter> parameters)
         {
-            if (configuration.AdditionalSettings.ContainsKey("userdequeueparams"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueParamsKey))
             {
-                configuration.AdditionalSettings["userdequeueparams"] = parameters;
+                configuration.AdditionalSettings[UserDequeueParamsKey] = parameters;
             }
             else
             {
-                configuration.AdditionalSettings.Add("userdequeueparams", parameters);
+                configuration.AdditionalSettings.Add(UserDequeueParamsKey, parameters);
             }
         }
 
@@ -252,7 +255,7 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// <param name="whereClause">The where clause.</param>
         public static void SetUserWhereClause(this QueueConsumerConfiguration configuration, string whereClause)
         {
-            if (configuration.AdditionalSettings.ContainsKey("userdequeueparams"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueParamsKey))
             {
                 configuration.AdditionalSettings["userdequeue"] = whereClause;
             }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
@@ -32,17 +32,14 @@ namespace DotNetWorkQueue.Transport.SQLite.Trace.Decorator
     public class RollbackMessageCommandHandlerDecorator : ICommandHandler<RollbackMessageCommand<long>>
     {
         private readonly ICommandHandler<RollbackMessageCommand<long>> _handler;
-        private readonly ActivitySource _tracer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RollbackMessageCommandHandlerDecorator"/> class.
         /// </summary>
         /// <param name="handler">The handler.</param>
-        /// <param name="tracer">The tracer.</param>
-        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<long>> handler, ActivitySource tracer)
+        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<long>> handler)
         {
             _handler = handler;
-            _tracer = tracer;
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/RollbackMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/RollbackMessageCommandHandler.cs
@@ -36,6 +36,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
         private readonly SqlServerCommandStringCache _commandCache;
         private readonly ConcurrentDictionary<string, string> _rollbackDictionary;
         private readonly object _setupSqlLocker = new object();
+        private const string QueueIdParameter = "@QueueID";
+        private const string HeartBeatParameter = "@HeartBeat";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RollbackMessageCommandHandler" /> class.
@@ -73,16 +75,16 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                     using (var command = connection.CreateCommand())
                     {
                         command.Transaction = trans;
-                        command.Parameters.Add("@QueueID", SqlDbType.BigInt);
-                        command.Parameters["@QueueID"].Value = rollBackCommand.QueueId;
+                        command.Parameters.Add(QueueIdParameter, SqlDbType.BigInt);
+                        command.Parameters[QueueIdParameter].Value = rollBackCommand.QueueId;
 
                         if (_options.Value.EnableDelayedProcessing && rollBackCommand.IncreaseQueueDelay.HasValue)
                         {
                             if (rollBackCommand.LastHeartBeat.HasValue)
                             {
                                 command.CommandText = GetRollbackSql(false, true);
-                                command.Parameters.Add("@HeartBeat", SqlDbType.DateTime);
-                                command.Parameters["@HeartBeat"].Value = rollBackCommand.LastHeartBeat.Value;
+                                command.Parameters.Add(HeartBeatParameter, SqlDbType.DateTime);
+                                command.Parameters[HeartBeatParameter].Value = rollBackCommand.LastHeartBeat.Value;
                             }
                             else
                             {
@@ -99,8 +101,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                             if (rollBackCommand.LastHeartBeat.HasValue)
                             {
                                 command.CommandText = GetRollbackSql(false, true);
-                                command.Parameters.Add("@HeartBeat", SqlDbType.DateTime);
-                                command.Parameters["@HeartBeat"].Value = rollBackCommand.LastHeartBeat.Value;
+                                command.Parameters.Add(HeartBeatParameter, SqlDbType.DateTime);
+                                command.Parameters[HeartBeatParameter].Value = rollBackCommand.LastHeartBeat.Value;
                             }
                             else
                             {
@@ -118,8 +120,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                         using (var command = connection.CreateCommand())
                         {
                             command.Transaction = trans;
-                            command.Parameters.Add("@QueueID", SqlDbType.BigInt);
-                            command.Parameters["@QueueID"].Value = rollBackCommand.QueueId;
+                            command.Parameters.Add(QueueIdParameter, SqlDbType.BigInt);
+                            command.Parameters[QueueIdParameter].Value = rollBackCommand.QueueId;
                             command.Parameters.Add("@status", SqlDbType.Int);
                             command.Parameters["@status"].Value = Convert.ToInt16(QueueStatuses.Waiting);
                             command.CommandText =

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandler.cs
@@ -38,6 +38,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
     /// </summary>
     internal class SendMessageCommandHandler : ICommandHandlerWithOutput<SendMessageCommand, long>
     {
+        private const string BodyParameter = "@body";
+        private const string HeadersParameter = "@headers";
         private readonly ITableNameHelper _tableNameHelper;
         private readonly ICompositeSerialization _serializer;
         private bool? _messageExpirationEnabled;
@@ -135,14 +137,14 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                                     Body = commandSend.MessageToSend.Body
                                 }, commandSend.MessageToSend.Headers);
 
-                            command.Parameters.Add("@body", SqlDbType.VarBinary, -1);
-                            command.Parameters["@body"].Value = serialization.Output;
+                            command.Parameters.Add(BodyParameter, SqlDbType.VarBinary, -1);
+                            command.Parameters[BodyParameter].Value = serialization.Output;
 
                             commandSend.MessageToSend.SetHeader(_headers.StandardHeaders.MessageInterceptorGraph,
                                 serialization.Graph);
 
-                            command.Parameters.Add("@headers", SqlDbType.VarBinary, -1);
-                            command.Parameters["@headers"].Value =
+                            command.Parameters.Add(HeadersParameter, SqlDbType.VarBinary, -1);
+                            command.Parameters[HeadersParameter].Value =
                                 _serializer.InternalSerializer.ConvertToBytes(commandSend.MessageToSend.Headers);
 
                             var id = Convert.ToInt64(command.ExecuteScalar());
@@ -236,14 +238,14 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                     new MessageBody { Body = commandSend.MessageToSend.Body },
                     commandSend.MessageToSend.Headers);
 
-                command.Parameters.Add("@body", SqlDbType.VarBinary, -1);
-                command.Parameters["@body"].Value = serialization.Output;
+                command.Parameters.Add(BodyParameter, SqlDbType.VarBinary, -1);
+                command.Parameters[BodyParameter].Value = serialization.Output;
 
                 commandSend.MessageToSend.SetHeader(
                     _headers.StandardHeaders.MessageInterceptorGraph, serialization.Graph);
 
-                command.Parameters.Add("@headers", SqlDbType.VarBinary, -1);
-                command.Parameters["@headers"].Value =
+                command.Parameters.Add(HeadersParameter, SqlDbType.VarBinary, -1);
+                command.Parameters[HeadersParameter].Value =
                     _serializer.InternalSerializer.ConvertToBytes(commandSend.MessageToSend.Headers);
 
                 id = Convert.ToInt64(command.ExecuteScalar());

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -38,6 +38,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
     /// </summary>
     internal class SendMessageCommandHandlerAsync : ICommandHandlerWithOutputAsync<SendMessageCommand, long>
     {
+        private const string BodyParameter = "@body";
+        private const string HeadersParameter = "@headers";
         private readonly ITableNameHelper _tableNameHelper;
         private readonly ICompositeSerialization _serializer;
         private bool? _messageExpirationEnabled;
@@ -134,14 +136,14 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                                     Body = commandSend.MessageToSend.Body
                                 }, commandSend.MessageToSend.Headers);
 
-                            command.Parameters.Add("@body", SqlDbType.VarBinary, -1);
-                            command.Parameters["@body"].Value = serialization.Output;
+                            command.Parameters.Add(BodyParameter, SqlDbType.VarBinary, -1);
+                            command.Parameters[BodyParameter].Value = serialization.Output;
 
                             commandSend.MessageToSend.SetHeader(_headers.StandardHeaders.MessageInterceptorGraph,
                                 serialization.Graph);
 
-                            command.Parameters.Add("@headers", SqlDbType.VarBinary, -1);
-                            command.Parameters["@headers"].Value =
+                            command.Parameters.Add(HeadersParameter, SqlDbType.VarBinary, -1);
+                            command.Parameters[HeadersParameter].Value =
                                 _serializer.InternalSerializer.ConvertToBytes(commandSend.MessageToSend.Headers);
 
                             var id = Convert.ToInt64(await command.ExecuteScalarAsync().ConfigureAwait(false));
@@ -240,14 +242,14 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                     new MessageBody { Body = commandSend.MessageToSend.Body },
                     commandSend.MessageToSend.Headers);
 
-                command.Parameters.Add("@body", SqlDbType.VarBinary, -1);
-                command.Parameters["@body"].Value = serialization.Output;
+                command.Parameters.Add(BodyParameter, SqlDbType.VarBinary, -1);
+                command.Parameters[BodyParameter].Value = serialization.Output;
 
                 commandSend.MessageToSend.SetHeader(
                     _headers.StandardHeaders.MessageInterceptorGraph, serialization.Graph);
 
-                command.Parameters.Add("@headers", SqlDbType.VarBinary, -1);
-                command.Parameters["@headers"].Value =
+                command.Parameters.Add(HeadersParameter, SqlDbType.VarBinary, -1);
+                command.Parameters[HeadersParameter].Value =
                     _serializer.InternalSerializer.ConvertToBytes(commandSend.MessageToSend.Headers);
 
                 id = Convert.ToInt64(await command.ExecuteScalarAsync().ConfigureAwait(false));

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueInit.cs
@@ -271,7 +271,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             init.SetDefaultsIfNeeded(container, "SqlServerMessageQueueTransportOptions", "SqlServerMessageQueueTransportOptions");
         }
 
-        private void SetupPolicy(IContainer container)
+        private static void SetupPolicy(IContainer container)
         {
             RetrySqlPolicyCreation.Register(container);
         }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueSchema.cs
@@ -30,6 +30,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
     /// </summary>
     public class SqlServerMessageQueueSchema
     {
+        private const string ColumnQueueId = "QueueID";
+        private const string ColumnStatus = "Status";
         private readonly ITableNameHelper _tableNameHelper;
         private readonly Lazy<SqlServerMessageQueueTransportOptions> _options;
         private readonly ISqlSchema _schema;
@@ -84,14 +86,14 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         {
             //--main data table--
             var main = new Table(GetOwner(), _tableNameHelper.QueueName);
-            var mainPrimaryKey = new Column("QueueID", ColumnTypes.Bigint, false, null) { Identity = new Identity(1, 1) };
+            var mainPrimaryKey = new Column(ColumnQueueId, ColumnTypes.Bigint, false, null) { Identity = new Identity(1, 1) };
 
             main.Columns.Add(mainPrimaryKey);
             main.Columns.Add(new Column("Body", ColumnTypes.Varbinary, -1, false, null));
             main.Columns.Add(new Column("Headers", ColumnTypes.Varbinary, -1, false, null));
 
             //add primary key constraint
-            main.Constraints.Add(new Constraint("PK_" + _tableNameHelper.QueueName, ConstraintType.PrimaryKey, "QueueID"));
+            main.Constraints.Add(new Constraint("PK_" + _tableNameHelper.QueueName, ConstraintType.PrimaryKey, ColumnQueueId));
             main.PrimaryKey.Clustered = true;
             main.PrimaryKey.Unique = true;
             return main;
@@ -117,15 +119,15 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         {
             //--Status Table --
             var status = new Table(GetOwner(), _tableNameHelper.StatusName);
-            var mainPrimaryKey = new Column("QueueID", ColumnTypes.Bigint, false, null);
+            var mainPrimaryKey = new Column(ColumnQueueId, ColumnTypes.Bigint, false, null);
             status.Columns.Add(mainPrimaryKey);
 
             //add primary key constraint
-            status.Constraints.Add(new Constraint("PK_" + _tableNameHelper.StatusName, ConstraintType.PrimaryKey, "QueueID"));
+            status.Constraints.Add(new Constraint("PK_" + _tableNameHelper.StatusName, ConstraintType.PrimaryKey, ColumnQueueId));
             status.PrimaryKey.Unique = true;
             status.PrimaryKey.Clustered = true;
 
-            status.Columns.Add(new Column("Status", ColumnTypes.Int, false, null));
+            status.Columns.Add(new Column(ColumnStatus, ColumnTypes.Int, false, null));
             status.Columns.Add(new Column("CorrelationID", ColumnTypes.Uniqueidentifier, false, null));
 
             if (!_options.Value.AdditionalColumnsOnMetaData)
@@ -159,11 +161,11 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         {
             //--Meta Data Table --
             var meta = new Table(GetOwner(), _tableNameHelper.MetaDataName);
-            var mainPrimaryKey = new Column("QueueID", ColumnTypes.Bigint, false, null);
+            var mainPrimaryKey = new Column(ColumnQueueId, ColumnTypes.Bigint, false, null);
             meta.Columns.Add(mainPrimaryKey);
 
             //add primary key constraint
-            meta.Constraints.Add(new Constraint("PK_" + _tableNameHelper.MetaDataName, ConstraintType.PrimaryKey, "QueueID"));
+            meta.Constraints.Add(new Constraint("PK_" + _tableNameHelper.MetaDataName, ConstraintType.PrimaryKey, ColumnQueueId));
             meta.PrimaryKey.Unique = true;
 
             if (_options.Value.EnablePriority)
@@ -175,7 +177,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
 
             if (_options.Value.EnableStatus)
             {
-                meta.Columns.Add(new Column("Status", ColumnTypes.Int, false, null));
+                meta.Columns.Add(new Column(ColumnStatus, ColumnTypes.Int, false, null));
             }
             if (_options.Value.EnableDelayedProcessing)
             {
@@ -218,7 +220,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             var clusterIndex = new List<string>();
             if (_options.Value.EnableStatus)
             {
-                clusterIndex.Add("Status");
+                clusterIndex.Add(ColumnStatus);
             }
             if (_options.Value.EnablePriority)
             {
@@ -240,7 +242,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
 
             if (clusterIndex.Count > 0)
             {
-                clusterIndex.Add("QueueID");
+                clusterIndex.Add(ColumnQueueId);
                 var cluster = new Constraint("IX_DeQueue", ConstraintType.Index, clusterIndex)
                 {
                     Clustered = true,
@@ -281,7 +283,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             };
             errorTracking.Columns.Add(errorTrackingPrimaryKey);
 
-            errorTracking.Columns.Add(new Column("QueueID", ColumnTypes.Bigint, false, null));
+            errorTracking.Columns.Add(new Column(ColumnQueueId, ColumnTypes.Bigint, false, null));
             errorTracking.Columns.Add(new Column("ExceptionType", ColumnTypes.Varchar, 500, false, null));
             errorTracking.Columns.Add(new Column("RetryCount", ColumnTypes.Int, false, null));
 
@@ -290,7 +292,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             errorTracking.PrimaryKey.Clustered = true;
             errorTracking.PrimaryKey.Unique = true;
 
-            errorTracking.Constraints.Add(new Constraint("IX_QueueID", ConstraintType.Index, "QueueID"));
+            errorTracking.Constraints.Add(new Constraint("IX_QueueID", ConstraintType.Index, ColumnQueueId));
 
             foreach (var c in errorTracking.Constraints)
             {
@@ -339,9 +341,9 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             var primaryKey = new Column("HistoryID", ColumnTypes.Bigint, false, null) { Identity = new Identity(1, 1) };
             history.Columns.Add(primaryKey);
 
-            history.Columns.Add(new Column("QueueID", ColumnTypes.Nvarchar, 100, false, null));
+            history.Columns.Add(new Column(ColumnQueueId, ColumnTypes.Nvarchar, 100, false, null));
             history.Columns.Add(new Column("CorrelationID", ColumnTypes.Nvarchar, 38, true, null));
-            history.Columns.Add(new Column("Status", ColumnTypes.Int, false, null));
+            history.Columns.Add(new Column(ColumnStatus, ColumnTypes.Int, false, null));
             history.Columns.Add(new Column("EnqueuedUtc", ColumnTypes.Datetime, false, null));
             history.Columns.Add(new Column("StartedUtc", ColumnTypes.Datetime, true, null));
             history.Columns.Add(new Column("CompletedUtc", ColumnTypes.Datetime, true, null));
@@ -359,10 +361,10 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             history.PrimaryKey.Unique = true;
 
             // Index on QueueID for lookups by message — name must be unique per schema
-            history.Constraints.Add(new Constraint($"IX_{_tableNameHelper.HistoryName}_QueueID", ConstraintType.Index, "QueueID"));
+            history.Constraints.Add(new Constraint($"IX_{_tableNameHelper.HistoryName}_QueueID", ConstraintType.Index, ColumnQueueId));
             // Index on Status + CompletedUtc for purge queries and status filtering
             history.Constraints.Add(new Constraint($"IX_{_tableNameHelper.HistoryName}_Status_Completed", ConstraintType.Index,
-                new List<string> { "Status", "CompletedUtc" }));
+                new List<string> { ColumnStatus, "CompletedUtc" }));
 
             foreach (var c in history.Constraints)
             {

--- a/Source/DotNetWorkQueue.Transport.SqlServer/ConfigurationExtensions.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/ConfigurationExtensions.cs
@@ -176,6 +176,9 @@ namespace DotNetWorkQueue.Transport.SqlServer
     /// </summary>
     public static class QueueQueueConsumerConfigurationExtensions
     {
+        private const string UserDequeueParamsFactoryKey = "userdequeueparamsfactory";
+        private const string UserDequeueParamsKey = "userdequeueparams";
+        private const string UserDequeueFactoryKey = "userdequeuefactory";
         /// <summary>
         /// Gets the user parameters for de-queue
         /// </summary>
@@ -184,11 +187,11 @@ namespace DotNetWorkQueue.Transport.SqlServer
         /// <remarks>The factory method will always be returned if set, even if the non-factory method is also set</remarks>
         public static List<SqlParameter> GetUserParameters(this QueueConsumerConfiguration configuration)
         {
-            if (configuration.AdditionalSettings.TryGetValue("userdequeueparamsfactory", out var dequeueParamsFactory))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueParamsFactoryKey, out var dequeueParamsFactory))
             {
                 return ((Func<List<SqlParameter>>)dequeueParamsFactory).Invoke();
             }
-            if (configuration.AdditionalSettings.TryGetValue("userdequeueparams", out var dequeueParams))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueParamsKey, out var dequeueParams))
             {
                 return (List<SqlParameter>)dequeueParams;
             }
@@ -202,7 +205,7 @@ namespace DotNetWorkQueue.Transport.SqlServer
         /// <remarks>The factory method will always be returned if set, even if the non-factory method is also set</remarks>
         public static string GetUserClause(this QueueConsumerConfiguration configuration)
         {
-            if (configuration.AdditionalSettings.TryGetValue("userdequeuefactory", out var dequeueClauseFactory))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueFactoryKey, out var dequeueClauseFactory))
             {
                 return ((Func<string>)dequeueClauseFactory).Invoke();
             }
@@ -222,22 +225,22 @@ namespace DotNetWorkQueue.Transport.SqlServer
         /// <remarks>The delegate will fire every time the queue begins to look for an item to de-queue</remarks>
         public static void SetUserParametersAndClause(this QueueConsumerConfiguration configuration, Func<List<SqlParameter>> parameters, Func<string> whereClause)
         {
-            if (configuration.AdditionalSettings.ContainsKey("userdequeueparamsfactory"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueParamsFactoryKey))
             {
-                configuration.AdditionalSettings["userdequeueparamsfactory"] = parameters;
+                configuration.AdditionalSettings[UserDequeueParamsFactoryKey] = parameters;
             }
             else
             {
-                configuration.AdditionalSettings.Add("userdequeueparamsfactory", parameters);
+                configuration.AdditionalSettings.Add(UserDequeueParamsFactoryKey, parameters);
             }
 
-            if (configuration.AdditionalSettings.ContainsKey("userdequeuefactory"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueFactoryKey))
             {
-                configuration.AdditionalSettings["userdequeuefactory"] = whereClause;
+                configuration.AdditionalSettings[UserDequeueFactoryKey] = whereClause;
             }
             else
             {
-                configuration.AdditionalSettings.Add("userdequeuefactory", whereClause);
+                configuration.AdditionalSettings.Add(UserDequeueFactoryKey, whereClause);
             }
         }
 
@@ -248,14 +251,14 @@ namespace DotNetWorkQueue.Transport.SqlServer
         /// <param name="parameter">The parameter.</param>
         public static void AddUserParameter(this QueueConsumerConfiguration configuration, SqlParameter parameter)
         {
-            if (configuration.AdditionalSettings.TryGetValue("userdequeueparams", out var dequeueParams))
+            if (configuration.AdditionalSettings.TryGetValue(UserDequeueParamsKey, out var dequeueParams))
             {
                 ((List<SqlParameter>)dequeueParams).Add(parameter);
             }
             else
             {
                 var data = new List<SqlParameter> { parameter };
-                configuration.AdditionalSettings.Add("userdequeueparams", data);
+                configuration.AdditionalSettings.Add(UserDequeueParamsKey, data);
             }
         }
 
@@ -266,13 +269,13 @@ namespace DotNetWorkQueue.Transport.SqlServer
         /// <param name="parameters">The parameters.</param>
         public static void SetUserParameters(this QueueConsumerConfiguration configuration, List<SqlParameter> parameters)
         {
-            if (configuration.AdditionalSettings.ContainsKey("userdequeueparams"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueParamsKey))
             {
-                configuration.AdditionalSettings["userdequeueparams"] = parameters;
+                configuration.AdditionalSettings[UserDequeueParamsKey] = parameters;
             }
             else
             {
-                configuration.AdditionalSettings.Add("userdequeueparams", parameters);
+                configuration.AdditionalSettings.Add(UserDequeueParamsKey, parameters);
             }
         }
 
@@ -283,7 +286,7 @@ namespace DotNetWorkQueue.Transport.SqlServer
         /// <param name="whereClause">The where clause.</param>
         public static void SetUserWhereClause(this QueueConsumerConfiguration configuration, string whereClause)
         {
-            if (configuration.AdditionalSettings.ContainsKey("userdequeueparams"))
+            if (configuration.AdditionalSettings.ContainsKey(UserDequeueParamsKey))
             {
                 configuration.AdditionalSettings["userdequeue"] = whereClause;
             }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Trace/Decorator/RollbackMessageCommandHandlerDecorator.cs
@@ -32,17 +32,14 @@ namespace DotNetWorkQueue.Transport.SqlServer.Trace.Decorator
     public class RollbackMessageCommandHandlerDecorator : ICommandHandler<RollbackMessageCommand<long>>
     {
         private readonly ICommandHandler<RollbackMessageCommand<long>> _handler;
-        private readonly ActivitySource _tracer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RollbackMessageCommandHandlerDecorator"/> class.
         /// </summary>
         /// <param name="handler">The handler.</param>
-        /// <param name="tracer">The tracer.</param>
-        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<long>> handler, ActivitySource tracer)
+        public RollbackMessageCommandHandlerDecorator(ICommandHandler<RollbackMessageCommand<long>> handler)
         {
             _handler = handler;
-            _tracer = tracer;
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue/Configuration/RetryDelay.cs
+++ b/Source/DotNetWorkQueue/Configuration/RetryDelay.cs
@@ -107,7 +107,7 @@ namespace DotNetWorkQueue.Configuration
         /// </summary>
         /// <param name="exceptionType">Type of the exception.</param>
         /// <returns></returns>
-        private IEnumerable<Type> GetAllExceptionTypes(Type exceptionType)
+        private static IEnumerable<Type> GetAllExceptionTypes(Type exceptionType)
         {
             for (var current = exceptionType; current != null; current = current.BaseType)
                 yield return current;

--- a/Source/DotNetWorkQueue/IoC/ContainerWrapper.cs
+++ b/Source/DotNetWorkQueue/IoC/ContainerWrapper.cs
@@ -351,7 +351,7 @@ namespace DotNetWorkQueue.IoC
         /// <param name="lifeStyle">The life style.</param>
         /// <returns></returns>
         /// <exception cref="DotNetWorkQueueException"></exception>
-        private Lifestyle GetLifeStyle(LifeStyles lifeStyle)
+        private static Lifestyle GetLifeStyle(LifeStyles lifeStyle)
         {
             switch (lifeStyle)
             {

--- a/Source/DotNetWorkQueue/IoC/CreateContainer.cs
+++ b/Source/DotNetWorkQueue/IoC/CreateContainer.cs
@@ -171,7 +171,7 @@ namespace DotNetWorkQueue.IoC
         /// Default, Send, Receive
         /// </returns>
         /// <exception cref="DotNetWorkQueueException">A transport init module should inherit from ITransportInitSend, ITransportInitReceive or ITransportInitDuplex</exception>
-        private RegistrationTypes GetRegistrationType(ITransportInit registration)
+        private static RegistrationTypes GetRegistrationType(ITransportInit registration)
         {
             if (registration is ITransportInitDuplex ||
                 registration is ITransportInitReceive && registration is ITransportInitSend)

--- a/Source/DotNetWorkQueue/Messages/MessageMethodHandling.cs
+++ b/Source/DotNetWorkQueue/Messages/MessageMethodHandling.cs
@@ -111,7 +111,7 @@ namespace DotNetWorkQueue.Messages
         /// <param name="action">The action.</param>
         /// <param name="receivedMessage">The received message.</param>
         /// <param name="workerNotification">The worker notification.</param>
-        private void HandleAction(Action<IReceivedMessage<MessageExpression>, IWorkerNotification> action, IReceivedMessage<MessageExpression> receivedMessage, IWorkerNotification workerNotification)
+        private static void HandleAction(Action<IReceivedMessage<MessageExpression>, IWorkerNotification> action, IReceivedMessage<MessageExpression> receivedMessage, IWorkerNotification workerNotification)
         {
             action.DynamicInvoke(receivedMessage, workerNotification);
         }

--- a/Source/DotNetWorkQueue/Metrics/Decorator/IInternalSerializerDecorator.cs
+++ b/Source/DotNetWorkQueue/Metrics/Decorator/IInternalSerializerDecorator.cs
@@ -24,9 +24,7 @@ namespace DotNetWorkQueue.Metrics.Decorator
     {
         private readonly ITimer _messageToBytesTimer;
         private readonly ITimer _bytesToMessageTimer;
-        private readonly ITimer _messageToStringTimer;
         private readonly IHistogram _resultSizeHistogram;
-        private readonly IHistogram _resultSizeStringHistogram;
         private readonly IInternalSerializer _handler;
 
         /// <summary>
@@ -42,9 +40,7 @@ namespace DotNetWorkQueue.Metrics.Decorator
             var name = "InternalSerializer";
             _bytesToMessageTimer = metrics.Timer($"dotnetworkqueue.{connectionInformation.QueueName}.{name}.ConvertBytesToTimer", Units.Calls);
             _messageToBytesTimer = metrics.Timer($"dotnetworkqueue.{connectionInformation.QueueName}.{name}.ConvertToBytesTimer", Units.Calls);
-            _messageToStringTimer = metrics.Timer($"dotnetworkqueue.{connectionInformation.QueueName}.{name}.ConvertToStringTimer", Units.Calls);
             _resultSizeHistogram = metrics.Histogram($"dotnetworkqueue.{connectionInformation.QueueName}.{name}.ConvertToBytesHistogram", Units.Bytes);
-            _resultSizeStringHistogram = metrics.Histogram($"dotnetworkqueue.{connectionInformation.QueueName}.{name}.ConvertToStringHistogram", Units.Bytes);
             _handler = handler;
         }
 

--- a/Source/DotNetWorkQueue/Queue/MessageHandlerCancellationDecorator.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageHandlerCancellationDecorator.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace DotNetWorkQueue.Queue
 {
@@ -30,15 +29,12 @@ namespace DotNetWorkQueue.Queue
     {
         private readonly IMessageHandler _handler;
         private readonly MessageCancellationTracker _tracker;
-        private readonly ILogger _log;
 
         public MessageHandlerCancellationDecorator(IMessageHandler handler,
-            MessageCancellationTracker tracker,
-            ILogger log)
+            MessageCancellationTracker tracker)
         {
             _handler = handler;
             _tracker = tracker;
-            _log = log;
         }
 
         public void Handle(IReceivedMessageInternal message, IWorkerNotification workerNotification)
@@ -84,15 +80,12 @@ namespace DotNetWorkQueue.Queue
     {
         private readonly IMessageHandlerAsync _handler;
         private readonly MessageCancellationTracker _tracker;
-        private readonly ILogger _log;
 
         public MessageHandlerAsyncCancellationDecorator(IMessageHandlerAsync handler,
-            MessageCancellationTracker tracker,
-            ILogger log)
+            MessageCancellationTracker tracker)
         {
             _handler = handler;
             _tracker = tracker;
-            _log = log;
         }
 
         public async Task HandleAsync(IReceivedMessageInternal message, IWorkerNotification workerNotification)

--- a/Source/DotNetWorkQueue/Queue/ProducerMethodQueue.cs
+++ b/Source/DotNetWorkQueue/Queue/ProducerMethodQueue.cs
@@ -33,25 +33,20 @@ namespace DotNetWorkQueue.Queue
     {
         private readonly IProducerQueue<MessageExpression> _queue;
         private readonly IExpressionSerializer _serializer;
-        private readonly ICompositeSerialization _compositeSerialization;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProducerMethodQueue" /> class.
         /// </summary>
         /// <param name="queue">The queue.</param>
         /// <param name="serializer">The serializer.</param>
-        /// <param name="compositeSerialization">The composite serialization.</param>
         public ProducerMethodQueue(IProducerQueue<MessageExpression> queue,
-            IExpressionSerializer serializer,
-            ICompositeSerialization compositeSerialization)
+            IExpressionSerializer serializer)
         {
             Guard.NotNull(() => queue, queue);
             Guard.NotNull(() => serializer, serializer);
-            Guard.NotNull(() => compositeSerialization, compositeSerialization);
 
             _queue = queue;
             _serializer = serializer;
-            _compositeSerialization = compositeSerialization;
         }
         /// <inheritdoc />
         public QueueProducerConfiguration Configuration => _queue.Configuration;

--- a/Source/DotNetWorkQueue/Queue/ProducerQueue.cs
+++ b/Source/DotNetWorkQueue/Queue/ProducerQueue.cs
@@ -247,7 +247,7 @@ namespace DotNetWorkQueue.Queue
         /// Checks that the message type is public and throws an exception if it is not
         /// </summary>
         /// <remarks>Might remove this requirement in the future; a bit tricky since we use dynamic types to avoid passing the message type all over the consumer queue implementations</remarks>
-        private void CheckMessageType()
+        private static void CheckMessageType()
         {
             var messageType = typeof(T);
             if (messageType.IsNotPublic)

--- a/Source/DotNetWorkQueue/Queue/WaitForThreadToFinish.cs
+++ b/Source/DotNetWorkQueue/Queue/WaitForThreadToFinish.cs
@@ -18,8 +18,6 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Threading.Tasks;
-using DotNetWorkQueue.Validation;
-using Microsoft.Extensions.Logging;
 
 namespace DotNetWorkQueue.Queue
 {
@@ -28,16 +26,6 @@ namespace DotNetWorkQueue.Queue
     /// </summary>
     public class WaitForThreadToFinish
     {
-        private readonly ILogger _log;
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WaitForThreadToFinish"/> class.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        public WaitForThreadToFinish(ILogger log)
-        {
-            Guard.NotNull(() => log, log);
-            _log = log;
-        }
         /// <summary>
         ///  Waits for specified worker task to finish, or until the timeout period has been reached.
         /// </summary>

--- a/Source/DotNetWorkQueue/Trace/InjectHeaders.cs
+++ b/Source/DotNetWorkQueue/Trace/InjectHeaders.cs
@@ -33,6 +33,7 @@ namespace DotNetWorkQueue.Trace
     /// </summary>
     public static class TraceExtensions
     {
+        private const string MessageIdTagName = "MessageId";
         /// <summary>
         /// Injects the specified tracer.
         /// </summary>
@@ -168,7 +169,7 @@ namespace DotNetWorkQueue.Trace
         public static void AddMessageIdTag(this Activity span, IQueueOutputMessage message)
         {
             if (message.SentMessage.MessageId.HasValue)
-                span.SetTag("MessageId", message.SentMessage.MessageId.Id.Value.ToString());
+                span.SetTag(MessageIdTagName, message.SentMessage.MessageId.Id.Value.ToString());
         }
         /// <summary>
         /// Adds the message identifier tag.
@@ -178,7 +179,7 @@ namespace DotNetWorkQueue.Trace
         public static void AddMessageIdTag(this Activity span, IReceivedMessageInternal message)
         {
             if (message.MessageId.HasValue)
-                span.SetTag("MessageId", message.MessageId.Id.Value.ToString());
+                span.SetTag(MessageIdTagName, message.MessageId.Id.Value.ToString());
         }
         /// <summary>
         /// Adds the message identifier tag.
@@ -188,7 +189,7 @@ namespace DotNetWorkQueue.Trace
         public static void AddMessageIdTag(this Activity span, IMessageContext context)
         {
             if (context.MessageId.HasValue)
-                span.SetTag("MessageId", context.MessageId.Id.Value.ToString());
+                span.SetTag(MessageIdTagName, context.MessageId.Id.Value.ToString());
         }
         /// <summary>
         /// Adds the message identifier tag.
@@ -198,7 +199,7 @@ namespace DotNetWorkQueue.Trace
         public static void AddMessageIdTag(this Activity span, IMessageId id)
         {
             if (id != null && id.HasValue)
-                span.SetTag("MessageId", id.Id.Value.ToString());
+                span.SetTag(MessageIdTagName, id.Id.Value.ToString());
         }
         /// <summary>
         /// Adds the message identifier tag.
@@ -208,7 +209,7 @@ namespace DotNetWorkQueue.Trace
         public static void AddMessageIdTag(this Activity span, string id)
         {
             if (!string.IsNullOrEmpty(id))
-                span.SetTag("MessageId", id);
+                span.SetTag(MessageIdTagName, id);
         }
     }
 }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/MemoryMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/MemoryMessageQueueInit.cs
@@ -139,7 +139,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
             transportReceive.LockFeatures();
         }
 
-        private IEnumerable<TimeSpan> GetQueueDelay()
+        private static IEnumerable<TimeSpan> GetQueueDelay()
         {
             return new List<TimeSpan>(0);
         }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/PurgeMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/PurgeMessageHistoryHandler.cs
@@ -27,13 +27,11 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
     public class PurgeMessageHistoryHandler : IPurgeMessageHistory
     {
         private readonly IConnectionInformation _connectionInformation;
-        private readonly IBaseTransportOptions _options;
 
         /// <inheritdoc />
-        public PurgeMessageHistoryHandler(IConnectionInformation connectionInformation, IBaseTransportOptions options)
+        public PurgeMessageHistoryHandler(IConnectionInformation connectionInformation)
         {
             _connectionInformation = connectionInformation;
-            _options = options;
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/QueryMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/QueryMessageHistoryHandler.cs
@@ -28,13 +28,11 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
     public class QueryMessageHistoryHandler : IQueryMessageHistory
     {
         private readonly IConnectionInformation _connectionInformation;
-        private readonly IBaseTransportOptions _options;
 
         /// <inheritdoc />
-        public QueryMessageHistoryHandler(IConnectionInformation connectionInformation, IBaseTransportOptions options)
+        public QueryMessageHistoryHandler(IConnectionInformation connectionInformation)
         {
             _connectionInformation = connectionInformation;
-            _options = options;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Third SonarCloud code-smell sweep (Bucket D), following #184 (MSTEST0037) and #186 (Bucket A). Mechanical, behavior-preserving refactors — **96 findings cleared**.

## What changed

**S4487 — remove unread private fields (30)**
Drop 30 unused private fields and their now-dead constructor parameters (all DI-autowired):
- 11 Memory dashboard no-op handlers (`IDataStorage`)
- 6 history Purge/Query handlers, Redis/Relational/Memory (`IBaseTransportOptions` — reads/purges intentionally don't gate on `EnableHistory`, per each class's remarks)
- 5 rollback trace decorators (`ActivitySource` — they enrich `Activity.Current`, never start a span)
- LiteDb send handlers (`TransportConfigurationSend`), core serializer string-path timer/histogram, cancellation-decorator `ILogger`, `ProducerMethodQueue` `ICompositeSerialization`, `WaitForThreadToFinish` `ILogger`
- Updated the handful of test constructions (cancellation-decorator, Redis/Relational history handlers, 9 Memory dashboard construct tests)

**S2325 — make private helpers static (27 of 44)**
Added `static` to 27 **private** helpers with no instance-state access (Init/Schema table builders, policy setup, delay sequences, container helpers). Same-class callers need no change.
- **17 public members deliberately left** (`ValidConfiguration()` ×3, `TableNameHelper.JobTableName` (~48 call sites), `PolicyDefinitions` ×6, `MessageCancellationTracker.Register/Unregister`, `Identity.Script/Clone`, `WorkerTerminate.AttemptToTerminate`, `WaitForThreadToFinish.Wait`, `WorkGroupNoOp.MaxQueueSize`) — converting them is source-breaking for external callers of a published library. Can be marked won't-fix in SonarCloud.

**S1192 — extract duplicated string literals to consts (39)**
Repeated SQL parameter/column names, Redis hash-field names, config keys, and trace tags → `private const` across SqlServer/PostgreSQL/SQLite/Redis/RelationalDatabase send/rollback/schema/history handlers, `ConfigurationExtensions`, and core `InjectHeaders`.

## Verification
- Full solution builds clean (0 warnings, 0 errors, net10.0 + net8.0)
- All pure unit test projects pass: **2,023 tests, 0 failures** (core, Memory, SqlServer, PostgreSQL, SQLite, Redis, LiteDb, RelationalDatabase)

## Notes
- No user-facing behavior change. No changelog entry / version bump — matches the #186 (Bucket A) precedent for mechanical Sonar cleanups.
- Nominal ctor-signature changes on some public infra classes (history handlers, trace decorators, `ProducerMethodQueue`, `WaitForThreadToFinish`) are DI-instantiated and not user-constructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in message handling and history updates across transports.
  * Standardized tracing and logging behavior for send/rollback flows.

* **Refactor**
  * Simplified several components by removing unused dependencies and making shared helpers more efficient.
  * Centralized repeated setting, schema, and parameter names to reduce duplication.

* **Tests**
  * Updated test coverage to match the simplified construction patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->