### PR TITLE
fix: drop [Serializable] from exceptions (S3925) + repair broken Release build

### DIFF
--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbMessageQueueCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbMessageQueueCreation.cs
@@ -166,7 +166,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/ConnectionHolder.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/ConnectionHolder.cs
@@ -151,7 +151,6 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         private void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueCreation.cs
@@ -141,7 +141,6 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueMonitor.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueMonitor.cs
@@ -104,7 +104,6 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueWorkSub.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueWorkSub.cs
@@ -98,7 +98,6 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue.Transport.Redis/RedisConnection.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/RedisConnection.cs
@@ -63,7 +63,6 @@ namespace DotNetWorkQueue.Transport.Redis
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueCreation.cs
@@ -167,7 +167,6 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/ConnectionHolder.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/ConnectionHolder.cs
@@ -161,7 +161,6 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         private void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueCreation.cs
@@ -167,7 +167,6 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Admin/AdminApi.cs
+++ b/Source/DotNetWorkQueue/Admin/AdminApi.cs
@@ -95,7 +95,6 @@ namespace DotNetWorkQueue.Admin
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/BaseContainer.cs
+++ b/Source/DotNetWorkQueue/BaseContainer.cs
@@ -48,7 +48,6 @@ namespace DotNetWorkQueue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Exceptions/CommitException.cs
+++ b/Source/DotNetWorkQueue/Exceptions/CommitException.cs
@@ -28,7 +28,6 @@ namespace DotNetWorkQueue.Exceptions
     /// This means that the message was processed, but now the transport does not know this.
     /// The same exact message may be sent through for processing again at some point, depending on queue settings.
     /// </remarks>
-    [Serializable]
     public class CommitException : MessageException
     {
         /// <summary>

--- a/Source/DotNetWorkQueue/Exceptions/CompileException.cs
+++ b/Source/DotNetWorkQueue/Exceptions/CompileException.cs
@@ -25,7 +25,6 @@ namespace DotNetWorkQueue.Exceptions
     /// An error has occurred while compiling code
     /// </summary>
     /// <seealso cref="DotNetWorkQueue.Exceptions.DotNetWorkQueueException" />
-    [Serializable]
     public class CompileException : DotNetWorkQueueException
     {
         /// <summary>

--- a/Source/DotNetWorkQueue/Exceptions/DotNetWorkQueueException.cs
+++ b/Source/DotNetWorkQueue/Exceptions/DotNetWorkQueueException.cs
@@ -24,7 +24,6 @@ namespace DotNetWorkQueue.Exceptions
     /// Generic queue exception
     /// </summary>
     /// <remarks>When the queue encounters a non specific error, this exception is thrown.</remarks>
-    [Serializable]
     public class DotNetWorkQueueException : Exception
     {
         /// <summary>

--- a/Source/DotNetWorkQueue/Exceptions/InterceptorException.cs
+++ b/Source/DotNetWorkQueue/Exceptions/InterceptorException.cs
@@ -23,7 +23,6 @@ namespace DotNetWorkQueue.Exceptions
     /// <summary>
     /// An interceptor has thrown an exception.
     /// </summary>
-    [Serializable]
     public class InterceptorException : DotNetWorkQueueException
     {
         /// <summary>

--- a/Source/DotNetWorkQueue/Exceptions/JobSchedulerException.cs
+++ b/Source/DotNetWorkQueue/Exceptions/JobSchedulerException.cs
@@ -24,7 +24,6 @@ namespace DotNetWorkQueue.Exceptions
     /// An exception thrown from <see cref="IJobScheduler"/>
     /// </summary>
     /// <seealso cref="DotNetWorkQueue.Exceptions.DotNetWorkQueueException" />
-    [Serializable]
     public class JobSchedulerException : DotNetWorkQueueException
     {
         /// <summary>

--- a/Source/DotNetWorkQueue/Exceptions/MessageException.cs
+++ b/Source/DotNetWorkQueue/Exceptions/MessageException.cs
@@ -25,7 +25,6 @@ namespace DotNetWorkQueue.Exceptions
     /// An error has occurred while processing a message in user code
     /// </summary>
     /// <remarks>This exception is generated when user message handling code throws an unhanded exception</remarks>
-    [Serializable]
     public class MessageException : DotNetWorkQueueException
     {
         /// <summary>

--- a/Source/DotNetWorkQueue/Exceptions/PoisonMessageException.cs
+++ b/Source/DotNetWorkQueue/Exceptions/PoisonMessageException.cs
@@ -28,7 +28,6 @@ namespace DotNetWorkQueue.Exceptions
     /// When possible, all 'standard' data is included with the exception. Transport specific data is generally not included.
     /// For instance, user defined columns from the SQL server transport are not included.
     /// </remarks>
-    [Serializable]
     public class PoisonMessageException : MessageException
     {
         /// <summary>

--- a/Source/DotNetWorkQueue/Exceptions/ReceiveMessageException.cs
+++ b/Source/DotNetWorkQueue/Exceptions/ReceiveMessageException.cs
@@ -28,7 +28,6 @@ namespace DotNetWorkQueue.Exceptions
     /// The transport may not be responding. However, it's also possible that a message was
     /// de-queued, but failed to de-serialize
     /// </remarks>
-    [Serializable]
     public class ReceiveMessageException : DotNetWorkQueueException
     {
         /// <summary>

--- a/Source/DotNetWorkQueue/Exceptions/SerializationException.cs
+++ b/Source/DotNetWorkQueue/Exceptions/SerializationException.cs
@@ -23,7 +23,6 @@ namespace DotNetWorkQueue.Exceptions
     /// <summary>
     /// An error has occurred when trying to serialize or de-serialize a message
     /// </summary>
-    [Serializable]
     public class SerializationException : DotNetWorkQueueException
     {
         /// <summary>

--- a/Source/DotNetWorkQueue/IoC/ContainerWrapper.cs
+++ b/Source/DotNetWorkQueue/IoC/ContainerWrapper.cs
@@ -76,7 +76,6 @@ namespace DotNetWorkQueue.IoC
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Messages/MessageContext.cs
+++ b/Source/DotNetWorkQueue/Messages/MessageContext.cs
@@ -142,7 +142,6 @@ namespace DotNetWorkQueue.Messages
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         private void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Messages/MessageMethodHandling.cs
+++ b/Source/DotNetWorkQueue/Messages/MessageMethodHandling.cs
@@ -120,7 +120,6 @@ namespace DotNetWorkQueue.Messages
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/BaseMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/BaseMonitor.cs
@@ -252,7 +252,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/BaseQueue.cs
+++ b/Source/DotNetWorkQueue/Queue/BaseQueue.cs
@@ -156,7 +156,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/HeartBeatWorker.cs
+++ b/Source/DotNetWorkQueue/Queue/HeartBeatWorker.cs
@@ -127,7 +127,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/ProducerQueue.cs
+++ b/Source/DotNetWorkQueue/Queue/ProducerQueue.cs
@@ -200,7 +200,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/QueueCancelWork.cs
+++ b/Source/DotNetWorkQueue/Queue/QueueCancelWork.cs
@@ -114,7 +114,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/QueueMaintenanceService.cs
+++ b/Source/DotNetWorkQueue/Queue/QueueMaintenanceService.cs
@@ -85,7 +85,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         private void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/QueueMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/QueueMonitor.cs
@@ -144,7 +144,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/WaitForEventOrCancel.cs
+++ b/Source/DotNetWorkQueue/Queue/WaitForEventOrCancel.cs
@@ -85,7 +85,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/WorkerBase.cs
+++ b/Source/DotNetWorkQueue/Queue/WorkerBase.cs
@@ -91,7 +91,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Queue/WorkerWaitForEventOrCancel.cs
+++ b/Source/DotNetWorkQueue/Queue/WorkerWaitForEventOrCancel.cs
@@ -91,7 +91,6 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         private void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/TaskScheduling/Scheduler.cs
+++ b/Source/DotNetWorkQueue/TaskScheduling/Scheduler.cs
@@ -141,7 +141,6 @@ namespace DotNetWorkQueue.TaskScheduling
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/TaskScheduling/TaskScheduler.cs
+++ b/Source/DotNetWorkQueue/TaskScheduling/TaskScheduler.cs
@@ -415,7 +415,6 @@ namespace DotNetWorkQueue.TaskScheduling
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/TaskScheduling/WaitForEventOrCancelThreadPool.cs
+++ b/Source/DotNetWorkQueue/TaskScheduling/WaitForEventOrCancelThreadPool.cs
@@ -115,7 +115,6 @@ namespace DotNetWorkQueue.TaskScheduling
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         private void ThrowIfDisposed()
         {

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/MessageQueueCreation.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/MessageQueueCreation.cs
@@ -120,7 +120,6 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         /// <summary>
         /// Throws an exception if this instance has been disposed.
         /// </summary>
-        /// <param name="name">The name.</param>
         /// <exception cref="System.ObjectDisposedException"></exception>
         protected void ThrowIfDisposed()
         {


### PR DESCRIPTION
## Two fixes — one Sonar smell, one broken Release build I found along the way

### 1. S3925 — remove `[Serializable]` from 9 exception types
The 9 exception classes carried `[Serializable]` (inheriting `Exception`'s `ISerializable`) but no deserialization constructor, which S3925 flags.

The rule's literal suggestion — *add* `protected (SerializationInfo, StreamingContext)` — is **wrong for this project**: the only TFMs are net8/net10, where `BinaryFormatter` is removed/obsolete and the base `Exception(SerializationInfo, StreamingContext)` ctor is obsolete (SYSLIB0051). Adding it would pull obsolete-API usage into the Release build (`TreatWarningsAsErrors`) and fail it.

None of the 9 implement custom serialization (`GetObjectData`/`SerializationInfo`), so `[Serializable]` was dead metadata. Per Microsoft's SYSLIB0051 guidance, the correct net8+ fix is to **remove `[Serializable]`** — clears the rule, removes dead metadata, introduces no obsolete warnings. Non-breaking (BinaryFormatter can't consume these anyway).

### 2. Repair the broken Release build (pre-existing — was blocking publish)
While verifying #1 in Release I found the Release build was **already broken on master**: **76 CS1572 errors**. 28 disposable classes carried a stale `/// <param name="name">The name.</param>` doc on methods (`ThrowIfDisposed()` etc.) that became **parameterless** during the `ObjectDisposedException.ThrowIf` migration. Debug doesn't generate XML docs so it was invisible; Release (`GenerateDocumentationFile` + `TreatWarningsAsErrors`) failed — which would fail `publish.yml`'s verify-gate.

Removed the 28 orphaned `<param name="name">` lines (core + all 5 transports). Every one was compiler-confirmed stale (CS1572).

### Verification
- **Full `DotNetWorkQueueNoTests.sln` Release build (`-p:CI=true`): 0 warnings / 0 errors** — publish path is green again.
- 920 core unit tests pass.

_Net: 37 files, all deletions (9 attributes + 28 stale doc lines)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected disposal-related API documentation across queue, transport, scheduling, and administration components.
  * Removed inaccurate parameter references and clarified when disposed-object exceptions may occur.

* **Bug Fixes**
  * Improved disposal checks for monitoring components to reliably detect disposed instances.
  * Updated exception metadata by removing legacy serialization support from several custom exception types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->