### PR TITLE
Sonar Bucket B (part 1): structured logging templates (CA2254/S2629)

### DIFF
--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/CreateNotifications.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/CreateNotifications.cs
@@ -19,32 +19,32 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
         }
         private static void OnMessageCompleted(ILogger log, MessageCompleteNotification obj)
         {
-            log.LogTrace($"Processing completed {obj.MessageId}");
+            log.LogTrace("Processing completed {MessageId}", obj.MessageId);
         }
 
         private static void OnMessageRollBack(ILogger log, RollBackNotification obj)
         {
-            log.LogTrace($"Processing has triggered a rollback {System.Environment.NewLine}{obj.MessageId}{System.Environment.NewLine}{obj.Error}");
+            log.LogTrace("Processing has triggered a rollback {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
         }
 
         private static void OnPoisonMessage(ILogger log, PoisonMessageNotification obj)
         {
-            log.LogTrace($"Processing has triggered a poison message {System.Environment.NewLine}{obj.MessageId}{System.Environment.NewLine}{obj.Error}");
+            log.LogTrace("Processing has triggered a poison message {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
         }
 
         private static void OnMessageMovedToErrorQueue(ILogger log, ErrorNotification obj)
         {
-            log.LogTrace($"Processing has failed {System.Environment.NewLine}{obj.MessageId}{System.Environment.NewLine}{obj.Error}");
+            log.LogTrace("Processing has failed {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
         }
 
         private static void OnReceiveMessageError(ILogger log, ErrorReceiveNotification obj)
         {
-            log.LogTrace($"Processing has failed to dequeue a message {System.Environment.NewLine}{obj.Error}");
+            log.LogTrace("Processing has failed to dequeue a message {NewLine}{Error}", System.Environment.NewLine, obj.Error);
         }
 
         private static void OnError(ILogger log, ErrorNotification obj)
         {
-            log.LogTrace($"Processing has failed {System.Environment.NewLine}{obj.Error}");
+            log.LogTrace("Processing has failed {NewLine}{Error}", System.Environment.NewLine, obj.Error);
         }
     }
 }

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/OsDetectionHelper.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/OsDetectionHelper.cs
@@ -35,7 +35,7 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
             catch (Exception ex)
             {
                 // Handle exceptions (e.g., insufficient permissions to read registry)
-                logger?.LogError($"Error reading registry: {ex.Message}");
+                logger?.LogError("Error reading registry: {ErrorMessage}", ex.Message);
             }
 
             return false;

--- a/Source/DotNetWorkQueue.Tests/Logging/LogMessageTemplateTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Logging/LogMessageTemplateTests.cs
@@ -1,0 +1,89 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Tests.Logging
+{
+    /// <summary>
+    /// Verifies that the structured-logging message templates introduced for CA2254/S2629
+    /// render to the same text the original string interpolation produced. Guards against a
+    /// placeholder/argument mismatch, which the logging framework would render silently
+    /// (no exception) rather than fail.
+    /// </summary>
+    [TestClass]
+    public class LogMessageTemplateTests
+    {
+        [TestMethod]
+        public void SinglePlaceholder_RendersInterpolatedEquivalent()
+        {
+            var logger = new CapturingLogger();
+            const string id = "msg-1";
+            logger.LogDebug("HeartBeat processing completed {MessageId}", id);
+            Assert.AreEqual($"HeartBeat processing completed {id}", logger.LastMessage);
+        }
+
+        [TestMethod]
+        public void TwoPlaceholders_RendersInterpolatedEquivalent()
+        {
+            var logger = new CapturingLogger();
+            const int count = 5;
+            const string queue = "q1";
+            logger.LogInformation("Deleted {Count} error messages from {QueueName}", count, queue);
+            Assert.AreEqual($"Deleted {count} error messages from {queue}", logger.LastMessage);
+        }
+
+        [TestMethod]
+        public void RepeatedNewLinePlaceholders_PreserveMultiLineOutput()
+        {
+            var logger = new CapturingLogger();
+            var nl = Environment.NewLine;
+            const string id = "id-1";
+            const string err = "boom";
+            logger.LogWarning(
+                "Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {NewLine}{MessageId}{NewLine2}{Error}",
+                nl, id, nl, err);
+            Assert.AreEqual(
+                $"Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {nl}{id}{nl}{err}",
+                logger.LastMessage);
+        }
+
+        [TestMethod]
+        public void ExceptionArgument_RendersToStringInline()
+        {
+            var logger = new CapturingLogger();
+            var nl = Environment.NewLine;
+            var ex = new InvalidOperationException("kaboom");
+            logger.LogError("An error has occurred while trying to rollback a message{NewLine}{Exception}", nl, ex);
+            Assert.AreEqual($"An error has occurred while trying to rollback a message{nl}{ex}", logger.LastMessage);
+        }
+
+        [TestMethod]
+        public void RetryTemplate_RendersInterpolatedEquivalent()
+        {
+            var logger = new CapturingLogger();
+            var nl = Environment.NewLine;
+            const double retryMs = 250d;
+            const int attempt = 3;
+            var ex = new TimeoutException("db");
+            logger.LogWarning(
+                "An error has occurred; we will try to re-run the transaction in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times{NewLine}{Exception}",
+                retryMs, attempt, nl, ex);
+            Assert.AreEqual(
+                $"An error has occurred; we will try to re-run the transaction in {retryMs} ms. An error has occurred {attempt} times{nl}{ex}",
+                logger.LastMessage);
+        }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            public string LastMessage { get; private set; }
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                LastMessage = formatter(state, exception);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/DatabaseExists.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/DatabaseExists.cs
@@ -57,7 +57,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
 
             var exist = File.Exists(fileName.FileName);
             if (!exist)
-                _logger.LogDebug($"database {fileName.FileName} was not found");
+                _logger.LogDebug("database {FileName} was not found", fileName.FileName);
             return exist;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
@@ -123,7 +123,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         {
             if (!LoggedMissingDb && !_databaseExists.Exists())
             {
-                _log.LogWarning($"Database file {_getFileNameFromConnection.GetFileName(_configuration.TransportConfiguration.ConnectionInfo.ConnectionString).FileName} does not exist");
+                _log.LogWarning("Database file {FileName} does not exist", _getFileNameFromConnection.GetFileName(_configuration.TransportConfiguration.ConnectionInfo.ConnectionString).FileName);
                 LoggedMissingDb = true;
             }
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/RemoveMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/RemoveMessage.cs
@@ -110,7 +110,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             }
             catch (Exception e)
             {
-                _log.LogError($"Failed to commit a transaction; this might be due to a DB timeout{System.Environment.NewLine}{e}");
+                _log.LogError("Failed to commit a transaction; this might be due to a DB timeout{NewLine}{Exception}", System.Environment.NewLine, e);
 
                 //don't attempt to use the transaction again at this point.
                 connection.Transaction = null;
@@ -130,7 +130,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
                 }
                 catch (Exception e)
                 {
-                    _log.LogWarning($"Failed to delete status table record for message {context.MessageId.Id.Value}; record may be orphaned{System.Environment.NewLine}{e}");
+                    _log.LogWarning("Failed to delete status table record for message {MessageId}; record may be orphaned{NewLine}{Exception}", context.MessageId.Id.Value, System.Environment.NewLine, e);
                 }
             }
             return count > 0 ? RemoveMessageStatus.Removed : RemoveMessageStatus.NotFound;

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/RetrySQLPolicyCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/RetrySQLPolicyCreation.cs
@@ -109,7 +109,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
                 UseJitter = true,
                 OnRetry = args =>
                 {
-                    log.LogWarning($"An error has occurred; we will try to re-run the transaction in {args.RetryDelay.TotalMilliseconds} ms. An error has occurred {args.AttemptNumber + 1} times{System.Environment.NewLine}{args.Outcome.Exception}");
+                    log.LogWarning("An error has occurred; we will try to re-run the transaction in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times{NewLine}{Exception}", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1, System.Environment.NewLine, args.Outcome.Exception);
                     if (Activity.Current != null)
                     {
                         using (var scope = tracer.StartActivity("RetrySqlPolicy"))

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/DelayedProcessingActionDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/DelayedProcessingActionDecorator.cs
@@ -50,7 +50,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Logging.Decorator
             var records = _handler.Run(token);
             if (records > 0)
             {
-                _log.LogInformation($"Moved {records} records from the delayed queue to the pending queue");
+                _log.LogInformation("Moved {Records} records from the delayed queue to the pending queue", records);
             }
             return records;
         }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/ReceiveMessageQueryDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/ReceiveMessageQueryDecorator.cs
@@ -51,7 +51,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Logging.Decorator
             var result = _handler.Handle(query);
             if (result != null && result.Expired)
             {
-                _log.LogDebug($"Message {result.MessageId} expired before it could be processed");
+                _log.LogDebug("Message {MessageId} expired before it could be processed", result.MessageId);
             }
             return result;
         }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessagesError.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessagesError.cs
@@ -122,7 +122,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
                 new MoveRecordToErrorQueueCommand<string>(exception, context.MessageId.Id.Value.ToString(), context));
             //we are done doing any processing - remove the messageID to block other actions
             context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
-            _log.LogError($"Message with ID {message.MessageId} has failed and has been moved to the error queue{System.Environment.NewLine}{exception}");
+            _log.LogError("Message with ID {MessageId} has failed and has been moved to the error queue{NewLine}{Exception}", message.MessageId, System.Environment.NewLine, exception);
             return ReceiveMessagesErrorResult.Error;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/RetryTransactionPolicyCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/RetryTransactionPolicyCreation.cs
@@ -125,7 +125,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                 UseJitter = true,
                 OnRetry = args =>
                 {
-                    log.LogWarning($"An error has occurred; we will try to re-run the statement in {args.RetryDelay.TotalMilliseconds} ms. An error has occurred {args.AttemptNumber + 1} times{System.Environment.NewLine}{args.Outcome.Exception}");
+                    log.LogWarning("An error has occurred; we will try to re-run the statement in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times{NewLine}{Exception}", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1, System.Environment.NewLine, args.Outcome.Exception);
                     if (Activity.Current != null)
                     {
                         using (var scope = tracer.StartActivity("RetrySqlPolicy"))

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
@@ -126,7 +126,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         {
             if (!LoggedMissingDb && !_databaseExists.Exists(_configuration.TransportConfiguration.ConnectionInfo.ConnectionString))
             {
-                _log.LogWarning($"Database file {_getFileNameFromConnection.GetFileName(_configuration.TransportConfiguration.ConnectionInfo.ConnectionString).FileName} does not exist");
+                _log.LogWarning("Database file {FileName} does not exist", _getFileNameFromConnection.GetFileName(_configuration.TransportConfiguration.ConnectionInfo.ConnectionString).FileName);
                 LoggedMissingDb = true;
             }
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/FindExpiredRecordsToDeleteQueryHandlerErrorDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/FindExpiredRecordsToDeleteQueryHandlerErrorDecorator.cs
@@ -50,7 +50,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
             {
                 if (e.Message.Contains("abort due to ROLLBACK", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    _logger.LogWarning($"The query has been aborted{System.Environment.NewLine}{e}");
+                    _logger.LogWarning("The query has been aborted{NewLine}{Exception}", System.Environment.NewLine, e);
                     return Enumerable.Empty<long>();
                 }
                 else

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/FindRecordsToResetByHeartBeatDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/FindRecordsToResetByHeartBeatDecorator.cs
@@ -66,7 +66,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
             {
                 if (e.Message.Contains("abort due to ROLLBACK", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    _logger.LogWarning($"The query has been aborted{System.Environment.NewLine}{e}");
+                    _logger.LogWarning("The query has been aborted{NewLine}{Exception}", System.Environment.NewLine, e);
                     return Enumerable.Empty<MessageToReset<long>>();
                 }
                 else

--- a/Source/DotNetWorkQueue.Transport.Shared/Basic/ReceiveErrorMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.Shared/Basic/ReceiveErrorMessage.cs
@@ -117,7 +117,7 @@ namespace DotNetWorkQueue.Transport.Shared.Basic
                 new MoveRecordToErrorQueueCommand<T>(exception, (T)context.MessageId.Id.Value, context));
             //we are done doing any processing - remove the messageID to block other actions
             context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
-            _log.LogError($"Message with ID {message.MessageId} has failed and has been moved to the error queue{System.Environment.NewLine}{exception}");
+            _log.LogError("Message with ID {MessageId} has failed and has been moved to the error queue{NewLine}{Exception}", message.MessageId, System.Environment.NewLine, exception);
             return ReceiveMessagesErrorResult.Error;
         }
         #endregion

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/Message/RollbackMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/Message/RollbackMessage.cs
@@ -128,7 +128,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.Message
             }
             catch (Exception e)
             {
-                _log.LogError($"Failed to rollback a transaction; this might be due to a DB timeout{System.Environment.NewLine}{e}");
+                _log.LogError("Failed to rollback a transaction; this might be due to a DB timeout{NewLine}{Exception}", System.Environment.NewLine, e);
 
                 //don't attempt to use the transaction again at this point.
                 connection.Transaction = null;

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/RemoveMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/RemoveMessage.cs
@@ -111,7 +111,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             }
             catch (Exception e)
             {
-                _log.LogError($"Failed to commit a transaction; this might be due to a DB timeout{System.Environment.NewLine}{e}");
+                _log.LogError("Failed to commit a transaction; this might be due to a DB timeout{NewLine}{Exception}", System.Environment.NewLine, e);
 
                 //don't attempt to use the transaction again at this point.
                 connection.Transaction = null;
@@ -131,7 +131,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
                 }
                 catch (Exception e)
                 {
-                    _log.LogWarning($"Failed to delete status table record for message {context.MessageId.Id.Value}; record may be orphaned{System.Environment.NewLine}{e}");
+                    _log.LogWarning("Failed to delete status table record for message {MessageId}; record may be orphaned{NewLine}{Exception}", context.MessageId.Id.Value, System.Environment.NewLine, e);
                 }
             }
             return count > 0 ? RemoveMessageStatus.Removed : RemoveMessageStatus.NotFound;

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/RetrySqlPolicyCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/RetrySqlPolicyCreation.cs
@@ -108,7 +108,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
                 UseJitter = true,
                 OnRetry = args =>
                 {
-                    log.LogWarning($"An error has occurred; we will try to re-run the transaction in {args.RetryDelay.TotalMilliseconds} ms. An error has occurred {args.AttemptNumber + 1} times{System.Environment.NewLine}{args.Outcome.Exception}");
+                    log.LogWarning("An error has occurred; we will try to re-run the transaction in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times{NewLine}{Exception}", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1, System.Environment.NewLine, args.Outcome.Exception);
                     if (Activity.Current != null)
                     {
                         using (var scope = tracer.StartActivity("RetrySqlPolicy"))

--- a/Source/DotNetWorkQueue/JobScheduler/JobScheduler.cs
+++ b/Source/DotNetWorkQueue/JobScheduler/JobScheduler.cs
@@ -80,8 +80,8 @@ namespace DotNetWorkQueue.JobScheduler
         public void Start()
         {
             //log task time (from time factory) and local machine time to show differences..
-            _log.LogInformation($"Scheduler time is {_getTime.Create().GetCurrentUtcDate()}");
-            _log.LogInformation($"Local time is {DateTime.UtcNow}");
+            _log.LogInformation("Scheduler time is {SchedulerTime}", _getTime.Create().GetCurrentUtcDate());
+            _log.LogInformation("Local time is {LocalTime}", DateTime.UtcNow);
 
             Task.Run(PollAsync);
         }

--- a/Source/DotNetWorkQueue/JobScheduler/ScheduledJob.cs
+++ b/Source/DotNetWorkQueue/JobScheduler/ScheduledJob.cs
@@ -194,24 +194,24 @@ namespace DotNetWorkQueue.JobScheduler
                         if (result.Status == JobQueuedStatus.Success || result.Status == JobQueuedStatus.RequeuedDueToErrorStatus)
                         {
                             RaiseEnQueue(result);
-                            _queue.Logger.LogDebug($"job {this} queued");
+                            _queue.Logger.LogDebug("job {Job} queued", this);
                         }
                         else if (result.Status == JobQueuedStatus.AlreadyQueuedWaiting ||
                                  result.Status == JobQueuedStatus.AlreadyQueuedProcessing ||
                                  result.Status == JobQueuedStatus.AlreadyProcessed)
                         {
-                            _queue.Logger.LogWarning($"Failed to enqueue job {this}, the status is {result.Status}");
+                            _queue.Logger.LogWarning("Failed to enqueue job {Job}, the status is {Status}", this, result.Status);
                             RaiseNonFatalFailureEnQueue(result);
                         }
                         else if (result.SendingException != null)
                         {
-                            _queue.Logger.LogError($"An error has occurred adding job {this} into the queue{System.Environment.NewLine}{result.SendingException}");
+                            _queue.Logger.LogError("An error has occurred adding job {Job} into the queue{NewLine}{Exception}", this, System.Environment.NewLine, result.SendingException);
                             RaiseException(result.SendingException);
                         }
                     }
                     catch (Exception ex)
                     {
-                        _queue.Logger.LogError($"A fatal error has occurred trying to add job {this} into the queue{System.Environment.NewLine}{ex}");
+                        _queue.Logger.LogError("A fatal error has occurred trying to add job {Job} into the queue{NewLine}{Exception}", this, System.Environment.NewLine, ex);
                         RaiseException(ex);
                     }
                 }

--- a/Source/DotNetWorkQueue/Logging/Decorator/IClearErrorMessagesDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IClearErrorMessagesDecorator.cs
@@ -53,7 +53,7 @@ namespace DotNetWorkQueue.Logging.Decorator
             var count = _handler.ClearMessages(cancelToken);
             if (count > 0)
             {
-                _log.LogInformation($"Deleted {count} error messages from {_connectionInfo.QueueName}");
+                _log.LogInformation("Deleted {Count} error messages from {QueueName}", count, _connectionInfo.QueueName);
             }
             return count;
         }

--- a/Source/DotNetWorkQueue/Logging/Decorator/IClearExpiredMessagesDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IClearExpiredMessagesDecorator.cs
@@ -57,7 +57,7 @@ namespace DotNetWorkQueue.Logging.Decorator
             var count = _handler.ClearMessages(cancelToken);
             if (count > 0)
             {
-                _log.LogInformation($"Deleted {count} expired messages from {_connectionInfo.QueueName}");
+                _log.LogInformation("Deleted {Count} expired messages from {QueueName}", count, _connectionInfo.QueueName);
             }
             return count;
         }

--- a/Source/DotNetWorkQueue/Logging/Decorator/IReceivePoisonMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IReceivePoisonMessageDecorator.cs
@@ -54,7 +54,7 @@ namespace DotNetWorkQueue.Logging.Decorator
                 var messageId = context.MessageId.Id.Value.ToString();
                 _handler.Handle(context, exception);
                 _log.LogError(
-                    $"Message with ID {messageId} has failed after de-queue, but before finishing loading. This message is considered a poison message, and has been moved to the error queue{System.Environment.NewLine}{exception}");
+                    "Message with ID {MessageId} has failed after de-queue, but before finishing loading. This message is considered a poison message, and has been moved to the error queue{NewLine}{Exception}", messageId, System.Environment.NewLine, exception);
             }
             else
             {

--- a/Source/DotNetWorkQueue/Logging/Decorator/IResetHeartBeatDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IResetHeartBeatDecorator.cs
@@ -55,7 +55,7 @@ namespace DotNetWorkQueue.Logging.Decorator
             if (count.Count > 0)
             {
                 _log.LogInformation(
-                   $"Reset the status of {count.Count} records that where outside of the heartbeat window of {_configuration.HeartBeat.Time.TotalSeconds} seconds");
+                   "Reset the status of {Count} records that where outside of the heartbeat window of {HeartBeatSeconds} seconds", count.Count, _configuration.HeartBeat.Time.TotalSeconds);
             }
             return count;
         }

--- a/Source/DotNetWorkQueue/Logging/Decorator/IRollbackMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IRollbackMessageDecorator.cs
@@ -50,7 +50,7 @@ namespace DotNetWorkQueue.Logging.Decorator
             }
             catch (Exception e)
             {
-                _log.LogError($"An error has occurred while trying to rollback a message{System.Environment.NewLine}{e}");
+                _log.LogError("An error has occurred while trying to rollback a message{NewLine}{Exception}", System.Environment.NewLine, e);
                 return false;
             }
         }

--- a/Source/DotNetWorkQueue/Messages/ReceivedMessage.cs
+++ b/Source/DotNetWorkQueue/Messages/ReceivedMessage.cs
@@ -109,7 +109,7 @@ namespace DotNetWorkQueue.Messages
                 }
                 catch (Exception e)
                 {
-                    _logger.LogWarning($"Failed to load the previous error messages {System.Environment.NewLine}{e}");
+                    _logger.LogWarning("Failed to load the previous error messages {NewLine}{Exception}", System.Environment.NewLine, e);
                 }
                 return _previousErrors;
             }

--- a/Source/DotNetWorkQueue/Queue/BaseMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/BaseMonitor.cs
@@ -134,7 +134,7 @@ namespace DotNetWorkQueue.Queue
             }
             catch (Exception error)
             {
-                _log.LogError($"An exception has occurred in the monitor delegate {System.Environment.NewLine}{error}");
+                _log.LogError("An exception has occurred in the monitor delegate {NewLine}{Exception}", System.Environment.NewLine, error);
             }
             finally
             {

--- a/Source/DotNetWorkQueue/Queue/HeartBeatScheduler.cs
+++ b/Source/DotNetWorkQueue/Queue/HeartBeatScheduler.cs
@@ -137,32 +137,32 @@ namespace DotNetWorkQueue.Queue
 
         private void OnMessageCompleted(MessageCompleteNotification obj)
         {
-            _log.LogDebug($"HeartBeat processing completed {obj.MessageId}");
+            _log.LogDebug("HeartBeat processing completed {MessageId}", obj.MessageId);
         }
 
         private void OnMessageRollBack(RollBackNotification obj)
         {
-            _log.LogWarning($"Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {System.Environment.NewLine}{obj.MessageId}{System.Environment.NewLine}{obj.Error}");
+            _log.LogWarning("Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
         }
 
         private void OnPoisonMessage(PoisonMessageNotification obj)
         {
-            _log.LogWarning($"Heart beat processing has triggered a poison message {System.Environment.NewLine}{obj.MessageId}{System.Environment.NewLine}{obj.Error}");
+            _log.LogWarning("Heart beat processing has triggered a poison message {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
         }
 
         private void OnMessageMovedToErrorQueue(ErrorNotification obj)
         {
-            _log.LogError($"Heart beat processing has failed {System.Environment.NewLine}{obj.MessageId}{System.Environment.NewLine}{obj.Error}");
+            _log.LogError("Heart beat processing has failed {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
         }
 
         private void OnReceiveMessageError(ErrorReceiveNotification obj)
         {
-            _log.LogWarning($"Heart beat processing has failed to dequeue a message {System.Environment.NewLine}{obj.Error}");
+            _log.LogWarning("Heart beat processing has failed to dequeue a message {NewLine}{Error}", System.Environment.NewLine, obj.Error);
         }
 
         private void OnError(ErrorNotification obj)
         {
-            _log.LogError($"Heart beat processing has failed {System.Environment.NewLine}{obj.Error}");
+            _log.LogError("Heart beat processing has failed {NewLine}{Error}", System.Environment.NewLine, obj.Error);
         }
     }
 }

--- a/Source/DotNetWorkQueue/Queue/HeartBeatWorker.cs
+++ b/Source/DotNetWorkQueue/Queue/HeartBeatWorker.cs
@@ -160,7 +160,7 @@ namespace DotNetWorkQueue.Queue
                     var removed = _scheduler?.RemoveJob(_job.Name);
                     if (removed.HasValue && !removed.Value)
                     {
-                        _logger.LogWarning($"Failed to remove job {_job.Name} from the heartbeat scheduler");
+                        _logger.LogWarning("Failed to remove job {JobName} from the heartbeat scheduler", _job.Name);
                     }
                 }
                 lock (_cancelLocker)
@@ -205,19 +205,19 @@ namespace DotNetWorkQueue.Queue
                     if (status.LastHeartBeatTime.HasValue)
                     {
                         _context.WorkerNotification.HeartBeat.Status = status;
-                        _logger.LogTrace($"Set heartbeat for message {status.MessageId.Id.Value}");
+                        _logger.LogTrace("Set heartbeat for message {MessageId}", status.MessageId.Id.Value);
                     }
                     else
                     {
                         _logger.LogDebug(
-                            $"Failed to set heartbeat for message ID {status.MessageId.Id.Value}; since no exception was generated, this probably means that the record no longer exists");
+                            "Failed to set heartbeat for message ID {MessageId}; since no exception was generated, this probably means that the record no longer exists", status.MessageId.Id.Value);
                     }
                 }
             }
             catch (Exception error)
             {
                 _logger.LogError(
-                    $"An error has occurred while updating the heartbeat field for a record that is being processed{System.Environment.NewLine}{error}");
+                    "An error has occurred while updating the heartbeat field for a record that is being processed{NewLine}{Exception}", System.Environment.NewLine, error);
 
                 lock (_runningLocker)
                 {

--- a/Source/DotNetWorkQueue/Queue/MessageExceptionHandler.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageExceptionHandler.cs
@@ -71,7 +71,7 @@ namespace DotNetWorkQueue.Queue
             catch (Exception errorHandlingError)
             {
                 _log.LogError(
-                    $"An error has occurred while trying to move message {message.MessageId} to the error queue{System.Environment.NewLine}{exception}");
+                    "An error has occurred while trying to move message {MessageId} to the error queue{NewLine}{Exception}", message.MessageId, System.Environment.NewLine, exception);
                 throw new DotNetWorkQueueException("An error has occurred in the error handling code",
                     errorHandlingError);
             }

--- a/Source/DotNetWorkQueue/Queue/MessageProcessing.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageProcessing.cs
@@ -137,7 +137,7 @@ namespace DotNetWorkQueue.Queue
             catch (Exception ex) //not cool - one of the exception events threw an exception
             {
                 //there isn't a whole lot we can do here
-                _log.LogError($"An error has occurred while trying to handle an exception{System.Environment.NewLine}{ex}");
+                _log.LogError("An error has occurred while trying to handle an exception{NewLine}{Exception}", System.Environment.NewLine, ex);
                 _consumerQueueErrorNotification.InvokeError(new ErrorReceiveNotification(ex));
             }
         }
@@ -168,7 +168,7 @@ namespace DotNetWorkQueue.Queue
                 {
                     //an exception occurred trying to get the message from the transport
                     _log.LogError(
-                        $"An error has occurred while receiving a message from the transport{System.Environment.NewLine}{e}");
+                        "An error has occurred while receiving a message from the transport{NewLine}{Exception}", System.Environment.NewLine, e);
                     _consumerQueueErrorNotification.InvokeError(new ErrorReceiveNotification(e));
                     _seriousExceptionProcessBackOffHelper.Value.Wait();
                 }

--- a/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
@@ -141,7 +141,7 @@ namespace DotNetWorkQueue.Queue
             catch (Exception ex) //not cool - one of the exception events threw an exception
             {
                 //there is not a lot we can do here - log the exception
-                _log.LogError($"An error has occurred while trying to handle an exception{System.Environment.NewLine}{ex}");
+                _log.LogError("An error has occurred while trying to handle an exception{NewLine}{Exception}", System.Environment.NewLine, ex);
                 _consumerQueueErrorNotification.InvokeError(new ErrorReceiveNotification(ex));
             }
             finally
@@ -174,7 +174,7 @@ namespace DotNetWorkQueue.Queue
                 catch (ReceiveMessageException e)
                 //an exception occurred trying to get the message from the transport
                 {
-                    _log.LogError($"An error has occurred while receiving a message from the transport{System.Environment.NewLine}{e}");
+                    _log.LogError("An error has occurred while receiving a message from the transport{NewLine}{Exception}", System.Environment.NewLine, e);
                     _consumerQueueErrorNotification.InvokeError(new ErrorReceiveNotification(e));
                     _seriousExceptionProcessBackOffHelper.Value.Wait();
                 }

--- a/Source/DotNetWorkQueue/Queue/PrimaryWorker.cs
+++ b/Source/DotNetWorkQueue/Queue/PrimaryWorker.cs
@@ -84,7 +84,7 @@ namespace DotNetWorkQueue.Queue
             WorkerName = _nameFactory.Create();
             WorkerTask = Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning);
 
-            _log.LogDebug($"{WorkerName} created");
+            _log.LogDebug("{WorkerName} created", WorkerName);
 
             _workerCollection.Start();
         }
@@ -98,7 +98,7 @@ namespace DotNetWorkQueue.Queue
 
             if (WorkerTask != null)
             {
-                _log.LogDebug($"Stopping worker {WorkerName}");
+                _log.LogDebug("Stopping worker {WorkerName}", WorkerName);
             }
 
             _workerCollection.Stop();
@@ -144,7 +144,7 @@ namespace DotNetWorkQueue.Queue
             {
                 WaitOnAsyncTask.Wait(() => MessageProcessing.AsyncTaskCount > 0,
                     () => _log.LogWarning(
-                        $"Unable to terminate because async requests have not finished. Current task count is {MessageProcessing.AsyncTaskCount}"));
+                        "Unable to terminate because async requests have not finished. Current task count is {AsyncTaskCount}", MessageProcessing.AsyncTaskCount));
             }
         }
     }

--- a/Source/DotNetWorkQueue/Queue/ProducerQueue.cs
+++ b/Source/DotNetWorkQueue/Queue/ProducerQueue.cs
@@ -229,7 +229,7 @@ namespace DotNetWorkQueue.Queue
             {
                 WaitOnAsyncTask.Wait(() => _asyncTaskCount > 0,
                     () => _log.LogWarning(
-                        $"Unable to terminate because async requests have not finished. Current task count is {_asyncTaskCount}"));
+                        "Unable to terminate because async requests have not finished. Current task count is {AsyncTaskCount}", _asyncTaskCount));
             }
         }
 

--- a/Source/DotNetWorkQueue/Queue/StopWorkers.cs
+++ b/Source/DotNetWorkQueue/Queue/StopWorkers.cs
@@ -116,7 +116,7 @@ namespace DotNetWorkQueue.Queue
                 }
                 catch (Exception e)
                 {
-                    _log.LogError($"An error has occurred while disposing of a worker{System.Environment.NewLine}{e}");
+                    _log.LogError("An error has occurred while disposing of a worker{NewLine}{Exception}", System.Environment.NewLine, e);
                 }
             }
         }

--- a/Source/DotNetWorkQueue/Queue/Worker.cs
+++ b/Source/DotNetWorkQueue/Queue/Worker.cs
@@ -78,7 +78,7 @@ namespace DotNetWorkQueue.Queue
             WorkerName = _nameFactory.Create();
             WorkerTask = Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning);
 
-            _log.LogDebug($"{WorkerName} created");
+            _log.LogDebug("{WorkerName} created", WorkerName);
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace DotNetWorkQueue.Queue
             if (WorkerTask == null)
                 return;
 
-            _log.LogDebug($"Stopping worker {WorkerName}");
+            _log.LogDebug("Stopping worker {WorkerName}", WorkerName);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace DotNetWorkQueue.Queue
             {
                 WaitOnAsyncTask.Wait(() => MessageProcessing.AsyncTaskCount > 0,
                     () => _log.LogWarning(
-                        $"Unable to terminate because async requests have not finished. Current task count is {MessageProcessing.AsyncTaskCount}"));
+                        "Unable to terminate because async requests have not finished. Current task count is {AsyncTaskCount}", MessageProcessing.AsyncTaskCount));
             }
         }
     }

--- a/Source/DotNetWorkQueue/Queue/WorkerCollection.cs
+++ b/Source/DotNetWorkQueue/Queue/WorkerCollection.cs
@@ -87,7 +87,7 @@ namespace DotNetWorkQueue.Queue
                     throw new DotNetWorkQueueException("Start must only be called once");
                 }
 
-                _log.LogDebug($"Initializing with {_workerConfiguration.WorkerCount} workers");
+                _log.LogDebug("Initializing with {WorkerCount} workers", _workerConfiguration.WorkerCount);
                 CreateWorkers();
 
                 if (_workers == null || _workers.Count <= 0) return;

--- a/Source/DotNetWorkQueue/TaskScheduling/TaskScheduler.cs
+++ b/Source/DotNetWorkQueue/TaskScheduling/TaskScheduler.cs
@@ -143,10 +143,10 @@ namespace DotNetWorkQueue.TaskScheduling
 
             if (_logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.Log(LogLevel.Trace, $"Task count for group {group.Name} is {current}");
+                _logger.Log(LogLevel.Trace, "Task count for group {GroupName} is {Current}", group.Name, current);
 
                 var queue = Interlocked.Read(ref _currentTaskCount);
-                _logger.Log(LogLevel.Trace, $"Task count is {queue} with the max being {_configuration.MaximumThreads}");
+                _logger.Log(LogLevel.Trace, "Task count is {Queue} with the max being {MaximumThreads}", queue, _configuration.MaximumThreads);
             }
         }
 
@@ -158,7 +158,7 @@ namespace DotNetWorkQueue.TaskScheduling
             var current = Interlocked.Increment(ref _currentTaskCount);
 
             if (_logger.IsEnabled(LogLevel.Trace))
-                _logger.Log(LogLevel.Trace, $"Task count is {current} with the max being {_configuration.MaximumThreads}");
+                _logger.Log(LogLevel.Trace, "Task count is {Current} with the max being {MaximumThreads}", current, _configuration.MaximumThreads);
         }
 
         /// <summary>
@@ -169,7 +169,7 @@ namespace DotNetWorkQueue.TaskScheduling
             var current = Interlocked.Decrement(ref _currentTaskCount);
 
             if (_logger.IsEnabled(LogLevel.Trace))
-                _logger.Log(LogLevel.Trace, $"Task count is {current} with the max being {_configuration.MaximumThreads}");
+                _logger.Log(LogLevel.Trace, "Task count is {Current} with the max being {MaximumThreads}", current, _configuration.MaximumThreads);
         }
 
         /// <summary>
@@ -181,10 +181,10 @@ namespace DotNetWorkQueue.TaskScheduling
             var current = Interlocked.Decrement(ref _groups[group].CurrentWorkItems);
             if (_logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.Log(LogLevel.Trace, $"Task count for group {group.Name} is {current}");
+                _logger.Log(LogLevel.Trace, "Task count for group {GroupName} is {Current}", group.Name, current);
 
                 var queue = Interlocked.Read(ref _currentTaskCount);
-                _logger.Log(LogLevel.Trace, $"Task count is {queue} with the max being {_configuration.MaximumThreads}");
+                _logger.Log(LogLevel.Trace, "Task count is {Queue} with the max being {MaximumThreads}", queue, _configuration.MaximumThreads);
             }
         }
 

--- a/Source/DotNetWorkQueue/Time/BaseTime.cs
+++ b/Source/DotNetWorkQueue/Time/BaseTime.cs
@@ -86,7 +86,7 @@ namespace DotNetWorkQueue.Time
                 var localTime = DateTime.UtcNow;
                 Offset = time - localTime;
                 ServerOffsetObtained = localTime;
-                Log.LogDebug($"[{Name}] server difference is {Offset.TotalMilliseconds} MS");
+                Log.LogDebug("[{Name}] server difference is {OffsetMs} MS", Name, Offset.TotalMilliseconds);
             }
             return DateTime.UtcNow.Add(Offset);
         }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/ReceiveErrorMessage.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/ReceiveErrorMessage.cs
@@ -67,7 +67,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
 
             //we are done doing any processing - remove the messageID to block other actions
             context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
-            _log.LogError($"Message with ID {message.MessageId} has failed and has been moved to the error queue {System.Environment.NewLine}{exception}");
+            _log.LogError("Message with ID {MessageId} has failed and has been moved to the error queue {NewLine}{Exception}", message.MessageId, System.Environment.NewLine, exception);
             return ReceiveMessagesErrorResult.Error;
         }
         #endregion


### PR DESCRIPTION
Fifth SonarCloud sweep (Bucket B, part 1) — structured logging, following #184, #186, #188, #189.

## What changed
Converted **69 interpolated logging calls** (`$"...{x}..."`) to static message templates with named placeholders + arguments:

```csharp
// before
_log.LogError($"Message with ID {message.MessageId} has failed{Environment.NewLine}{exception}");
// after
_log.LogError("Message with ID {MessageId} has failed{NewLine}{Exception}", message.MessageId, System.Environment.NewLine, exception);
```

Across core, all transports (SqlServer/PostgreSQL/SQLite/Redis/LiteDB/Shared/Memory), and the integration-test notification helper. **Clears CA2254 and its Sonar mirror S2629** (~62 shared + 7 test sites).

**Output preserved exactly** — where `Environment.NewLine` was interpolated it's passed as an argument (rather than dropped or hardcoded), so multi-line log formatting is unchanged.

## Not in this PR
**CA1873** ("argument may be expensive if logging is disabled", 37) is a different fix (`IsEnabled` guards / `LoggerMessage`). ~25 of its sites are the same calls converted here, so templating clears the cheap-arg ones automatically; the residual (Dashboard services + a few method-call args) is a focused follow-up.

## Verification
- Full solution builds clean, 0 errors (net10.0 + net8.0)
- 0 interpolated `Log*($"...")` calls remain
- Unit suites green (core 915, Memory, Redis)

No changelog/version bump (matches the #186/#188/#189 mechanical-cleanup precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated logging across queue processing, workers, scheduling, and transport components to use structured message templates (with named placeholders for message IDs, queue/job details, retry info, and exceptions).
  * Kept log text and behavior effectively the same, improving consistency of error, warning, and trace output.
* **Tests**
  * Added logging template rendering tests to confirm structured-log placeholders produce the same output as equivalent interpolated messages (including multi-line and exception scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->