### PR TITLE
Sonar Bucket C: reliability bugs + dispose-pattern (S1751/S4586/S3881)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Client/DashboardApiClient.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Client/DashboardApiClient.cs
@@ -30,7 +30,7 @@ namespace DotNetWorkQueue.Dashboard.Client
     /// <summary>
     /// Strongly-typed client for all DotNetWorkQueue Dashboard API endpoints.
     /// </summary>
-    public class DashboardApiClient : IDisposable
+    public sealed class DashboardApiClient : IDisposable
     {
         private readonly HttpClient _httpClient;
         private readonly bool _ownsHttpClient;

--- a/Source/DotNetWorkQueue.Dashboard.Client/DashboardConsumerClient.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Client/DashboardConsumerClient.cs
@@ -29,7 +29,7 @@ namespace DotNetWorkQueue.Dashboard.Client
     /// Client that automatically registers a consumer with the Dashboard API,
     /// sends periodic heartbeats, and unregisters on disposal.
     /// </summary>
-    public class DashboardConsumerClient : IDisposable, IAsyncDisposable
+    public sealed class DashboardConsumerClient : IDisposable, IAsyncDisposable
     {
         private readonly HttpClient _httpClient;
         private readonly bool _ownsHttpClient;

--- a/Source/DotNetWorkQueue.Tests/TaskScheduling/MessageHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Tests/TaskScheduling/MessageHandlerTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoNSubstitute;
@@ -35,6 +37,32 @@ namespace DotNetWorkQueue.Tests.TaskScheduling
                 Substitute.For<IWorkerNotification>(),
                 Action,
                 factory);
+        }
+
+        [TestMethod]
+        public void Handle_When_Worker_Stopping_Throws_OperationCanceled()
+        {
+            void Action(IReceivedMessage<FakeMessage> message, IWorkerNotification notification)
+            {
+            }
+
+            //worker is stopping and the transport supports rollback -> the item must not be
+            //queued. The handler must surface OperationCanceledException (the clean rollback
+            //path) rather than returning a null Task, which would NRE when the consumer awaits it.
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            var cancel = Substitute.For<ICancelWork>();
+            cancel.Tokens.Returns(new List<CancellationToken> { cts.Token });
+
+            var notifications = Substitute.For<IWorkerNotification>();
+            notifications.TransportSupportsRollback.Returns(true);
+            notifications.WorkerStopping.Returns(cancel);
+
+            var test = Create();
+
+            Assert.ThrowsExactly<OperationCanceledException>(() =>
+                test.HandleAsync(Substitute.For<IWorkGroup>(), Substitute.For<IReceivedMessage<FakeMessage>>(),
+                    notifications, Action, Substitute.For<ITaskFactory>()));
         }
 
         private SchedulerMessageHandler Create()

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbConnection.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbConnection.cs
@@ -26,7 +26,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
     /// Wraps a LiteDatabase. If direct/memory will leave the instance alone on dispose. If shared, database will be disposed.
     /// </summary>
     /// <seealso cref="System.IDisposable" />
-    public class LiteDbConnection : IDisposable
+    public sealed class LiteDbConnection : IDisposable
     {
         private readonly bool _shared;
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteHoldConnection.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteHoldConnection.cs
@@ -23,7 +23,7 @@ using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.SQLite.Basic
 {
-    internal class SqLiteHoldConnection : IDisposable
+    internal sealed class SqLiteHoldConnection : IDisposable
     {
         private readonly IGetFileNameFromConnectionString _getFileNameFromConnection;
         private readonly IDbFactory _dbFactory;
@@ -68,7 +68,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
 
         #region IDisposable Support
         private bool _disposedValue; // To detect redundant calls
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (!_disposedValue)
             {

--- a/Source/DotNetWorkQueue.Transport.Shared/Basic/Query/FindErrorMessagesToDeleteQuery.cs
+++ b/Source/DotNetWorkQueue.Transport.Shared/Basic/Query/FindErrorMessagesToDeleteQuery.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Threading;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Shared.Basic.Query
 {
@@ -33,7 +32,6 @@ namespace DotNetWorkQueue.Transport.Shared.Basic.Query
         /// <param name="cancellation">The cancellation.</param>
         public FindErrorMessagesToDeleteQuery(CancellationToken cancellation)
         {
-            Guard.NotNull(() => Cancellation, Cancellation);
             Cancellation = cancellation;
         }
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.Shared/Basic/Query/FindExpiredMessagesToDeleteQuery.cs
+++ b/Source/DotNetWorkQueue.Transport.Shared/Basic/Query/FindExpiredMessagesToDeleteQuery.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Threading;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Shared.Basic.Query
 {
@@ -33,7 +32,6 @@ namespace DotNetWorkQueue.Transport.Shared.Basic.Query
         /// <param name="cancellation">The cancellation.</param>
         public FindExpiredMessagesToDeleteQuery(CancellationToken cancellation)
         {
-            Guard.NotNull(() => Cancellation, Cancellation);
             Cancellation = cancellation;
         }
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.Shared/Basic/Query/FindMessagesToResetByHeartBeatQuery.cs
+++ b/Source/DotNetWorkQueue.Transport.Shared/Basic/Query/FindMessagesToResetByHeartBeatQuery.cs
@@ -18,7 +18,6 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Threading;
-using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Shared.Basic.Query
 {
@@ -34,7 +33,6 @@ namespace DotNetWorkQueue.Transport.Shared.Basic.Query
         /// <param name="cancellation">The cancellation.</param>
         public FindMessagesToResetByHeartBeatQuery(CancellationToken cancellation)
         {
-            Guard.NotNull(() => Cancellation, Cancellation);
             Cancellation = cancellation;
         }
         /// <summary>

--- a/Source/DotNetWorkQueue/Factory/ContainerFactory.cs
+++ b/Source/DotNetWorkQueue/Factory/ContainerFactory.cs
@@ -28,7 +28,7 @@ namespace DotNetWorkQueue.Factory
     /// </summary>
     /// <remarks><seealso cref="IContainer"/> cannot be injected into most IoC containers, as that's a circular reference. However, root factories
     /// sometimes need access to the container. This allows access to the container without <seealso cref="IContainer"/> being injected</remarks>
-    internal class ContainerFactory : IContainerFactory, IDisposable
+    internal sealed class ContainerFactory : IContainerFactory, IDisposable
     {
         private ContainerWrapper _containerWrapper;
         private int _disposeCount;

--- a/Source/DotNetWorkQueue/Interceptors/Interception.cs
+++ b/Source/DotNetWorkQueue/Interceptors/Interception.cs
@@ -87,11 +87,8 @@ namespace DotNetWorkQueue.Interceptors
 
         private IMessageInterceptor GetInterceptor(Type type)
         {
-            foreach (var interceptor in _interceptors.Where(interceptor => interceptor.BaseType == type))
-            {
-                return interceptor;
-            }
-            return _createdInterceptors.GetOrAdd(type, t => _interceptorFactory.Create(t));
+            var interceptor = _interceptors.FirstOrDefault(i => i.BaseType == type);
+            return interceptor ?? _createdInterceptors.GetOrAdd(type, t => _interceptorFactory.Create(t));
         }
     }
 }

--- a/Source/DotNetWorkQueue/Messages/MessageContext.cs
+++ b/Source/DotNetWorkQueue/Messages/MessageContext.cs
@@ -23,7 +23,7 @@ using System.Threading;
 
 namespace DotNetWorkQueue.Messages
 {
-    internal class MessageContext : IMessageContext
+    internal sealed class MessageContext : IMessageContext
     {
         private readonly Dictionary<string, object> _items = new Dictionary<string, object>();
         private int _disposeCount;

--- a/Source/DotNetWorkQueue/Metrics/Decorator/IMessageMethodHandlingDecorator.cs
+++ b/Source/DotNetWorkQueue/Metrics/Decorator/IMessageMethodHandlingDecorator.cs
@@ -25,7 +25,7 @@ namespace DotNetWorkQueue.Metrics.Decorator
     /// Metrics for executing linq methods
     /// </summary>
     /// <seealso cref="DotNetWorkQueue.IMessageMethodHandling" />
-    internal class MessageMethodHandlingDecorator : IMessageMethodHandling
+    internal sealed class MessageMethodHandlingDecorator : IMessageMethodHandling
     {
         private readonly IMessageMethodHandling _handler;
         private readonly ITimer _runMethodCompiledCodeTimer;

--- a/Source/DotNetWorkQueue/Metrics/Decorator/IQueueCreationDecorator.cs
+++ b/Source/DotNetWorkQueue/Metrics/Decorator/IQueueCreationDecorator.cs
@@ -21,7 +21,7 @@ using DotNetWorkQueue.Queue;
 
 namespace DotNetWorkQueue.Metrics.Decorator
 {
-    internal class QueueCreationDecorator : IQueueCreation
+    internal sealed class QueueCreationDecorator : IQueueCreation
     {
         private readonly IQueueCreation _handler;
         private readonly ITimer _createQueueTimer;

--- a/Source/DotNetWorkQueue/Metrics/Net/MetricsContextNet.cs
+++ b/Source/DotNetWorkQueue/Metrics/Net/MetricsContextNet.cs
@@ -23,7 +23,7 @@ using System.Diagnostics.Metrics;
 
 namespace DotNetWorkQueue.Metrics.Net
 {
-    internal class MetricsContextNet : IMetricsContext
+    internal sealed class MetricsContextNet : IMetricsContext
     {
         private readonly Meter _meter;
         private readonly ConcurrentDictionary<string, CounterNet> _counters = new ConcurrentDictionary<string, CounterNet>();

--- a/Source/DotNetWorkQueue/Metrics/Net/MetricsNet.cs
+++ b/Source/DotNetWorkQueue/Metrics/Net/MetricsNet.cs
@@ -24,7 +24,7 @@ using System.Diagnostics.Metrics;
 namespace DotNetWorkQueue.Metrics.Net
 {
     /// <inheritdoc />
-    public class MetricsNet : IMetrics, IDisposable
+    public sealed class MetricsNet : IMetrics, IDisposable
     {
         private readonly Meter _meter;
         private readonly ConcurrentDictionary<string, CounterNet> _counters = new ConcurrentDictionary<string, CounterNet>();

--- a/Source/DotNetWorkQueue/Metrics/Net/TimerContextNet.cs
+++ b/Source/DotNetWorkQueue/Metrics/Net/TimerContextNet.cs
@@ -23,7 +23,7 @@ using System.Diagnostics.Metrics;
 
 namespace DotNetWorkQueue.Metrics.Net
 {
-    internal class TimerContextNet : ITimerContext
+    internal sealed class TimerContextNet : ITimerContext
     {
         private readonly Histogram<double> _histogram;
         private readonly KeyValuePair<string, object>[] _tags;

--- a/Source/DotNetWorkQueue/Metrics/Net/TimerNet.cs
+++ b/Source/DotNetWorkQueue/Metrics/Net/TimerNet.cs
@@ -23,7 +23,7 @@ using System.Diagnostics.Metrics;
 
 namespace DotNetWorkQueue.Metrics.Net
 {
-    internal class TimerNet : ITimer, IDisposable
+    internal sealed class TimerNet : ITimer, IDisposable
     {
         private readonly Histogram<double> _histogram;
         private readonly KeyValuePair<string, object>[] _tags;

--- a/Source/DotNetWorkQueue/Metrics/NoOp/MetricsNoOp.cs
+++ b/Source/DotNetWorkQueue/Metrics/NoOp/MetricsNoOp.cs
@@ -43,7 +43,7 @@ namespace DotNetWorkQueue.Metrics.NoOp
 
         }
     }
-    internal class MetricsContextNoOp : IMetricsContext
+    internal sealed class MetricsContextNoOp : IMetricsContext
     {
         private readonly ITimer _timer = new TimerNoOp();
         private readonly ICounter _counter = new CounterNoOp();
@@ -100,7 +100,7 @@ namespace DotNetWorkQueue.Metrics.NoOp
 
         }
     }
-    internal class TimerContextNoOp : ITimerContext
+    internal sealed class TimerContextNoOp : ITimerContext
     {
         public TimeSpan Elapsed => TimeSpan.Zero;
 
@@ -109,7 +109,7 @@ namespace DotNetWorkQueue.Metrics.NoOp
 
         }
     }
-    internal class TimerNoOp : ITimer, IDisposable
+    internal sealed class TimerNoOp : ITimer, IDisposable
     {
         private readonly ITimerContext _timerContext = new TimerContextNoOp();
 
@@ -193,7 +193,7 @@ namespace DotNetWorkQueue.Metrics.NoOp
 
         }
     }
-    internal class MetricsNoOp : IMetrics, IDisposable
+    internal sealed class MetricsNoOp : IMetrics, IDisposable
     {
         private readonly ITimer _timer = new TimerNoOp();
         private readonly ICounter _counter = new CounterNoOp();

--- a/Source/DotNetWorkQueue/Queue/ConsumerMethodQueue.cs
+++ b/Source/DotNetWorkQueue/Queue/ConsumerMethodQueue.cs
@@ -28,7 +28,7 @@ namespace DotNetWorkQueue.Queue
     /// </summary>
     /// <seealso cref="DotNetWorkQueue.Queue.BaseQueue" />
     /// <seealso cref="DotNetWorkQueue.IConsumerMethodQueue" />
-    public class ConsumerMethodQueue : BaseQueue, IConsumerMethodQueue
+    public sealed class ConsumerMethodQueue : BaseQueue, IConsumerMethodQueue
     {
         private readonly IConsumerQueue _queue;
         private readonly IMessageMethodHandling _messageMethodHandling;
@@ -87,7 +87,7 @@ namespace DotNetWorkQueue.Queue
             _queue.Dispose();
             _messageMethodHandling.Dispose();
 
-            base.Dispose(true);
+            base.Dispose(disposing);
         }
     }
 }

--- a/Source/DotNetWorkQueue/Queue/ConsumerQueue.cs
+++ b/Source/DotNetWorkQueue/Queue/ConsumerQueue.cs
@@ -28,7 +28,7 @@ namespace DotNetWorkQueue.Queue
     /// <summary>
     /// Defines a queue that can process messages
     /// </summary>
-    public class ConsumerQueue : BaseQueue, IConsumerQueue
+    public sealed class ConsumerQueue : BaseQueue, IConsumerQueue
     {
         private readonly QueueConsumerConfiguration _configuration;
         private readonly Lazy<IPrimaryWorker> _primaryWorker;
@@ -151,7 +151,7 @@ namespace DotNetWorkQueue.Queue
                 _stopWorker.StopPrimary(_primaryWorker.Value);
                 _primaryWorker.Value.Dispose();
             }
-            base.Dispose(true);
+            base.Dispose(disposing);
         }
         #endregion
     }

--- a/Source/DotNetWorkQueue/Queue/ConsumerQueueAsync.cs
+++ b/Source/DotNetWorkQueue/Queue/ConsumerQueueAsync.cs
@@ -29,7 +29,7 @@ namespace DotNetWorkQueue.Queue
     /// <summary>
     /// Defines a queue that can process messages in an async fashion.
     /// </summary>
-    public class ConsumerQueueAsync : BaseQueue, IConsumerQueueAsync
+    public sealed class ConsumerQueueAsync : BaseQueue, IConsumerQueueAsync
     {
         private readonly QueueConsumerConfiguration _configuration;
         private readonly Lazy<IPrimaryWorker> _primaryWorker;
@@ -152,7 +152,7 @@ namespace DotNetWorkQueue.Queue
                 _stopWorker.StopPrimary(_primaryWorker.Value);
                 _primaryWorker.Value.Dispose();
             }
-            base.Dispose(true);
+            base.Dispose(disposing);
         }
     }
 }

--- a/Source/DotNetWorkQueue/Queue/HeartBeatScheduler.cs
+++ b/Source/DotNetWorkQueue/Queue/HeartBeatScheduler.cs
@@ -30,7 +30,7 @@ using System.Threading;
 namespace DotNetWorkQueue.Queue
 {
     /// <inheritdoc />
-    public class HeartBeatScheduler : IHeartBeatScheduler
+    public sealed class HeartBeatScheduler : IHeartBeatScheduler
     {
         private readonly IHeartBeatThreadPoolConfiguration _configuration;
         private readonly IGetTimeFactory _timeFactory;

--- a/Source/DotNetWorkQueue/Queue/WorkerWaitForEventOrCancel.cs
+++ b/Source/DotNetWorkQueue/Queue/WorkerWaitForEventOrCancel.cs
@@ -24,7 +24,7 @@ namespace DotNetWorkQueue.Queue
     /// <summary>
     /// Allows workers to be paused, and suspend looking for work until awoken
     /// </summary>
-    internal class WorkerWaitForEventOrCancel : IWorkerWaitForEventOrCancel
+    internal sealed class WorkerWaitForEventOrCancel : IWorkerWaitForEventOrCancel
     {
         private readonly IWaitForEventOrCancelWorker _waitForEventOrCancel;
         private readonly IWorkerConfiguration _workerConfiguration;
@@ -93,7 +93,7 @@ namespace DotNetWorkQueue.Queue
         /// </summary>
         /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
-        protected void ThrowIfDisposed()
+        private void ThrowIfDisposed()
         {
             ObjectDisposedException.ThrowIf(Interlocked.CompareExchange(ref _disposeCount, 0, 0) != 0, this);
         }

--- a/Source/DotNetWorkQueue/TaskScheduling/SchedulerMessageHandler.cs
+++ b/Source/DotNetWorkQueue/TaskScheduling/SchedulerMessageHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Logging;
@@ -71,10 +72,12 @@ namespace DotNetWorkQueue.TaskScheduling
             while (true)
             {
                 //verify that we are not canceling or stopping before trying to queue the item
-                //however, the transport must support rollbacks
+                //however, the transport must support rollbacks. ShouldHandle returns true or
+                //throws OperationCanceledException (which the consumer treats as a rollback);
+                //the canceled task below is a defensive non-null fallback if that contract changes.
                 if (!ShouldHandle(notifications))
                 {
-                    return null;
+                    return Task.FromCanceled(new CancellationToken(true));
                 }
 
                 if (taskFactory.TryStartNew(state => { WrappedFunction(message, notifications, functionToRun); }, new StateInformation(workGroup), task =>

--- a/Source/DotNetWorkQueue/TaskScheduling/WaitForEventOrCancelThreadPool.cs
+++ b/Source/DotNetWorkQueue/TaskScheduling/WaitForEventOrCancelThreadPool.cs
@@ -27,7 +27,7 @@ namespace DotNetWorkQueue.TaskScheduling
     /// <summary>
     /// Allows a scheduler to indicate that it's full and cannot accept more work
     /// </summary>
-    internal class WaitForEventOrCancelThreadPool : IWaitForEventOrCancelThreadPool
+    internal sealed class WaitForEventOrCancelThreadPool : IWaitForEventOrCancelThreadPool
     {
         private readonly ConcurrentDictionary<IWorkGroup, IWaitForEventOrCancel> _waitForEventForGroups;
         private readonly Lazy<IWaitForEventOrCancel> _waitForEvent;
@@ -117,14 +117,14 @@ namespace DotNetWorkQueue.TaskScheduling
         /// </summary>
         /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
-        protected void ThrowIfDisposed()
+        private void ThrowIfDisposed()
         {
             ObjectDisposedException.ThrowIf(Interlocked.CompareExchange(ref _disposeCount, 0, 0) != 0, this);
         }
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
-        public virtual void Dispose()
+        public void Dispose()
         {
             if (Interlocked.Increment(ref _disposeCount) != 1) return;
 

--- a/Source/DotNetWorkQueue/Trace/Decorator/MessageMethodHandlingDecorator.cs
+++ b/Source/DotNetWorkQueue/Trace/Decorator/MessageMethodHandlingDecorator.cs
@@ -28,7 +28,7 @@ namespace DotNetWorkQueue.Trace.Decorator
     /// Tracer for linq message handling
     /// </summary>
     /// <seealso cref="DotNetWorkQueue.IMessageMethodHandling" />
-    public class MessageMethodHandlingDecorator : IMessageMethodHandling
+    public sealed class MessageMethodHandlingDecorator : IMessageMethodHandling
     {
         private readonly IMessageMethodHandling _handler;
         private readonly ActivitySource _tracer;

--- a/Source/DotNetWorkQueue/Trace/Decorator/ProducerMethodJobQueueDecorator.cs
+++ b/Source/DotNetWorkQueue/Trace/Decorator/ProducerMethodJobQueueDecorator.cs
@@ -32,7 +32,7 @@ namespace DotNetWorkQueue.Trace.Decorator
     /// 
     /// </summary>
     /// <seealso cref="DotNetWorkQueue.IProducerMethodJobQueue" />
-    public class ProducerMethodJobQueueDecorator : IProducerMethodJobQueue
+    public sealed class ProducerMethodJobQueueDecorator : IProducerMethodJobQueue
     {
         private readonly ActivitySource _tracer;
         private readonly IProducerMethodJobQueue _handler;

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/DataStorage.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/DataStorage.cs
@@ -34,7 +34,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
     /// </summary>
     /// <seealso cref="DotNetWorkQueue.Transport.Memory.IDataStorage" />
     /// <seealso cref="DotNetWorkQueue.Transport.Memory.IDataStorageSendMessage" />
-    public class DataStorage : IDataStorage, IDataStorageSendMessage, IDisposable
+    public sealed class DataStorage : IDataStorage, IDataStorageSendMessage, IDisposable
     {
         //next item to de-queue
         private static readonly ConcurrentDictionary<IConnectionInformation, BlockingCollection<Guid>> Queues;

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/Message/ReceiveMessage.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/Message/ReceiveMessage.cs
@@ -60,28 +60,25 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.Message
         /// </returns>
         public IReceivedMessageInternal GetMessage(IMessageContext context)
         {
-            while (true)
+            //if stopping, exit now
+            if (_cancelToken.Tokens.Any(t => t.IsCancellationRequested))
             {
-                //if stopping, exit now
-                if (_cancelToken.Tokens.Any(t => t.IsCancellationRequested))
-                {
-                    return null;
-                }
-
-                //ask for the next message
-                var receivedTransportMessage = _dataStorage.GetNextMessage(_configuration.Routes, TimeSpan.FromSeconds(5));
-
-                //if no message (null) run the no message action and return
-                if (receivedTransportMessage == null)
-                {
-                    return null;
-                }
-
-                //set the message ID on the context for later usage
-                context.SetMessageAndHeaders(receivedTransportMessage.MessageId, receivedTransportMessage.CorrelationId, receivedTransportMessage.Headers);
-
-                return receivedTransportMessage;
+                return null;
             }
+
+            //ask for the next message
+            var receivedTransportMessage = _dataStorage.GetNextMessage(_configuration.Routes, TimeSpan.FromSeconds(5));
+
+            //if no message (null) run the no message action and return
+            if (receivedTransportMessage == null)
+            {
+                return null;
+            }
+
+            //set the message ID on the context for later usage
+            context.SetMessageAndHeaders(receivedTransportMessage.MessageId, receivedTransportMessage.CorrelationId, receivedTransportMessage.Headers);
+
+            return receivedTransportMessage;
         }
     }
 }


### PR DESCRIPTION
Fourth SonarCloud sweep (Bucket C) — the correctness/reliability findings, following #184, #186 (Bucket A), #188 (Bucket D).

## Correctness bugs (with tests)
- **S4586** — `SchedulerMessageHandler.HandleAsync` returned a **null `Task`** on its not-handling branch. A null Task NREs when the consumer awaits it (`ProcessMessageAsync`), landing a stopping-time message in error handling instead of a clean rollback. Now returns a canceled Task, which flows through the existing `OperationCanceledException` rollback path. (The branch is currently unreachable — `ShouldHandle` throws or returns true — but the null return was a latent hazard.) **Added a regression test** asserting a stopping worker surfaces `OperationCanceledException`.
- **S1751** — `Memory ReceiveMessage.GetMessage` wrapped straight-line code in a `while(true)` that always returned on iteration 1 → unwrapped (no behavior change).
- **S1751** — `Interception.GetInterceptor` used a `foreach` that returned on the first match → `FirstOrDefault ?? GetOrAdd`.
- **Dead guards** — removed 3 `Guard.NotNull(CancellationToken)` calls (`Find*Query`); guarding a non-nullable struct against null is a silent no-op (surfaced while evaluating S2955).

S2955 itself (`Guard.NotNull` `value == null` on unconstrained `T`) is **left as-is** — the current behavior is correct (no-op for value types), and the compliant `where T : class` fix cascades into ~9 relational retry-decorator files with SimpleInjector open-generic risk not worth a single low-severity finding.

## Dispose pattern — S3881 (25 of 27)
Sealed 25 leaf `IDisposable` classes so they conform (a sealed class needs only a simple `Dispose()`), plus the cleanups sealing requires: de-virtualize now-pointless `Dispose()`/`Dispose(bool)`, forward `disposing` in the `ConsumerQueue*` overrides (was `base.Dispose(true)`), demote pointless `protected ThrowIfDisposed` to `private`.

**Left unsealed (2 still flagged):** `WaitForEventOrCancel` and `WorkerBase` are base classes — their S3881 fix is a virtual-`Dispose(bool)` cascade through the wait/worker lifecycle, disproportionately risky for a hygiene rule.

## ⚠️ API note
Sealing includes **11 public classes** (ConsumerQueue, DataStorage, MetricsNet, DashboardApiClient, LiteDbConnection, …). This is source-breaking for external code that *subclasses* them (rare — they're used via interfaces). Explicitly chosen. No changelog/version bump (matches the #186/#188 mechanical-cleanup precedent).

## Verification
- Full solution builds clean, 0 warnings / 0 errors (net10.0 + net8.0)
- All unit suites green (core 915 incl. new scheduler test, Memory, LiteDb, SQLite, SqlServer, PostgreSQL, RelationalDatabase)
- Memory integration consumer/producer lifecycle green (exercises the sealed worker/queue/dispose paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling so message processing now returns a canceled task/exception instead of a null result in stopping scenarios.
  * Fixed disposal behavior in consumer and worker components to behave more reliably during shutdown.
  * Updated in-memory message retrieval to stop immediately when cancellation is already requested.

* **Tests**
  * Added coverage for worker-stopping cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->