### PR TITLE
refactor: guard conditional log calls with IsEnabled (CA1873)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Api/DashboardApi.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/DashboardApi.cs
@@ -157,9 +157,10 @@ namespace DotNetWorkQueue.Dashboard.Api
                     var service = container.GetInstance<IQueueMaintenanceService>();
                     service.Start();
                     _maintenanceServices[kvp.Key] = service;
-                    _logger.LogInformation(
-                        "Started maintenance service for queue {QueueName} ({QueueId})",
-                        kvp.Value.QueueName, kvp.Key);
+                    if (_logger.IsEnabled(LogLevel.Information))
+                        _logger.LogInformation(
+                            "Started maintenance service for queue {QueueName} ({QueueId})",
+                            kvp.Value.QueueName, kvp.Key);
                 }
                 catch (Exception ex)
                 {

--- a/Source/DotNetWorkQueue.Dashboard.Api/Services/ConsumerPruningService.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Services/ConsumerPruningService.cs
@@ -59,7 +59,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Services
                     var pruned = _registry.PruneStale(staleThreshold);
                     if (pruned > 0)
                     {
-                        _logger.LogInformation("Pruned {Count} stale consumer(s)", pruned);
+                        if (_logger.IsEnabled(LogLevel.Information))
+                            _logger.LogInformation("Pruned {Count} stale consumer(s)", pruned);
                     }
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/Source/DotNetWorkQueue.Dashboard.Api/Services/DashboardService.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Services/DashboardService.cs
@@ -471,13 +471,15 @@ namespace DotNetWorkQueue.Dashboard.Api.Services
         /// </summary>
         private Type ResolveMessageBodyType(string portableName)
         {
-            _logger.LogDebug("Resolving message body type: {PortableName}", portableName);
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("Resolving message body type: {PortableName}", portableName);
 
             // Stage 1: already loaded in AppDomain
             var type = Type.GetType(portableName);
             if (type != null)
             {
-                _logger.LogDebug("Type resolved from AppDomain: {Type}", type.FullName);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug("Type resolved from AppDomain: {Type}", type.FullName);
                 return type;
             }
 
@@ -495,10 +497,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Services
             var resolved = TryLoadType(binPath, typeFullName);
             if (resolved != null)
             {
-                _logger.LogDebug("Type resolved from bin folder: {Path}", binPath);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug("Type resolved from bin folder: {Path}", binPath);
                 return resolved;
             }
-            _logger.LogDebug("Assembly not found in bin folder: {Path}", binPath);
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("Assembly not found in bin folder: {Path}", binPath);
 
             // Stage 3: try configured assembly paths
             foreach (var dir in _assemblyPaths)
@@ -507,10 +511,12 @@ namespace DotNetWorkQueue.Dashboard.Api.Services
                 resolved = TryLoadType(pluginPath, typeFullName);
                 if (resolved != null)
                 {
-                    _logger.LogDebug("Type resolved from plugin path: {Path}", pluginPath);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                        _logger.LogDebug("Type resolved from plugin path: {Path}", pluginPath);
                     return resolved;
                 }
-                _logger.LogDebug("Assembly not found in plugin path: {Path}", pluginPath);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug("Assembly not found in plugin path: {Path}", pluginPath);
             }
 
             _logger.LogWarning("Could not resolve type {PortableName}. Searched: bin={BinDir}, plugins=[{PluginDirs}]",

--- a/Source/DotNetWorkQueue.Dashboard.Ui/Services/LocalSourceHostedService.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui/Services/LocalSourceHostedService.cs
@@ -69,7 +69,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Services
             if (localSource != null)
             {
                 localSource.BaseUrl = address;
-                _logger.LogInformation("Local API source URL resolved to {Address}", address);
+                if (_logger.IsEnabled(LogLevel.Information))
+                    _logger.LogInformation("Local API source URL resolved to {Address}", address);
             }
 
             return Task.CompletedTask;

--- a/Source/DotNetWorkQueue.Dashboard.Ui/Services/SourceHealthMonitor.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui/Services/SourceHealthMonitor.cs
@@ -128,11 +128,13 @@ namespace DotNetWorkQueue.Dashboard.Ui.Services
                 {
                     if (newState.Status == SourceHealthStatus.Healthy)
                     {
-                        _logger.LogInformation("Source '{SourceName}' is now Healthy", source.Name);
+                        if (_logger.IsEnabled(LogLevel.Information))
+                            _logger.LogInformation("Source '{SourceName}' is now Healthy", source.Name);
                     }
                     else if (newState.Status == SourceHealthStatus.Unhealthy)
                     {
-                        _logger.LogInformation("Source '{SourceName}' is now Unhealthy: {ErrorMessage}", source.Name, newState.ErrorMessage);
+                        if (_logger.IsEnabled(LogLevel.Information))
+                            _logger.LogInformation("Source '{SourceName}' is now Unhealthy: {ErrorMessage}", source.Name, newState.ErrorMessage);
                     }
                 }
             }

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/CreateNotifications.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/CreateNotifications.cs
@@ -19,32 +19,38 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
         }
         private static void OnMessageCompleted(ILogger log, MessageCompleteNotification obj)
         {
-            log.LogTrace("Processing completed {MessageId}", obj.MessageId);
+            if (log.IsEnabled(LogLevel.Trace))
+                log.LogTrace("Processing completed {MessageId}", obj.MessageId);
         }
 
         private static void OnMessageRollBack(ILogger log, RollBackNotification obj)
         {
-            log.LogTrace("Processing has triggered a rollback {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
+            if (log.IsEnabled(LogLevel.Trace))
+                log.LogTrace("Processing has triggered a rollback {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
         }
 
         private static void OnPoisonMessage(ILogger log, PoisonMessageNotification obj)
         {
-            log.LogTrace("Processing has triggered a poison message {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
+            if (log.IsEnabled(LogLevel.Trace))
+                log.LogTrace("Processing has triggered a poison message {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
         }
 
         private static void OnMessageMovedToErrorQueue(ILogger log, ErrorNotification obj)
         {
-            log.LogTrace("Processing has failed {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
+            if (log.IsEnabled(LogLevel.Trace))
+                log.LogTrace("Processing has failed {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
         }
 
         private static void OnReceiveMessageError(ILogger log, ErrorReceiveNotification obj)
         {
-            log.LogTrace("Processing has failed to dequeue a message {NewLine}{Error}", System.Environment.NewLine, obj.Error);
+            if (log.IsEnabled(LogLevel.Trace))
+                log.LogTrace("Processing has failed to dequeue a message {NewLine}{Error}", System.Environment.NewLine, obj.Error);
         }
 
         private static void OnError(ILogger log, ErrorNotification obj)
         {
-            log.LogTrace("Processing has failed {NewLine}{Error}", System.Environment.NewLine, obj.Error);
+            if (log.IsEnabled(LogLevel.Trace))
+                log.LogTrace("Processing has failed {NewLine}{Error}", System.Environment.NewLine, obj.Error);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Tests/Logging/LogMessageTemplateTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Logging/LogMessageTemplateTests.cs
@@ -18,7 +18,8 @@ namespace DotNetWorkQueue.Tests.Logging
         {
             var logger = new CapturingLogger();
             const string id = "msg-1";
-            logger.LogDebug("HeartBeat processing completed {MessageId}", id);
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("HeartBeat processing completed {MessageId}", id);
             Assert.AreEqual($"HeartBeat processing completed {id}", logger.LastMessage);
         }
 
@@ -28,7 +29,8 @@ namespace DotNetWorkQueue.Tests.Logging
             var logger = new CapturingLogger();
             const int count = 5;
             const string queue = "q1";
-            logger.LogInformation("Deleted {Count} error messages from {QueueName}", count, queue);
+            if (logger.IsEnabled(LogLevel.Information))
+                logger.LogInformation("Deleted {Count} error messages from {QueueName}", count, queue);
             Assert.AreEqual($"Deleted {count} error messages from {queue}", logger.LastMessage);
         }
 

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/DatabaseExists.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/DatabaseExists.cs
@@ -57,7 +57,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
 
             var exist = File.Exists(fileName.FileName);
             if (!exist)
-                _logger.LogDebug("database {FileName} was not found", fileName.FileName);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug("database {FileName} was not found", fileName.FileName);
             return exist;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/DelayedProcessingActionDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/DelayedProcessingActionDecorator.cs
@@ -50,7 +50,8 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Logging.Decorator
             var records = _handler.Run(token);
             if (records > 0)
             {
-                _log.LogInformation("Moved {Records} records from the delayed queue to the pending queue", records);
+                if (_log.IsEnabled(LogLevel.Information))
+                    _log.LogInformation("Moved {Records} records from the delayed queue to the pending queue", records);
             }
             return records;
         }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/ReceiveMessageQueryDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/ReceiveMessageQueryDecorator.cs
@@ -51,7 +51,8 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Logging.Decorator
             var result = _handler.Handle(query);
             if (result != null && result.Expired)
             {
-                _log.LogDebug("Message {MessageId} expired before it could be processed", result.MessageId);
+                if (_log.IsEnabled(LogLevel.Debug))
+                    _log.LogDebug("Message {MessageId} expired before it could be processed", result.MessageId);
             }
             return result;
         }

--- a/Source/DotNetWorkQueue/JobScheduler/JobScheduler.cs
+++ b/Source/DotNetWorkQueue/JobScheduler/JobScheduler.cs
@@ -80,8 +80,10 @@ namespace DotNetWorkQueue.JobScheduler
         public void Start()
         {
             //log task time (from time factory) and local machine time to show differences..
-            _log.LogInformation("Scheduler time is {SchedulerTime}", _getTime.Create().GetCurrentUtcDate());
-            _log.LogInformation("Local time is {LocalTime}", DateTime.UtcNow);
+            if (_log.IsEnabled(LogLevel.Information))
+                _log.LogInformation("Scheduler time is {SchedulerTime}", _getTime.Create().GetCurrentUtcDate());
+            if (_log.IsEnabled(LogLevel.Information))
+                _log.LogInformation("Local time is {LocalTime}", DateTime.UtcNow);
 
             Task.Run(PollAsync);
         }
@@ -173,7 +175,8 @@ namespace DotNetWorkQueue.JobScheduler
                 _tasks.Add(name, job);
             }
 
-            _log.LogInformation("Job {JobName} scheduled: {ScheduleExpression} ({ScheduleDescription})", name, schedule.OriginalText, schedule.Description);
+            if (_log.IsEnabled(LogLevel.Information))
+                _log.LogInformation("Job {JobName} scheduled: {ScheduleExpression} ({ScheduleDescription})", name, schedule.OriginalText, schedule.Description);
 
             job.OnException += TaskOnOnException;
             job.OnEnQueue += JobOnOnEnQueue;
@@ -234,7 +237,8 @@ namespace DotNetWorkQueue.JobScheduler
                 _tasks.Add(name, job);
             }
 
-            _log.LogInformation("Job {JobName} scheduled: {ScheduleExpression} ({ScheduleDescription})", name, schedule.OriginalText, schedule.Description);
+            if (_log.IsEnabled(LogLevel.Information))
+                _log.LogInformation("Job {JobName} scheduled: {ScheduleExpression} ({ScheduleDescription})", name, schedule.OriginalText, schedule.Description);
 
             job.OnException += TaskOnOnException;
             job.OnEnQueue += JobOnOnEnQueue;

--- a/Source/DotNetWorkQueue/JobScheduler/JobScheduler.cs
+++ b/Source/DotNetWorkQueue/JobScheduler/JobScheduler.cs
@@ -81,9 +81,10 @@ namespace DotNetWorkQueue.JobScheduler
         {
             //log task time (from time factory) and local machine time to show differences..
             if (_log.IsEnabled(LogLevel.Information))
+            {
                 _log.LogInformation("Scheduler time is {SchedulerTime}", _getTime.Create().GetCurrentUtcDate());
-            if (_log.IsEnabled(LogLevel.Information))
                 _log.LogInformation("Local time is {LocalTime}", DateTime.UtcNow);
+            }
 
             Task.Run(PollAsync);
         }

--- a/Source/DotNetWorkQueue/JobScheduler/ScheduledJob.cs
+++ b/Source/DotNetWorkQueue/JobScheduler/ScheduledJob.cs
@@ -194,7 +194,8 @@ namespace DotNetWorkQueue.JobScheduler
                         if (result.Status == JobQueuedStatus.Success || result.Status == JobQueuedStatus.RequeuedDueToErrorStatus)
                         {
                             RaiseEnQueue(result);
-                            _queue.Logger.LogDebug("job {Job} queued", this);
+                            if (_queue.Logger.IsEnabled(LogLevel.Debug))
+                                _queue.Logger.LogDebug("job {Job} queued", this);
                         }
                         else if (result.Status == JobQueuedStatus.AlreadyQueuedWaiting ||
                                  result.Status == JobQueuedStatus.AlreadyQueuedProcessing ||

--- a/Source/DotNetWorkQueue/Logging/Decorator/IClearErrorMessagesDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IClearErrorMessagesDecorator.cs
@@ -53,7 +53,8 @@ namespace DotNetWorkQueue.Logging.Decorator
             var count = _handler.ClearMessages(cancelToken);
             if (count > 0)
             {
-                _log.LogInformation("Deleted {Count} error messages from {QueueName}", count, _connectionInfo.QueueName);
+                if (_log.IsEnabled(LogLevel.Information))
+                    _log.LogInformation("Deleted {Count} error messages from {QueueName}", count, _connectionInfo.QueueName);
             }
             return count;
         }

--- a/Source/DotNetWorkQueue/Logging/Decorator/IClearExpiredMessagesDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IClearExpiredMessagesDecorator.cs
@@ -57,7 +57,8 @@ namespace DotNetWorkQueue.Logging.Decorator
             var count = _handler.ClearMessages(cancelToken);
             if (count > 0)
             {
-                _log.LogInformation("Deleted {Count} expired messages from {QueueName}", count, _connectionInfo.QueueName);
+                if (_log.IsEnabled(LogLevel.Information))
+                    _log.LogInformation("Deleted {Count} expired messages from {QueueName}", count, _connectionInfo.QueueName);
             }
             return count;
         }

--- a/Source/DotNetWorkQueue/Logging/Decorator/IResetHeartBeatDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IResetHeartBeatDecorator.cs
@@ -54,8 +54,9 @@ namespace DotNetWorkQueue.Logging.Decorator
             var count = _handler.Reset(cancelToken);
             if (count.Count > 0)
             {
-                _log.LogInformation(
-                   "Reset the status of {Count} records that where outside of the heartbeat window of {HeartBeatSeconds} seconds", count.Count, _configuration.HeartBeat.Time.TotalSeconds);
+                if (_log.IsEnabled(LogLevel.Information))
+                    _log.LogInformation(
+                       "Reset the status of {Count} records that where outside of the heartbeat window of {HeartBeatSeconds} seconds", count.Count, _configuration.HeartBeat.Time.TotalSeconds);
             }
             return count;
         }

--- a/Source/DotNetWorkQueue/Queue/HeartBeatScheduler.cs
+++ b/Source/DotNetWorkQueue/Queue/HeartBeatScheduler.cs
@@ -137,7 +137,8 @@ namespace DotNetWorkQueue.Queue
 
         private void OnMessageCompleted(MessageCompleteNotification obj)
         {
-            _log.LogDebug("HeartBeat processing completed {MessageId}", obj.MessageId);
+            if (_log.IsEnabled(LogLevel.Debug))
+                _log.LogDebug("HeartBeat processing completed {MessageId}", obj.MessageId);
         }
 
         private void OnMessageRollBack(RollBackNotification obj)

--- a/Source/DotNetWorkQueue/Queue/HeartBeatWorker.cs
+++ b/Source/DotNetWorkQueue/Queue/HeartBeatWorker.cs
@@ -205,12 +205,14 @@ namespace DotNetWorkQueue.Queue
                     if (status.LastHeartBeatTime.HasValue)
                     {
                         _context.WorkerNotification.HeartBeat.Status = status;
-                        _logger.LogTrace("Set heartbeat for message {MessageId}", status.MessageId.Id.Value);
+                        if (_logger.IsEnabled(LogLevel.Trace))
+                            _logger.LogTrace("Set heartbeat for message {MessageId}", status.MessageId.Id.Value);
                     }
                     else
                     {
-                        _logger.LogDebug(
-                            "Failed to set heartbeat for message ID {MessageId}; since no exception was generated, this probably means that the record no longer exists", status.MessageId.Id.Value);
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                            _logger.LogDebug(
+                                "Failed to set heartbeat for message ID {MessageId}; since no exception was generated, this probably means that the record no longer exists", status.MessageId.Id.Value);
                     }
                 }
             }

--- a/Source/DotNetWorkQueue/Queue/PrimaryWorker.cs
+++ b/Source/DotNetWorkQueue/Queue/PrimaryWorker.cs
@@ -84,7 +84,8 @@ namespace DotNetWorkQueue.Queue
             WorkerName = _nameFactory.Create();
             WorkerTask = Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning);
 
-            _log.LogDebug("{WorkerName} created", WorkerName);
+            if (_log.IsEnabled(LogLevel.Debug))
+                _log.LogDebug("{WorkerName} created", WorkerName);
 
             _workerCollection.Start();
         }
@@ -98,7 +99,8 @@ namespace DotNetWorkQueue.Queue
 
             if (WorkerTask != null)
             {
-                _log.LogDebug("Stopping worker {WorkerName}", WorkerName);
+                if (_log.IsEnabled(LogLevel.Debug))
+                    _log.LogDebug("Stopping worker {WorkerName}", WorkerName);
             }
 
             _workerCollection.Stop();

--- a/Source/DotNetWorkQueue/Queue/Worker.cs
+++ b/Source/DotNetWorkQueue/Queue/Worker.cs
@@ -78,7 +78,8 @@ namespace DotNetWorkQueue.Queue
             WorkerName = _nameFactory.Create();
             WorkerTask = Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning);
 
-            _log.LogDebug("{WorkerName} created", WorkerName);
+            if (_log.IsEnabled(LogLevel.Debug))
+                _log.LogDebug("{WorkerName} created", WorkerName);
         }
 
         /// <summary>
@@ -93,7 +94,8 @@ namespace DotNetWorkQueue.Queue
             if (WorkerTask == null)
                 return;
 
-            _log.LogDebug("Stopping worker {WorkerName}", WorkerName);
+            if (_log.IsEnabled(LogLevel.Debug))
+                _log.LogDebug("Stopping worker {WorkerName}", WorkerName);
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue/Queue/WorkerCollection.cs
+++ b/Source/DotNetWorkQueue/Queue/WorkerCollection.cs
@@ -87,7 +87,8 @@ namespace DotNetWorkQueue.Queue
                     throw new DotNetWorkQueueException("Start must only be called once");
                 }
 
-                _log.LogDebug("Initializing with {WorkerCount} workers", _workerConfiguration.WorkerCount);
+                if (_log.IsEnabled(LogLevel.Debug))
+                    _log.LogDebug("Initializing with {WorkerCount} workers", _workerConfiguration.WorkerCount);
                 CreateWorkers();
 
                 if (_workers == null || _workers.Count <= 0) return;

--- a/Source/DotNetWorkQueue/Time/BaseTime.cs
+++ b/Source/DotNetWorkQueue/Time/BaseTime.cs
@@ -86,7 +86,8 @@ namespace DotNetWorkQueue.Time
                 var localTime = DateTime.UtcNow;
                 Offset = time - localTime;
                 ServerOffsetObtained = localTime;
-                Log.LogDebug("[{Name}] server difference is {OffsetMs} MS", Name, Offset.TotalMilliseconds);
+                if (Log.IsEnabled(LogLevel.Debug))
+                    Log.LogDebug("[{Name}] server difference is {OffsetMs} MS", Name, Offset.TotalMilliseconds);
             }
             return DateTime.UtcNow.Add(Offset);
         }


### PR DESCRIPTION
## Summary
Bucket B part 2 of the SonarCloud code-smell reduction effort. Wraps all **39 CA1873** sites ("evaluation of argument may be expensive if logging is disabled") in an `IsEnabled(level)` guard.

All flagged sites are low-severity levels — **18 Debug, 7 Trace, 14 Information** (zero Warning/Error/Critical) — so guarding is a genuine win: the `params object[]` allocation and property/method-call argument evaluation are now skipped when the level is off. Several sites are in the continuously-running worker / heartbeat / scheduler loops.

```csharp
// before
Log.LogDebug("[{Name}] server difference is {OffsetMs} MS", Name, Offset.TotalMilliseconds);
// after
if (Log.IsEnabled(LogLevel.Debug))
    Log.LogDebug("[{Name}] server difference is {OffsetMs} MS", Name, Offset.TotalMilliseconds);
```

## Context
Complements #190 (merged), which cleared **CA2254 / S2629** by converting interpolated log messages to constant templates. CA1873 is orthogonal to that templating and was not affected — it required these guards.

## Scope
- 39 guards across 21 files (core queue/scheduler/heartbeat, Dashboard API/UI, LiteDB + Redis transports, integration-test notification helpers, and the new log-template test).
- No behavior change: guarded calls only skip when the level is disabled.

## Verification
- Full solution builds clean (0 errors; pre-existing TripleDES/SYSLIB warnings only).
- `LogMessageTemplateTests` 5/5 pass.

_Note: mechanical PRs continue to trip the duplication quality gate (deferred repo-wide dedup pass); expected._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary log output by emitting debug/trace/info messages only when the corresponding log level is enabled across background services, workers, scheduling, health monitoring, and storage/transport checks.
  * Improved logging-related test behavior by guarding log calls based on the enabled log level, while keeping existing message rendering assertions intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->