### PR TITLE
ci: exclude parallel SQL transports from Sonar copy-paste detection

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -56,6 +56,13 @@ jobs:
           # integration pipeline), not SonarCloud. sonar.coverage.exclusions=** tells Sonar
           # not to expect coverage data, so its "Coverage on New Code" gate condition does not
           # fail every PR (this workflow only builds; it does not run tests).
-          ${{ runner.temp }}\scanner\dotnet-sonarscanner begin /k:"blehnen_DotNetWorkQueue" /o:"blehnen" /d:sonar.exclusions="**/*.png,**/*.ico,**/*.jpg,**/*.jpeg,**/*.gif,**/*.webp,**/*.woff,**/*.woff2,**/*.ttf,**/*.eot" /d:sonar.coverage.exclusions="**/*"
+          #
+          # sonar.cpd.exclusions excludes the relational SQL transports (SqlServer, PostgreSQL,
+          # SQLite) from copy-paste detection. These are deliberately-parallel implementations of
+          # the same relational pattern (all built on Transport.RelationalDatabase) and are
+          # ~27-32% self-similar by design, which is ~76% of the repo's total duplication. That
+          # intentional structure otherwise dominates the "Duplications on New Code" gate condition
+          # and fails routine PRs. Core, Redis, RelationalDatabase, and LiteDB keep full CPD signal.
+          ${{ runner.temp }}\scanner\dotnet-sonarscanner begin /k:"blehnen_DotNetWorkQueue" /o:"blehnen" /d:sonar.exclusions="**/*.png,**/*.ico,**/*.jpg,**/*.jpeg,**/*.gif,**/*.webp,**/*.woff,**/*.woff2,**/*.ttf,**/*.eot" /d:sonar.coverage.exclusions="**/*" /d:sonar.cpd.exclusions="**/DotNetWorkQueue.Transport.SqlServer/**/*,**/DotNetWorkQueue.Transport.PostgreSQL/**/*,**/DotNetWorkQueue.Transport.SQLite/**/*"
           dotnet build "Source/DotNetWorkQueue.sln" -c Debug
           ${{ runner.temp }}\scanner\dotnet-sonarscanner end


### PR DESCRIPTION
## Problem
The SonarQube quality gate fails on essentially every PR (and on the master push), which the user has been clearing via repeated admin overrides. Root cause, confirmed from the SonarCloud API:

- The **only** failing gate condition is `new_duplicated_lines_density` = **3.09%** vs the `> 3%` threshold — razor-thin (114 duplicated lines out of 3,693 new lines).
- **76% of the repo's entire duplication** (7,906 of 10,350 lines) lives in three projects: `Transport.SqlServer` (27.5%), `Transport.PostgreSQL` (31.7%), `Transport.SQLite` (26.6%).
- Those three are **deliberately-parallel** implementations of the same relational pattern (all built on `Transport.RelationalDatabase`). The self-similarity is intentional architecture, not copy-paste debt — so copy-paste *detection* on them is pure noise that dominates the new-code duplication metric.

## Fix
Add `sonar.cpd.exclusions` for the three relational SQL transport projects, mirroring the existing `sonar.coverage.exclusions` rationale already in this workflow (which was added for the same "don't fail every PR" reason).

```
/d:sonar.cpd.exclusions="**/DotNetWorkQueue.Transport.SqlServer/**/*,**/DotNetWorkQueue.Transport.PostgreSQL/**/*,**/DotNetWorkQueue.Transport.SQLite/**/*"
```

The globs match exactly the three transport project directories — **not** their `.Tests` / `.Integration.Tests` variants, which keep full CPD signal.

## Effect
- **Duplications on New Code** gate condition drops well under 3% and stays there → no more per-PR overrides.
- Overall duplication badge: **8.9% → ~2–3%**.
- Core, Redis, `RelationalDatabase` base, and LiteDB retain full copy-paste detection, so genuine copy-paste elsewhere is still caught.

Config-only change; no source or behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows CI quality-check configuration to reduce duplicate-code warnings for related database transport components.
  * Improved pipeline comments to better document the expected duplication behavior in these areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->