### PR TITLE
Harden SNTP time client + tests; RedisNames init guard (#199, #185)

### DIFF
--- a/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Basic/Time/SntpUnixTimeTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Basic/Time/SntpUnixTimeTests.cs
@@ -6,22 +6,41 @@ using NSubstitute;
 
 namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
 {
+    /// <summary>
+    /// Exercises the SNTP time client against a live NTP server (default pool.ntp.org).
+    /// </summary>
+    /// <remarks>
+    /// These tests reach the public NTP pool over UDP, so they depend on outbound network access.
+    /// A single <see cref="SntpUnixTime"/> instance is shared across every test via <see cref="ClassInit"/>
+    /// so the offset is fetched once (the client caches it) instead of issuing a burst of queries that a
+    /// public pool may rate-limit or drop. Tagged <c>ExternalNetwork</c> so a host with unreliable outbound
+    /// NTP can exclude them via <c>--filter "TestCategory!=ExternalNetwork"</c>.
+    /// </remarks>
     [TestClass]
+    [TestCategory("ExternalNetwork")]
     public class SntpUnixTimeTests
     {
+        private static SntpUnixTime _test;
+
+        [ClassInitialize]
+        public static void ClassInit(TestContext context)
+        {
+            var log = Substitute.For<ILogger>();
+            var configuration = new SntpTimeConfiguration();
+            _test = new SntpUnixTime(log, configuration);
+        }
+
         [TestMethod]
         public void GetCurrentUnixTimestampMilliseconds_Returns_Value()
         {
-            var test = Create();
-            var result = test.GetCurrentUnixTimestampMilliseconds();
+            var result = _test.GetCurrentUnixTimestampMilliseconds();
             Assert.IsGreaterThan(0, result);
         }
 
         [TestMethod]
         public void GetCurrentUnixTimestampMilliseconds_Is_Recent()
         {
-            var test = Create();
-            var result = test.GetCurrentUnixTimestampMilliseconds();
+            var result = _test.GetCurrentUnixTimestampMilliseconds();
 
             var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             var localUnixMs = (long)(DateTime.UtcNow - epoch).TotalMilliseconds;
@@ -34,9 +53,8 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
         [TestMethod]
         public void GetCurrentUnixTimestampMilliseconds_Cached_On_Second_Call()
         {
-            var test = Create();
-            var first = test.GetCurrentUnixTimestampMilliseconds();
-            var second = test.GetCurrentUnixTimestampMilliseconds();
+            var first = _test.GetCurrentUnixTimestampMilliseconds();
+            var second = _test.GetCurrentUnixTimestampMilliseconds();
 
             // Second call should use cached offset, so results should be very close
             Assert.IsLessThan(1000, Math.Abs(second - first),
@@ -46,10 +64,9 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
         [TestMethod]
         public void GetAddDifferenceMilliseconds_Adds_Offset()
         {
-            var test = Create();
-            var current = test.GetCurrentUnixTimestampMilliseconds();
+            var current = _test.GetCurrentUnixTimestampMilliseconds();
             var difference = TimeSpan.FromMinutes(5);
-            var result = test.GetAddDifferenceMilliseconds(difference);
+            var result = _test.GetAddDifferenceMilliseconds(difference);
 
             var expectedDifferenceMs = (long)difference.TotalMilliseconds;
             // Allow small tolerance for elapsed time between calls
@@ -60,10 +77,9 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
         [TestMethod]
         public void GetSubtractDifferenceMilliseconds_Subtracts_Offset()
         {
-            var test = Create();
-            var current = test.GetCurrentUnixTimestampMilliseconds();
+            var current = _test.GetCurrentUnixTimestampMilliseconds();
             var difference = TimeSpan.FromMinutes(5);
-            var result = test.GetSubtractDifferenceMilliseconds(difference);
+            var result = _test.GetSubtractDifferenceMilliseconds(difference);
 
             var expectedDifferenceMs = (long)difference.TotalMilliseconds;
             // Allow small tolerance for elapsed time between calls
@@ -74,20 +90,12 @@ namespace DotNetWorkQueue.Transport.Redis.Integration.Tests.Basic.Time
         [TestMethod]
         public void GetCurrentUtcDate_Returns_Recent_Date()
         {
-            var test = Create();
-            var result = test.GetCurrentUtcDate();
+            var result = _test.GetCurrentUtcDate();
 
             // Should be within 5 seconds of local UTC time
             var diff = Math.Abs((result - DateTime.UtcNow).TotalSeconds);
             Assert.IsLessThan(5, diff,
                 $"NTP date differs from local UTC by {diff} seconds");
-        }
-
-        private static SntpUnixTime Create()
-        {
-            var log = Substitute.For<ILogger>();
-            var configuration = new SntpTimeConfiguration();
-            return new SntpUnixTime(log, configuration);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisNames.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisNames.cs
@@ -28,6 +28,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
     {
         private readonly IConnectionInformation _connectionInformation;
         private readonly Dictionary<string, string> _names;
+        private volatile bool _namesLoaded;
         private const string QueuePrefix = "{YADNQ_";
         #region Constructor
         /// <summary>
@@ -335,10 +336,10 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
 
         private void BuildListIfNeeded()
         {
-            if (_names.Count == 17) return; //don't return unless all names are loaded
+            if (_namesLoaded) return; //flag is only set after every name has been added, so it can't drift from the entry count
             lock (_names)
             {
-                if (_names.Count != 0) return;
+                if (_namesLoaded) return;
                 _names.Add("Notification", string.Concat(QueuePrefix, _connectionInformation.QueueName, "_}Notifications"));
                 _names.Add("Pending", string.Concat(QueuePrefix, _connectionInformation.QueueName, "_}Pending"));
                 _names.Add("Working", string.Concat(QueuePrefix, _connectionInformation.QueueName, "_}Working"));
@@ -356,6 +357,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
                 _names.Add("Route", string.Concat(QueuePrefix, _connectionInformation.QueueName, "_}Routes"));
                 _names.Add("Configuration", string.Concat(QueuePrefix, _connectionInformation.QueueName, "_}Configuration"));
                 _names.Add("JobEvent", string.Concat(QueuePrefix, "}JobEvent"));  //NOTE - not part of a queue
+                _namesLoaded = true;
             }
         }
     }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Time/SntpUnixTime.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Time/SntpUnixTime.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading;
 using DotNetWorkQueue.Logging;
 using GuerrillaNtp;
 using Microsoft.Extensions.Logging;
@@ -80,15 +81,29 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Time
         {
             if (!TimeExpired()) return (long)(DateTime.UtcNow - UnixEpoch).TotalMilliseconds + _millisecondsDifference;
 
-            lock (_getTime)
+            //Serialize refreshes so only one thread queries the NTP server at a time - a burst of
+            //concurrent queries is exactly what public pools rate-limit. But other threads must not
+            //block behind the (retry-wrapped, so potentially multi-second on an outage) query: on a
+            //warm cache they serve the last-known offset instead. Only the very first (cold) call,
+            //which has no cached value yet, waits for the query to complete.
+            var lockTaken = false;
+            try
             {
-                if (!TimeExpired())
-                    return (long)(DateTime.UtcNow - UnixEpoch).TotalMilliseconds + _millisecondsDifference;
+                if (ServerOffsetObtained == default)
+                    Monitor.Enter(_getTime, ref lockTaken);
+                else
+                    Monitor.TryEnter(_getTime, ref lockTaken);
 
-                var clock = _queryPipeline.Execute(() => _ntpClient.Query());
-                _millisecondsDifference = (long)clock.CorrectionOffset.TotalMilliseconds;
-
-                ServerOffsetObtained = DateTime.UtcNow;
+                if (lockTaken && TimeExpired())
+                {
+                    var clock = _queryPipeline.Execute(() => _ntpClient.Query());
+                    _millisecondsDifference = (long)clock.CorrectionOffset.TotalMilliseconds;
+                    ServerOffsetObtained = DateTime.UtcNow;
+                }
+            }
+            finally
+            {
+                if (lockTaken) Monitor.Exit(_getTime);
             }
             return (long)(DateTime.UtcNow - UnixEpoch).TotalMilliseconds + _millisecondsDifference;
         }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Time/SntpUnixTime.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Time/SntpUnixTime.cs
@@ -20,6 +20,8 @@ using System;
 using DotNetWorkQueue.Logging;
 using GuerrillaNtp;
 using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Retry;
 
 namespace DotNetWorkQueue.Transport.Redis.Basic.Time
 {
@@ -31,6 +33,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Time
         private readonly object _getTime = new object();
         private long _millisecondsDifference;
         private readonly NtpClient _ntpClient;
+        private readonly ResiliencePipeline _queryPipeline;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SntpUnixTime" /> class.
@@ -41,6 +44,24 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Time
             : base(log, configuration)
         {
             _ntpClient = new NtpClient(configuration.Server, configuration.TimeOut, configuration.Port);
+
+            //a single UDP query to a public NTP pool can be silently dropped or rate-limited, surfacing
+            //as a socket timeout. Retry a few times with jittered backoff so a transient loss doesn't fail.
+            _queryPipeline = new ResiliencePipelineBuilder()
+                .AddRetry(new RetryStrategyOptions
+                {
+                    ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+                    MaxRetryAttempts = 3,
+                    Delay = TimeSpan.FromMilliseconds(250),
+                    BackoffType = DelayBackoffType.Exponential,
+                    UseJitter = true,
+                    OnRetry = args =>
+                    {
+                        Log.LogWarning(args.Outcome.Exception, "NTP query failed; retrying in {RetryDelayMs} ms (attempt {AttemptNumber})", args.RetryDelay.TotalMilliseconds, args.AttemptNumber + 1);
+                        return default;
+                    }
+                })
+                .Build();
         }
 
         /// <summary>
@@ -64,7 +85,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Time
                 if (!TimeExpired())
                     return (long)(DateTime.UtcNow - UnixEpoch).TotalMilliseconds + _millisecondsDifference;
 
-                var clock = _ntpClient.Query();
+                var clock = _queryPipeline.Execute(() => _ntpClient.Query());
                 _millisecondsDifference = (long)clock.CorrectionOffset.TotalMilliseconds;
 
                 ServerOffsetObtained = DateTime.UtcNow;


### PR DESCRIPTION
Closes #199. Closes #185.

Two small, cohesive Redis-transport hardening fixes bundled into one PR (one serialized Jenkins build instead of two).

## #199 — SNTP integration-test NTP flakiness

Intermittent Jenkins failures: `SntpUnixTimeTests.*` → `SocketException: Connection timed out` from `GuerrillaNtp.NtpClient.Query()`. Root cause is NTP-specific, not a general transport/helper issue — the transport defaults to `TimeLocations.RedisServer` (Redis `TIME` command) and never touches NTP, so only these 6 SNTP tests reach `pool.ntp.org`. Each test built a fresh `SntpUnixTime` (empty cache) → a **burst of 6 live UDP queries** from one IP, which public pools rate-limit/drop; there was no retry anywhere.

Fixes (issue's priority order):
1. **Share one `SntpUnixTime`** across the 6 tests via `[ClassInitialize]` — offset fetched **once**, the client's `TimeExpired()` cache serves the rest. Local run: 6 tests in **407 ms** (was ~6 separate queries).
2. **Jittered Polly retry** (3 attempts, exponential + jitter) around `_ntpClient.Query()` in production `GetUnixTime()`, matching the existing SQLite/SQL retry idiom. Hardens real NTP usage too. On total failure the last exception still propagates — a genuinely unreachable NTP source *should* surface, which is what (3) is for.
3. **`[TestCategory("ExternalNetwork")]`** on the tests so a flaky host can exclude them via `--filter "TestCategory!=ExternalNetwork"` (mirrors the existing `StarvationBaseline` exclusion) without dropping coverage elsewhere.

## #185 — RedisNames fragile count guard

`BuildListIfNeeded()` gated on a hardcoded `_names.Count == 17`, which had to be hand-synced with the number of `_names.Add(...)` calls. Replaced with a `volatile bool _namesLoaded` flag set **after** all names are added, so the guard can't drift when key names are added/removed (also avoids reading `Dictionary.Count` outside the lock).

## Verification
- `Release -p:CI=true` build of the Redis transport: 0 warnings / 0 errors (XML-doc + warnings-as-errors clean).
- Redis unit tests: 187/187 pass (incl. `RedisNamesTests`, which covers the full name set).
- SNTP integration tests: 6/6 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of network time retrieval by retrying transient NTP failures with exponential backoff and jitter.
  - Added warning logs during retry attempts to make time-sync issues easier to diagnose.
  - Enhanced concurrent initialization for Redis name mappings to avoid redundant rebuilds and reduce contention.

- **Tests**
  - Updated external-network integration tests to reuse a shared cached time source and labeled the tests as requiring outbound UDP access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->