### PR TITLE
fix: clear the S2955 bug and suppress the deliberate 3DES vulnerabilities

### DIFF
--- a/Source/DotNetWorkQueue/Interceptors/TripleDesMessageInterceptor.cs
+++ b/Source/DotNetWorkQueue/Interceptors/TripleDesMessageInterceptor.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using DotNetWorkQueue.Validation;
 
@@ -50,6 +51,8 @@ namespace DotNetWorkQueue.Interceptors
         /// <param name="input">The input.</param>
         /// <param name="headers">the message headers</param>
         /// <returns></returns>
+        [SuppressMessage("Security", "S5547:Cipher algorithms should be robust",
+            Justification = "3DES is intentionally retained (see [Obsolete] on the type) so existing 3DES-encrypted messages remain decryptable. New code should use AesMessageInterceptor.")]
         public MessageInterceptorResult MessageToBytes(byte[] input, IReadOnlyDictionary<string, object> headers)
         {
             Guard.NotNull(() => input, input);
@@ -68,6 +71,8 @@ namespace DotNetWorkQueue.Interceptors
         /// <param name="input">The input.</param>
         /// <param name="headers">the message headers</param>
         /// <returns></returns>
+        [SuppressMessage("Security", "S5547:Cipher algorithms should be robust",
+            Justification = "3DES is intentionally retained (see [Obsolete] on the type) so existing 3DES-encrypted messages remain decryptable. New code should use AesMessageInterceptor.")]
         public byte[] BytesToMessage(byte[] input, IReadOnlyDictionary<string, object> headers)
         {
             Guard.NotNull(() => input, input);

--- a/Source/DotNetWorkQueue/netfx/System/Guard.cs
+++ b/Source/DotNetWorkQueue/netfx/System/Guard.cs
@@ -51,7 +51,10 @@ namespace DotNetWorkQueue.Validation
         /// <exception cref="System.ArgumentException">The <paramref name="value"/> is null.</exception>
         public static T NotNull<T>(Expression<Func<T>> reference, T value)
         {
-            if (value == null)
+            // ReferenceEquals rather than "value == null": T is unconstrained, so the == operator
+            // trips S2955. This is behavior-identical (value types box to a non-null reference; a
+            // null Nullable<T> boxes to null) while only checking for a genuine null reference.
+            if (ReferenceEquals(value, null))
                 throw new ArgumentNullException(GetParameterName(reference), "Parameter cannot be null.");
 
             return value;


### PR DESCRIPTION
Track 1 of the badge-reduction effort. Takes the public SonarCloud badge to **0 bugs and 0 vulnerabilities**.

## Bug — S2955 (`Guard.NotNull<T>`)
`value == null` on an unconstrained generic `T` trips S2955. Replaced with `ReferenceEquals(value, null)`:
- **Behavior-identical** — value types box to a non-null reference (so a value-typed `T` is never "null", as today), and a null `Nullable<T>` boxes to a null reference (so it still throws). Only genuine null references are caught.
- Avoids the `==` operator the rule flags, **without** a `where T : class` constraint — that constraint cascaded across every unconstrained-generic caller when it was tried in #189, so it was reverted then.

## Vulnerabilities — S5547 ×2 (`TripleDesMessageInterceptor`)
Both flag the `TripleDES.Create()` calls as a weak cipher. This type is **already `[Obsolete]`** and retained *only* so existing 3DES-encrypted messages remain decryptable (new code uses `AesMessageInterceptor`). Removing 3DES would break decryption of previously-encrypted payloads, so the finding is **accepted with justification in code** via method-level `[SuppressMessage]` pointing at the deliberate retention.

## Verification
- Core project builds clean (0/0).
- `TripleDESInterceptorTest` 3/3 pass (encrypt/decrypt roundtrip, which also exercises the `NotNull` input guard).

_Note: SonarCloud honors inline `[SuppressMessage]` for its Roslyn-analyzer rules. If the two S5547 findings don't clear on the next master scan, the fallback is a one-click "Accept" in the SonarCloud UI — but no code change should be needed._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of null values in generic scenarios to keep validation behavior consistent and reliable.
  * Continued support for decrypting and encrypting existing legacy-protected messages, helping preserve compatibility with older data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->