### PR TITLE
fix: simplify filter/reduce loops with LINQ (S3267, 5 issues)

### DIFF
--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/BatchSendValidation.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/BatchSendValidation.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DotNetWorkQueue.Messages;
 
 namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
@@ -36,14 +37,11 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
             IReadOnlyList<QueueMessage<IMessage, IAdditionalMessageData>> messages,
             IJobSchedulerMetaData jobSchedulerMetaData)
         {
-            foreach (var m in messages)
+            if (messages.Any(m => !string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData))))
             {
-                if (!string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData)))
-                {
-                    throw new NotSupportedException(
-                        "Batch send does not support scheduled jobs; send scheduled jobs individually " +
-                        "via Send(message).");
-                }
+                throw new NotSupportedException(
+                    "Batch send does not support scheduled jobs; send scheduled jobs individually " +
+                    "via Send(message).");
             }
         }
     }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueMonitor.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueMonitor.cs
@@ -80,14 +80,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             get
             {
-                DateTime? latest = null;
-                foreach (var monitor in _monitors)
-                {
-                    var ts = monitor.LastRunUtc;
-                    if (ts.HasValue && (!latest.HasValue || ts.Value > latest.Value))
-                        latest = ts;
-                }
-                return latest;
+                return _monitors.Max(monitor => monitor.LastRunUtc);
             }
         }
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/BatchSendValidation.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/BatchSendValidation.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DotNetWorkQueue.Messages;
 
 namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
@@ -36,14 +37,11 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
             IReadOnlyList<QueueMessage<IMessage, IAdditionalMessageData>> messages,
             IJobSchedulerMetaData jobSchedulerMetaData)
         {
-            foreach (var m in messages)
+            if (messages.Any(m => !string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData))))
             {
-                if (!string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData)))
-                {
-                    throw new NotSupportedException(
-                        "Batch send does not support scheduled jobs; send scheduled jobs individually " +
-                        "via Send(message).");
-                }
+                throw new NotSupportedException(
+                    "Batch send does not support scheduled jobs; send scheduled jobs individually " +
+                    "via Send(message).");
             }
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/BatchSendValidation.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/BatchSendValidation.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DotNetWorkQueue.Messages;
 
 namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
@@ -36,14 +37,11 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
             IReadOnlyList<QueueMessage<IMessage, IAdditionalMessageData>> messages,
             IJobSchedulerMetaData jobSchedulerMetaData)
         {
-            foreach (var m in messages)
+            if (messages.Any(m => !string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData))))
             {
-                if (!string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData)))
-                {
-                    throw new NotSupportedException(
-                        "Batch send does not support scheduled jobs; send scheduled jobs individually " +
-                        "via Send(message).");
-                }
+                throw new NotSupportedException(
+                    "Batch send does not support scheduled jobs; send scheduled jobs individually " +
+                    "via Send(message).");
             }
         }
     }

--- a/Source/DotNetWorkQueue/Queue/QueueMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/QueueMonitor.cs
@@ -120,14 +120,7 @@ namespace DotNetWorkQueue.Queue
         {
             get
             {
-                DateTime? latest = null;
-                foreach (var monitor in _monitors)
-                {
-                    var ts = monitor.LastRunUtc;
-                    if (ts.HasValue && (!latest.HasValue || ts.Value > latest.Value))
-                        latest = ts;
-                }
-                return latest;
+                return _monitors.Max(monitor => monitor.LastRunUtc);
             }
         }
 


### PR DESCRIPTION
Converts the **unambiguous** S3267 (loops→LINQ) cases; all behavior-preserving, no API change.

## Fixed (5)
| File(s) | Change |
|---|---|
| `BatchSendValidation.GuardNoScheduledJobs` (SqlServer / PostgreSQL / SQLite) | `foreach` + `if`-throw → `messages.Any(...)` guard — short-circuits on the first match exactly as before |
| `QueueMonitor` / `RedisQueueMonitor` `LastRunUtc` | manual max-of-nullable `foreach` → `_monitors.Max(m => m.LastRunUtc)` — nullable `Max` ignores nulls and returns `null` for an empty sequence, matching the old loop |

## Deliberately NOT fixed (7 — accepted in SonarCloud, not code-changed)
- **6× `SendMessageCommandBatchHandler(+Async)` serialize loops** (all 3 relational transports): each iteration mutates the message via `SetHeader(...)`. Rewriting a side-effecting loop as `Select`/`Where` is an anti-pattern, so these are left as explicit loops.
- **1× Redis `RemoveQueueInternal` dedup-delete loop**: the LINQ rewrite (side-effecting `Where` predicate) is clever, not clearer, and it's queue-teardown code — left as an explicit loop.

## Verification
- `NoTests.sln` **Release `-p:CI=true`**: 0 warnings / 0 errors
- Unit tests: core **920**, Redis **187**, SqlServer **170**, PostgreSQL **161**, SQLite **146** — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified queue monitoring calculations for the latest run timestamp.
  * Streamlined batch validation when detecting scheduled jobs across supported transports.

* **Bug Fixes**
  * Preserved existing validation behavior while ensuring unsupported scheduled-job batches continue to be rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->