### PR TITLE
fix: await async ADO.NET calls in async send handlers (S6966, 15 issues)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Ui/Program.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui/Program.cs
@@ -169,4 +169,4 @@ app.MapGet("/auth/logout", async (HttpContext ctx) =>
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
-app.Run();
+await app.RunAsync();

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
@@ -105,8 +105,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
             var results = new IQueueOutputMessage[messages.Count];
             using (var connection = new NpgsqlConnection(_configurationSend.ConnectionInfo.ConnectionString))
             {
-                connection.Open();
-                using (var trans = connection.BeginTransaction())
+                await connection.OpenAsync().ConfigureAwait(false);
+                using (var trans = await connection.BeginTransactionAsync().ConfigureAwait(false))
                 {
                     try
                     {
@@ -116,13 +116,13 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                             globalIndex = await ProcessChunkAsync(connection, trans, chunk, options, results, globalIndex)
                                 .ConfigureAwait(false);
                         }
-                        trans.Commit();
+                        await trans.CommitAsync().ConfigureAwait(false);
                     }
                     catch (Exception error)
                     {
                         try
                         {
-                            trans.Rollback();
+                            await trans.RollbackAsync().ConfigureAwait(false);
                         }
                         catch (Exception)
                         {

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -121,8 +121,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
 
             using (var connection = new NpgsqlConnection(_configurationSend.ConnectionInfo.ConnectionString))
             {
-                connection.Open();
-                using (var trans = connection.BeginTransaction())
+                await connection.OpenAsync().ConfigureAwait(false);
+                using (var trans = await connection.BeginTransactionAsync().ConfigureAwait(false))
                 {
                     if (string.IsNullOrWhiteSpace(jobName) || _jobExistsHandler.Handle(new DoesJobExistQuery<NpgsqlConnection, NpgsqlTransaction>(jobName, scheduledTime, connection, trans)) ==
                         QueueStatuses.NotQueued)
@@ -179,7 +179,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
                                 throw new DotNetWorkQueueException(
                                     "Failed to insert record - the ID of the new record returned by the server was 0");
                             }
-                            trans.Commit();
+                            await trans.CommitAsync().ConfigureAwait(false);
                             return id;
                         }
                     }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
@@ -100,8 +100,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
             var results = new IQueueOutputMessage[messages.Count];
             using (var connection = new SqlConnection(_configurationSend.ConnectionInfo.ConnectionString))
             {
-                connection.Open();
-                using (var trans = connection.BeginTransaction())
+                await connection.OpenAsync().ConfigureAwait(false);
+                using (var trans = (SqlTransaction)await connection.BeginTransactionAsync().ConfigureAwait(false))
                 {
                     try
                     {
@@ -111,13 +111,13 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                             globalIndex = await ProcessChunkAsync(connection, trans, chunk, options, results, globalIndex)
                                 .ConfigureAwait(false);
                         }
-                        trans.Commit();
+                        await trans.CommitAsync().ConfigureAwait(false);
                     }
                     catch (Exception error)
                     {
                         try
                         {
-                            trans.Rollback();
+                            await trans.RollbackAsync().ConfigureAwait(false);
                         }
                         catch (Exception)
                         {

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -120,8 +120,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
 
             using (var connection = new SqlConnection(_configurationSend.ConnectionInfo.ConnectionString))
             {
-                connection.Open();
-                using (var trans = connection.BeginTransaction())
+                await connection.OpenAsync().ConfigureAwait(false);
+                using (var trans = (SqlTransaction)await connection.BeginTransactionAsync().ConfigureAwait(false))
                 {
                     if (string.IsNullOrWhiteSpace(jobName) || _jobExistsHandler.Handle(new DoesJobExistQuery<SqlConnection, SqlTransaction>(jobName, scheduledTime, connection, trans)) ==
                         QueueStatuses.NotQueued)
@@ -178,7 +178,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                                 throw new DotNetWorkQueueException(
                                     "Failed to insert record - the ID of the new record returned by SQL server was 0");
                             }
-                            trans.Commit();
+                            await trans.CommitAsync().ConfigureAwait(false);
                             return id;
                         }
                     }


### PR DESCRIPTION
## What

Resolves the 15 open **S6966** ("Await the async overload") issues. Every flagged site is inside a method that is *already* `async Task` but reaches for a blocking ADO.NET call. Each is swapped for its async equivalent so the thread is no longer blocked mid-`await`.

| File | Sites |
|---|---|
| `Transport.SqlServer/.../SendMessageCommandHandlerAsync.cs` | Open, BeginTransaction, Commit |
| `Transport.SqlServer/.../SendMessageCommandBatchHandlerAsync.cs` | Open, BeginTransaction, Commit, Rollback |
| `Transport.PostgreSQL/.../SendMessageCommandHandlerAsync.cs` | Open, BeginTransaction, Commit |
| `Transport.PostgreSQL/.../SendMessageCommandBatchHandlerAsync.cs` | Open, BeginTransaction, Commit, Rollback |
| `Dashboard.Ui/Program.cs` | `app.Run()` → `await app.RunAsync()` |

## Why the SqlServer cast

`Microsoft.Data.SqlClient.SqlConnection` exposes **no** strongly-typed `BeginTransactionAsync` — only the base `DbConnection.BeginTransactionAsync()` returning `ValueTask<DbTransaction>`. The transaction flows into `SqlTransaction`-typed slots (`command.Transaction`, `DoesJobExistQuery<SqlConnection, SqlTransaction>`, `ProcessChunkAsync`), so the SqlServer sites cast the result to `SqlTransaction` (its genuine runtime type). Npgsql provides a strongly-typed overload (`ValueTask<NpgsqlTransaction>`), so PostgreSQL needs no cast.

## Behavior / risk

Behavior is unchanged — async ADO.NET calls are semantically equivalent to the blocking ones; no method signature or public XML doc changed (bodies only). The external/inbox-transaction paths (`HandleExternalTransactionAsync`) reuse a caller-owned connection and were never flagged, so they're untouched. These send + batch-send paths are already exercised by the SqlServer and PostgreSQL integration test stages.

## Verification

- Debug build: SqlServer, PostgreSQL, Dashboard.Ui — clean
- `NoTests.sln -c Release -p:CI=true` — **0 warnings, 0 errors**
- Existing SqlServer/PostgreSQL integration send tests (Jenkins)

Expected SonarCloud code smells after merge + rescan: **23 → 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved asynchronous database connection and transaction handling for PostgreSQL and SQL Server message processing.
  * Batch operations continue to commit atomically and roll back safely when errors occur.
  * Updated application startup to use asynchronous execution for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->