### PR TITLE
fix: pass exceptions to the logger exception parameter (S6668)

### DIFF
--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/CreateNotifications.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/CreateNotifications.cs
@@ -26,31 +26,31 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
         private static void OnMessageRollBack(ILogger log, RollBackNotification obj)
         {
             if (log.IsEnabled(LogLevel.Trace))
-                log.LogTrace("Processing has triggered a rollback {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
+                log.LogTrace(obj.Error, "Processing has triggered a rollback {MessageId}", obj.MessageId);
         }
 
         private static void OnPoisonMessage(ILogger log, PoisonMessageNotification obj)
         {
             if (log.IsEnabled(LogLevel.Trace))
-                log.LogTrace("Processing has triggered a poison message {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
+                log.LogTrace(obj.Error, "Processing has triggered a poison message {MessageId}", obj.MessageId);
         }
 
         private static void OnMessageMovedToErrorQueue(ILogger log, ErrorNotification obj)
         {
             if (log.IsEnabled(LogLevel.Trace))
-                log.LogTrace("Processing has failed {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
+                log.LogTrace(obj.Error, "Processing has failed {MessageId}", obj.MessageId);
         }
 
         private static void OnReceiveMessageError(ILogger log, ErrorReceiveNotification obj)
         {
             if (log.IsEnabled(LogLevel.Trace))
-                log.LogTrace("Processing has failed to dequeue a message {NewLine}{Error}", System.Environment.NewLine, obj.Error);
+                log.LogTrace(obj.Error, "Processing has failed to dequeue a message");
         }
 
         private static void OnError(ILogger log, ErrorNotification obj)
         {
             if (log.IsEnabled(LogLevel.Trace))
-                log.LogTrace("Processing has failed {NewLine}{Error}", System.Environment.NewLine, obj.Error);
+                log.LogTrace(obj.Error, "Processing has failed");
         }
     }
 }

--- a/Source/DotNetWorkQueue.Tests/Logging/LogMessageTemplateTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Logging/LogMessageTemplateTests.cs
@@ -5,10 +5,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DotNetWorkQueue.Tests.Logging
 {
     /// <summary>
-    /// Verifies that the structured-logging message templates introduced for CA2254/S2629
-    /// render to the same text the original string interpolation produced. Guards against a
-    /// placeholder/argument mismatch, which the logging framework would render silently
-    /// (no exception) rather than fail.
+    /// Verifies the structured-logging message templates: that placeholders render to the
+    /// expected text (guarding the CA2254/S2629 templating, which the framework renders
+    /// silently on a placeholder/argument mismatch rather than failing), and that exceptions
+    /// flow to the dedicated exception parameter rather than an inline {Exception} placeholder
+    /// (S6668).
     /// </summary>
     [TestClass]
     public class LogMessageTemplateTests
@@ -35,49 +36,50 @@ namespace DotNetWorkQueue.Tests.Logging
         }
 
         [TestMethod]
-        public void RepeatedNewLinePlaceholders_PreserveMultiLineOutput()
+        public void HeartbeatRollback_ExceptionToParameter_MessageIdPlaceholder()
         {
             var logger = new CapturingLogger();
-            var nl = Environment.NewLine;
             const string id = "id-1";
-            const string err = "boom";
-            logger.LogWarning(
-                "Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {NewLine}{MessageId}{NewLine2}{Error}",
-                nl, id, nl, err);
+            var ex = new InvalidOperationException("boom");
+            logger.LogWarning(ex,
+                "Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {MessageId}",
+                id);
             Assert.AreEqual(
-                $"Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {nl}{id}{nl}{err}",
+                $"Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {id}",
                 logger.LastMessage);
+            Assert.AreSame(ex, logger.LastException);
         }
 
         [TestMethod]
-        public void ExceptionArgument_RendersToStringInline()
+        public void ExceptionArgument_PassedToExceptionParameter()
         {
             var logger = new CapturingLogger();
-            var nl = Environment.NewLine;
             var ex = new InvalidOperationException("kaboom");
-            logger.LogError("An error has occurred while trying to rollback a message{NewLine}{Exception}", nl, ex);
-            Assert.AreEqual($"An error has occurred while trying to rollback a message{nl}{ex}", logger.LastMessage);
+            logger.LogError(ex, "An error has occurred while trying to rollback a message");
+            Assert.AreEqual("An error has occurred while trying to rollback a message", logger.LastMessage);
+            Assert.AreSame(ex, logger.LastException);
         }
 
         [TestMethod]
-        public void RetryTemplate_RendersInterpolatedEquivalent()
+        public void RetryTemplate_ExceptionToParameter_RendersPlaceholders()
         {
             var logger = new CapturingLogger();
-            var nl = Environment.NewLine;
             const double retryMs = 250d;
             const int attempt = 3;
             var ex = new TimeoutException("db");
-            logger.LogWarning(
-                "An error has occurred; we will try to re-run the transaction in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times{NewLine}{Exception}",
-                retryMs, attempt, nl, ex);
+            logger.LogWarning(ex,
+                "An error has occurred; we will try to re-run the transaction in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times",
+                retryMs, attempt);
             Assert.AreEqual(
-                $"An error has occurred; we will try to re-run the transaction in {retryMs} ms. An error has occurred {attempt} times{nl}{ex}",
+                $"An error has occurred; we will try to re-run the transaction in {retryMs} ms. An error has occurred {attempt} times",
                 logger.LastMessage);
+            Assert.AreSame(ex, logger.LastException);
         }
 
         private sealed class CapturingLogger : ILogger
         {
             public string LastMessage { get; private set; }
+            public Exception LastException { get; private set; }
             public IDisposable BeginScope<TState>(TState state) where TState : notnull => null;
             public bool IsEnabled(LogLevel logLevel) => true;
 
@@ -85,6 +87,7 @@ namespace DotNetWorkQueue.Tests.Logging
                 Func<TState, Exception, string> formatter)
             {
                 LastMessage = formatter(state, exception);
+                LastException = exception;
             }
         }
     }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/RemoveMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/RemoveMessage.cs
@@ -110,7 +110,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             }
             catch (Exception e)
             {
-                _log.LogError("Failed to commit a transaction; this might be due to a DB timeout{NewLine}{Exception}", System.Environment.NewLine, e);
+                _log.LogError(e, "Failed to commit a transaction; this might be due to a DB timeout");
 
                 //don't attempt to use the transaction again at this point.
                 connection.Transaction = null;
@@ -130,7 +130,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
                 }
                 catch (Exception e)
                 {
-                    _log.LogWarning("Failed to delete status table record for message {MessageId}; record may be orphaned{NewLine}{Exception}", context.MessageId.Id.Value, System.Environment.NewLine, e);
+                    _log.LogWarning(e, "Failed to delete status table record for message {MessageId}; record may be orphaned", context.MessageId.Id.Value);
                 }
             }
             return count > 0 ? RemoveMessageStatus.Removed : RemoveMessageStatus.NotFound;

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/RetrySQLPolicyCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/RetrySQLPolicyCreation.cs
@@ -109,7 +109,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
                 UseJitter = true,
                 OnRetry = args =>
                 {
-                    log.LogWarning("An error has occurred; we will try to re-run the transaction in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times{NewLine}{Exception}", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1, System.Environment.NewLine, args.Outcome.Exception);
+                    log.LogWarning(args.Outcome.Exception, "An error has occurred; we will try to re-run the transaction in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1);
                     if (Activity.Current != null)
                     {
                         using (var scope = tracer.StartActivity("RetrySqlPolicy"))

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessagesError.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessagesError.cs
@@ -122,7 +122,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
                 new MoveRecordToErrorQueueCommand<string>(exception, context.MessageId.Id.Value.ToString(), context));
             //we are done doing any processing - remove the messageID to block other actions
             context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
-            _log.LogError("Message with ID {MessageId} has failed and has been moved to the error queue{NewLine}{Exception}", message.MessageId, System.Environment.NewLine, exception);
+            _log.LogError(exception, "Message with ID {MessageId} has failed and has been moved to the error queue", message.MessageId);
             return ReceiveMessagesErrorResult.Error;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/RetryTransactionPolicyCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/RetryTransactionPolicyCreation.cs
@@ -125,7 +125,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                 UseJitter = true,
                 OnRetry = args =>
                 {
-                    log.LogWarning("An error has occurred; we will try to re-run the statement in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times{NewLine}{Exception}", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1, System.Environment.NewLine, args.Outcome.Exception);
+                    log.LogWarning(args.Outcome.Exception, "An error has occurred; we will try to re-run the statement in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1);
                     if (Activity.Current != null)
                     {
                         using (var scope = tracer.StartActivity("RetrySqlPolicy"))

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/FindExpiredRecordsToDeleteQueryHandlerErrorDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/FindExpiredRecordsToDeleteQueryHandlerErrorDecorator.cs
@@ -50,7 +50,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
             {
                 if (e.Message.Contains("abort due to ROLLBACK", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    _logger.LogWarning("The query has been aborted{NewLine}{Exception}", System.Environment.NewLine, e);
+                    _logger.LogWarning(e, "The query has been aborted");
                     return Enumerable.Empty<long>();
                 }
                 else

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/FindRecordsToResetByHeartBeatDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/FindRecordsToResetByHeartBeatDecorator.cs
@@ -66,7 +66,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
             {
                 if (e.Message.Contains("abort due to ROLLBACK", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    _logger.LogWarning("The query has been aborted{NewLine}{Exception}", System.Environment.NewLine, e);
+                    _logger.LogWarning(e, "The query has been aborted");
                     return Enumerable.Empty<MessageToReset<long>>();
                 }
                 else

--- a/Source/DotNetWorkQueue.Transport.Shared/Basic/ReceiveErrorMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.Shared/Basic/ReceiveErrorMessage.cs
@@ -117,7 +117,7 @@ namespace DotNetWorkQueue.Transport.Shared.Basic
                 new MoveRecordToErrorQueueCommand<T>(exception, (T)context.MessageId.Id.Value, context));
             //we are done doing any processing - remove the messageID to block other actions
             context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
-            _log.LogError("Message with ID {MessageId} has failed and has been moved to the error queue{NewLine}{Exception}", message.MessageId, System.Environment.NewLine, exception);
+            _log.LogError(exception, "Message with ID {MessageId} has failed and has been moved to the error queue", message.MessageId);
             return ReceiveMessagesErrorResult.Error;
         }
         #endregion

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/Message/RollbackMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/Message/RollbackMessage.cs
@@ -126,7 +126,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.Message
             }
             catch (Exception e)
             {
-                _log.LogError("Failed to rollback a transaction; this might be due to a DB timeout{NewLine}{Exception}", System.Environment.NewLine, e);
+                _log.LogError(e, "Failed to rollback a transaction; this might be due to a DB timeout");
 
                 //don't attempt to use the transaction again at this point.
                 connection.Transaction = null;

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/RemoveMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/RemoveMessage.cs
@@ -111,7 +111,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             }
             catch (Exception e)
             {
-                _log.LogError("Failed to commit a transaction; this might be due to a DB timeout{NewLine}{Exception}", System.Environment.NewLine, e);
+                _log.LogError(e, "Failed to commit a transaction; this might be due to a DB timeout");
 
                 //don't attempt to use the transaction again at this point.
                 connection.Transaction = null;
@@ -131,7 +131,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
                 }
                 catch (Exception e)
                 {
-                    _log.LogWarning("Failed to delete status table record for message {MessageId}; record may be orphaned{NewLine}{Exception}", context.MessageId.Id.Value, System.Environment.NewLine, e);
+                    _log.LogWarning(e, "Failed to delete status table record for message {MessageId}; record may be orphaned", context.MessageId.Id.Value);
                 }
             }
             return count > 0 ? RemoveMessageStatus.Removed : RemoveMessageStatus.NotFound;

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/RetrySqlPolicyCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/RetrySqlPolicyCreation.cs
@@ -108,7 +108,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
                 UseJitter = true,
                 OnRetry = args =>
                 {
-                    log.LogWarning("An error has occurred; we will try to re-run the transaction in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times{NewLine}{Exception}", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1, System.Environment.NewLine, args.Outcome.Exception);
+                    log.LogWarning(args.Outcome.Exception, "An error has occurred; we will try to re-run the transaction in {RetryDelayMs} ms. An error has occurred {AttemptNumber} times", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1);
                     if (Activity.Current != null)
                     {
                         using (var scope = tracer.StartActivity("RetrySqlPolicy"))

--- a/Source/DotNetWorkQueue/JobScheduler/ScheduledJob.cs
+++ b/Source/DotNetWorkQueue/JobScheduler/ScheduledJob.cs
@@ -206,13 +206,13 @@ namespace DotNetWorkQueue.JobScheduler
                         }
                         else if (result.SendingException != null)
                         {
-                            _queue.Logger.LogError("An error has occurred adding job {Job} into the queue{NewLine}{Exception}", this, System.Environment.NewLine, result.SendingException);
+                            _queue.Logger.LogError(result.SendingException, "An error has occurred adding job {Job} into the queue", this);
                             RaiseException(result.SendingException);
                         }
                     }
                     catch (Exception ex)
                     {
-                        _queue.Logger.LogError("A fatal error has occurred trying to add job {Job} into the queue{NewLine}{Exception}", this, System.Environment.NewLine, ex);
+                        _queue.Logger.LogError(ex, "A fatal error has occurred trying to add job {Job} into the queue", this);
                         RaiseException(ex);
                     }
                 }

--- a/Source/DotNetWorkQueue/Logging/Decorator/IReceivePoisonMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IReceivePoisonMessageDecorator.cs
@@ -53,8 +53,8 @@ namespace DotNetWorkQueue.Logging.Decorator
             {
                 var messageId = context.MessageId.Id.Value.ToString();
                 _handler.Handle(context, exception);
-                _log.LogError(
-                    "Message with ID {MessageId} has failed after de-queue, but before finishing loading. This message is considered a poison message, and has been moved to the error queue{NewLine}{Exception}", messageId, System.Environment.NewLine, exception);
+                _log.LogError(exception,
+                    "Message with ID {MessageId} has failed after de-queue, but before finishing loading. This message is considered a poison message, and has been moved to the error queue", messageId);
             }
             else
             {

--- a/Source/DotNetWorkQueue/Logging/Decorator/IRollbackMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IRollbackMessageDecorator.cs
@@ -50,7 +50,7 @@ namespace DotNetWorkQueue.Logging.Decorator
             }
             catch (Exception e)
             {
-                _log.LogError("An error has occurred while trying to rollback a message{NewLine}{Exception}", System.Environment.NewLine, e);
+                _log.LogError(e, "An error has occurred while trying to rollback a message");
                 return false;
             }
         }

--- a/Source/DotNetWorkQueue/Messages/ReceivedMessage.cs
+++ b/Source/DotNetWorkQueue/Messages/ReceivedMessage.cs
@@ -109,7 +109,7 @@ namespace DotNetWorkQueue.Messages
                 }
                 catch (Exception e)
                 {
-                    _logger.LogWarning("Failed to load the previous error messages {NewLine}{Exception}", System.Environment.NewLine, e);
+                    _logger.LogWarning(e, "Failed to load the previous error messages");
                 }
                 return _previousErrors;
             }

--- a/Source/DotNetWorkQueue/Queue/BaseMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/BaseMonitor.cs
@@ -134,7 +134,7 @@ namespace DotNetWorkQueue.Queue
             }
             catch (Exception error)
             {
-                _log.LogError("An exception has occurred in the monitor delegate {NewLine}{Exception}", System.Environment.NewLine, error);
+                _log.LogError(error, "An exception has occurred in the monitor delegate");
             }
             finally
             {

--- a/Source/DotNetWorkQueue/Queue/HeartBeatScheduler.cs
+++ b/Source/DotNetWorkQueue/Queue/HeartBeatScheduler.cs
@@ -143,27 +143,27 @@ namespace DotNetWorkQueue.Queue
 
         private void OnMessageRollBack(RollBackNotification obj)
         {
-            _log.LogWarning("Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
+            _log.LogWarning(obj.Error, "Heart beat processing has triggered a rollback; rollbacks are not supported for heartbeats {MessageId}", obj.MessageId);
         }
 
         private void OnPoisonMessage(PoisonMessageNotification obj)
         {
-            _log.LogWarning("Heart beat processing has triggered a poison message {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
+            _log.LogWarning(obj.Error, "Heart beat processing has triggered a poison message {MessageId}", obj.MessageId);
         }
 
         private void OnMessageMovedToErrorQueue(ErrorNotification obj)
         {
-            _log.LogError("Heart beat processing has failed {NewLine}{MessageId}{NewLine2}{Error}", System.Environment.NewLine, obj.MessageId, System.Environment.NewLine, obj.Error);
+            _log.LogError(obj.Error, "Heart beat processing has failed {MessageId}", obj.MessageId);
         }
 
         private void OnReceiveMessageError(ErrorReceiveNotification obj)
         {
-            _log.LogWarning("Heart beat processing has failed to dequeue a message {NewLine}{Error}", System.Environment.NewLine, obj.Error);
+            _log.LogWarning(obj.Error, "Heart beat processing has failed to dequeue a message");
         }
 
         private void OnError(ErrorNotification obj)
         {
-            _log.LogError("Heart beat processing has failed {NewLine}{Error}", System.Environment.NewLine, obj.Error);
+            _log.LogError(obj.Error, "Heart beat processing has failed");
         }
     }
 }

--- a/Source/DotNetWorkQueue/Queue/HeartBeatWorker.cs
+++ b/Source/DotNetWorkQueue/Queue/HeartBeatWorker.cs
@@ -218,8 +218,8 @@ namespace DotNetWorkQueue.Queue
             }
             catch (Exception error)
             {
-                _logger.LogError(
-                    "An error has occurred while updating the heartbeat field for a record that is being processed{NewLine}{Exception}", System.Environment.NewLine, error);
+                _logger.LogError(error,
+                    "An error has occurred while updating the heartbeat field for a record that is being processed");
 
                 lock (_runningLocker)
                 {

--- a/Source/DotNetWorkQueue/Queue/MessageExceptionHandler.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageExceptionHandler.cs
@@ -70,7 +70,7 @@ namespace DotNetWorkQueue.Queue
             }
             catch (Exception errorHandlingError)
             {
-                _log.LogError(exception,
+                _log.LogError(errorHandlingError,
                     "An error has occurred while trying to move message {MessageId} to the error queue", message.MessageId);
                 throw new DotNetWorkQueueException("An error has occurred in the error handling code",
                     errorHandlingError);

--- a/Source/DotNetWorkQueue/Queue/MessageExceptionHandler.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageExceptionHandler.cs
@@ -70,8 +70,8 @@ namespace DotNetWorkQueue.Queue
             }
             catch (Exception errorHandlingError)
             {
-                _log.LogError(
-                    "An error has occurred while trying to move message {MessageId} to the error queue{NewLine}{Exception}", message.MessageId, System.Environment.NewLine, exception);
+                _log.LogError(exception,
+                    "An error has occurred while trying to move message {MessageId} to the error queue", message.MessageId);
                 throw new DotNetWorkQueueException("An error has occurred in the error handling code",
                     errorHandlingError);
             }

--- a/Source/DotNetWorkQueue/Queue/MessageProcessing.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageProcessing.cs
@@ -137,7 +137,7 @@ namespace DotNetWorkQueue.Queue
             catch (Exception ex) //not cool - one of the exception events threw an exception
             {
                 //there isn't a whole lot we can do here
-                _log.LogError("An error has occurred while trying to handle an exception{NewLine}{Exception}", System.Environment.NewLine, ex);
+                _log.LogError(ex, "An error has occurred while trying to handle an exception");
                 _consumerQueueErrorNotification.InvokeError(new ErrorReceiveNotification(ex));
             }
         }
@@ -167,8 +167,8 @@ namespace DotNetWorkQueue.Queue
                 catch (ReceiveMessageException e)
                 {
                     //an exception occurred trying to get the message from the transport
-                    _log.LogError(
-                        "An error has occurred while receiving a message from the transport{NewLine}{Exception}", System.Environment.NewLine, e);
+                    _log.LogError(e,
+                        "An error has occurred while receiving a message from the transport");
                     _consumerQueueErrorNotification.InvokeError(new ErrorReceiveNotification(e));
                     _seriousExceptionProcessBackOffHelper.Value.Wait();
                 }

--- a/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
@@ -141,7 +141,7 @@ namespace DotNetWorkQueue.Queue
             catch (Exception ex) //not cool - one of the exception events threw an exception
             {
                 //there is not a lot we can do here - log the exception
-                _log.LogError("An error has occurred while trying to handle an exception{NewLine}{Exception}", System.Environment.NewLine, ex);
+                _log.LogError(ex, "An error has occurred while trying to handle an exception");
                 _consumerQueueErrorNotification.InvokeError(new ErrorReceiveNotification(ex));
             }
             finally
@@ -174,7 +174,7 @@ namespace DotNetWorkQueue.Queue
                 catch (ReceiveMessageException e)
                 //an exception occurred trying to get the message from the transport
                 {
-                    _log.LogError("An error has occurred while receiving a message from the transport{NewLine}{Exception}", System.Environment.NewLine, e);
+                    _log.LogError(e, "An error has occurred while receiving a message from the transport");
                     _consumerQueueErrorNotification.InvokeError(new ErrorReceiveNotification(e));
                     _seriousExceptionProcessBackOffHelper.Value.Wait();
                 }

--- a/Source/DotNetWorkQueue/Queue/StopWorkers.cs
+++ b/Source/DotNetWorkQueue/Queue/StopWorkers.cs
@@ -116,7 +116,7 @@ namespace DotNetWorkQueue.Queue
                 }
                 catch (Exception e)
                 {
-                    _log.LogError("An error has occurred while disposing of a worker{NewLine}{Exception}", System.Environment.NewLine, e);
+                    _log.LogError(e, "An error has occurred while disposing of a worker");
                 }
             }
         }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/ReceiveErrorMessage.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/ReceiveErrorMessage.cs
@@ -67,7 +67,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
 
             //we are done doing any processing - remove the messageID to block other actions
             context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
-            _log.LogError("Message with ID {MessageId} has failed and has been moved to the error queue {NewLine}{Exception}", message.MessageId, System.Environment.NewLine, exception);
+            _log.LogError(exception, "Message with ID {MessageId} has failed and has been moved to the error queue", message.MessageId);
             return ReceiveMessagesErrorResult.Error;
         }
         #endregion


### PR DESCRIPTION
## S6668 — exceptions logged as template arguments instead of the exception parameter

31 logging calls passed the exception via a `{NewLine}{Exception}` / `{Error}` **message-template placeholder** rather than `ILogger`'s dedicated `exception` parameter. That's a real correctness issue: structured sinks (and anything reading `LogEntry.Exception`) never receive the exception object — its type and stack trace are flattened into the message string via `.ToString()`, and only if the sink renders that placeholder.

### Fix
Each call now passes the exception to the exception parameter and drops the manual `{NewLine}{Exception}` formatting (the framework/sink formats the exception). Real placeholders are preserved.

```csharp
// before
_log.LogError("Failed to commit a transaction{NewLine}{Exception}", Environment.NewLine, e);
// after
_log.LogError(e, "Failed to commit a transaction");

// before (with a real placeholder kept)
_log.LogWarning("...for message {MessageId}...{NewLine}{Exception}", id, Environment.NewLine, e);
// after
_log.LogWarning(e, "...for message {MessageId}...", id);
```

**31 findings** across SqlServer / PostgreSQL / SQLite / Redis / Memory / Shared transports and core (`HeartBeatScheduler` ×5, `MessageProcessing(Async)`, `ScheduledJob`, `BaseMonitor`, retry policies, etc.).

### Also in this PR (consistency, not flagged)
- `CreateNotifications` integration-test helper — 5 identical `LogTrace` calls fixed the same way.
- `LogMessageTemplateTests` — 3 tests asserted the *old* `{NewLine}{Exception}` templates (the code they guarded changed). Rewritten to assert the exception now flows to the exception parameter; `CapturingLogger` now captures it. The 2 placeholder-rendering tests are unchanged.

### Verification
- `DotNetWorkQueue.sln` builds clean (0 errors; the 10 warnings are pre-existing TripleDES-obsolete usages).
- **920** core unit tests pass, including the 5 `LogMessageTemplateTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error/warning logging consistency by passing exceptions through standard structured logging overloads.
  * Removed inline exception and explicit newline formatting from log templates for cleaner, more reliable diagnostics.
  * Preserved important placeholders such as message identifiers and retry details in emitted logs.

* **Tests**
  * Extended logging tests to verify that exception arguments are rendered via the dedicated exception parameter.
  * Added coverage for placeholder rendering with attached exceptions and updated helper behavior to capture the last exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->