### PR TITLE
fix: nullable value-type members on consumer request models (S6964)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/ConsumersEndpointTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/Tests/ConsumersEndpointTests.cs
@@ -146,6 +146,45 @@ namespace DotNetWorkQueue.Dashboard.Api.Integration.Tests.Tests
             Assert.AreEqual(0, c.PoisonMessages);
         }
 
+        [TestMethod]
+        public async Task Heartbeat_With_Omitted_Metrics_Stores_Zero()
+        {
+            var registration = await RegisterAndDeserialize("M1", 1000);
+
+            // Post a heartbeat body that OMITS the metric counters entirely (absent, not
+            // zero-valued). The nullable model + controller coalescing must treat them as zero.
+            var response = await _server.Client.PostAsJsonAsync(
+                "api/v1/dashboard/consumers/heartbeat",
+                new { ConsumerId = registration.ConsumerId });
+
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+
+            var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
+                "api/v1/dashboard/consumers");
+            var c = consumers![0];
+            Assert.AreEqual(0, c.MessagesProcessed);
+            Assert.AreEqual(0, c.MessagesErrored);
+            Assert.AreEqual(0, c.MessagesRolledBack);
+            Assert.AreEqual(0, c.PoisonMessages);
+        }
+
+        [TestMethod]
+        public async Task Register_With_Omitted_ProcessId_Defaults_To_Zero()
+        {
+            // Omit ProcessId entirely; nullable model + coalescing stores 0.
+            var response = await _server.Client.PostAsJsonAsync(
+                "api/v1/dashboard/consumers/register",
+                new { QueueName = "testQueue", MachineName = "MNOPID" });
+
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+
+            var consumers = await _server.Client.GetFromJsonAsync<List<ConsumerInfoResponse>>(
+                "api/v1/dashboard/consumers");
+            var c = consumers![0];
+            Assert.AreEqual("MNOPID", c.MachineName);
+            Assert.AreEqual(0, c.ProcessId);
+        }
+
         // === Unregister ===
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Api/Controllers/ConsumersController.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Controllers/ConsumersController.cs
@@ -60,7 +60,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Controllers
             var consumerId = _registry.Register(
                 request.QueueName,
                 request.MachineName,
-                request.ProcessId,
+                request.ProcessId ?? 0,
                 request.FriendlyName);
 
             var response = new ConsumerRegistrationResponse
@@ -83,7 +83,7 @@ namespace DotNetWorkQueue.Dashboard.Api.Controllers
             if (!_options.EnableConsumerTracking)
                 return NotFound();
 
-            if (_registry.Heartbeat(request.ConsumerId, request.MessagesProcessed, request.MessagesErrored, request.MessagesRolledBack, request.PoisonMessages))
+            if (_registry.Heartbeat(request.ConsumerId ?? Guid.Empty, request.MessagesProcessed ?? 0, request.MessagesErrored ?? 0, request.MessagesRolledBack ?? 0, request.PoisonMessages ?? 0))
                 return NoContent();
 
             return NotFound();

--- a/Source/DotNetWorkQueue.Dashboard.Api/Models/ConsumerHeartbeatRequest.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Models/ConsumerHeartbeatRequest.cs
@@ -17,29 +17,32 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
-using System.ComponentModel.DataAnnotations;
 
 namespace DotNetWorkQueue.Dashboard.Api.Models
 {
     /// <summary>
     /// Request model for sending a consumer heartbeat.
     /// </summary>
+    /// <remarks>
+    /// Value-type members are nullable so the model binder can distinguish an omitted field
+    /// from a posted default; the controller coalesces each to its prior default, preserving
+    /// the released wire behavior (a missing counter counts as zero).
+    /// </remarks>
     public class ConsumerHeartbeatRequest
     {
         /// <summary>Gets or sets the consumer identifier returned from registration.</summary>
-        [Required]
-        public Guid ConsumerId { get; set; }
+        public Guid? ConsumerId { get; set; }
 
         /// <summary>Gets or sets the running total of successfully processed messages since consumer start.</summary>
-        public long MessagesProcessed { get; set; }
+        public long? MessagesProcessed { get; set; }
 
         /// <summary>Gets or sets the running total of messages that threw exceptions since consumer start.</summary>
-        public long MessagesErrored { get; set; }
+        public long? MessagesErrored { get; set; }
 
         /// <summary>Gets or sets the running total of messages rolled back since consumer start.</summary>
-        public long MessagesRolledBack { get; set; }
+        public long? MessagesRolledBack { get; set; }
 
         /// <summary>Gets or sets the running total of poison messages since consumer start.</summary>
-        public long PoisonMessages { get; set; }
+        public long? PoisonMessages { get; set; }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Api/Models/ConsumerRegistrationRequest.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/Models/ConsumerRegistrationRequest.cs
@@ -33,8 +33,8 @@ namespace DotNetWorkQueue.Dashboard.Api.Models
         [Required]
         public string MachineName { get; set; }
 
-        /// <summary>Gets or sets the process ID of the consumer.</summary>
-        public int ProcessId { get; set; }
+        /// <summary>Gets or sets the process ID of the consumer. Omitted (or null) is treated as 0.</summary>
+        public int? ProcessId { get; set; }
 
         /// <summary>Gets or sets an optional friendly name for this consumer instance.</summary>
         public string FriendlyName { get; set; }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/BatchSendValidation.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/BatchSendValidation.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DotNetWorkQueue.Messages;
 
 namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
@@ -36,14 +37,11 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
             IReadOnlyList<QueueMessage<IMessage, IAdditionalMessageData>> messages,
             IJobSchedulerMetaData jobSchedulerMetaData)
         {
-            foreach (var m in messages)
+            if (messages.Any(m => !string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData))))
             {
-                if (!string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData)))
-                {
-                    throw new NotSupportedException(
-                        "Batch send does not support scheduled jobs; send scheduled jobs individually " +
-                        "via Send(message).");
-                }
+                throw new NotSupportedException(
+                    "Batch send does not support scheduled jobs; send scheduled jobs individually " +
+                    "via Send(message).");
             }
         }
     }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueMonitor.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueMonitor.cs
@@ -80,14 +80,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             get
             {
-                DateTime? latest = null;
-                foreach (var monitor in _monitors)
-                {
-                    var ts = monitor.LastRunUtc;
-                    if (ts.HasValue && (!latest.HasValue || ts.Value > latest.Value))
-                        latest = ts;
-                }
-                return latest;
+                return _monitors.Max(monitor => monitor.LastRunUtc);
             }
         }
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/BatchSendValidation.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/BatchSendValidation.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DotNetWorkQueue.Messages;
 
 namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
@@ -36,14 +37,11 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
             IReadOnlyList<QueueMessage<IMessage, IAdditionalMessageData>> messages,
             IJobSchedulerMetaData jobSchedulerMetaData)
         {
-            foreach (var m in messages)
+            if (messages.Any(m => !string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData))))
             {
-                if (!string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData)))
-                {
-                    throw new NotSupportedException(
-                        "Batch send does not support scheduled jobs; send scheduled jobs individually " +
-                        "via Send(message).");
-                }
+                throw new NotSupportedException(
+                    "Batch send does not support scheduled jobs; send scheduled jobs individually " +
+                    "via Send(message).");
             }
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/BatchSendValidation.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/BatchSendValidation.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DotNetWorkQueue.Messages;
 
 namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
@@ -36,14 +37,11 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
             IReadOnlyList<QueueMessage<IMessage, IAdditionalMessageData>> messages,
             IJobSchedulerMetaData jobSchedulerMetaData)
         {
-            foreach (var m in messages)
+            if (messages.Any(m => !string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData))))
             {
-                if (!string.IsNullOrWhiteSpace(jobSchedulerMetaData.GetJobName(m.MessageData)))
-                {
-                    throw new NotSupportedException(
-                        "Batch send does not support scheduled jobs; send scheduled jobs individually " +
-                        "via Send(message).");
-                }
+                throw new NotSupportedException(
+                    "Batch send does not support scheduled jobs; send scheduled jobs individually " +
+                    "via Send(message).");
             }
         }
     }

--- a/Source/DotNetWorkQueue/Queue/QueueMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/QueueMonitor.cs
@@ -120,14 +120,7 @@ namespace DotNetWorkQueue.Queue
         {
             get
             {
-                DateTime? latest = null;
-                foreach (var monitor in _monitors)
-                {
-                    var ts = monitor.LastRunUtc;
-                    if (ts.HasValue && (!latest.HasValue || ts.Value > latest.Value))
-                        latest = ts;
-                }
-                return latest;
+                return _monitors.Max(monitor => monitor.LastRunUtc);
             }
         }
 


### PR DESCRIPTION
Resolves all 6 **S6964** (under-posting) issues on the consumer register/heartbeat request DTOs by making their value-type members nullable — the rule's canonical remedy — and coalescing to the prior default in the controller.

## Changes
| File | Change |
|---|---|
| `ConsumerHeartbeatRequest` | `ConsumerId` → `Guid?`; `MessagesProcessed`/`MessagesErrored`/`MessagesRolledBack`/`PoisonMessages` → `long?`; dropped the no-op `[Required]` on `ConsumerId` (it never fired on a non-nullable `Guid`) |
| `ConsumerRegistrationRequest` | `ProcessId` → `int?` |
| `ConsumersController` | coalesce at both call sites: `request.ProcessId ?? 0`, `request.ConsumerId ?? Guid.Empty`, `request.Messages* ?? 0` |
| `ConsumersEndpointTests` | +2 integration tests posting bodies that **omit** the fields entirely (not zero-valued) to cover the nullable/coalescing path |

## Compatibility
- **Wire behavior unchanged** — a missing counter still counts as 0; a missing `ProcessId` is still 0; a missing `ConsumerId` still resolves to `Guid.Empty` → 404. So no behavioral break to the released (v0.9.41+) contract.
- **Source-level:** the public DTO property types change (`long`→`long?`, etc.). These are server-side `[FromBody]` binding models; per maintainer direction a break here is acceptable for this recent feature.
- **Dashboard.Client is unaffected:** it posts anonymous objects with every field populated and does not reference these DTO types. Verified — no client change needed.

## Verification
- `NoTests.sln` **Release `-p:CI=true`**: 0 warnings / 0 errors
- Dashboard.Api unit **222** pass; Dashboard.Api integration (Memory) **65** pass (incl. the 2 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dashboard consumer heartbeats now handle omitted metric fields safely, recording missing counters as zero.
  - Consumer registration requests without a process ID now succeed and default the process ID to zero while retaining the machine name.
  - Batch submissions continue to reject scheduled jobs consistently across supported transports.

- **Refactor**
  - Simplified internal validation and queue-monitoring logic without changing standard processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->