### PR TITLE
fix: resolve final code-quality smells (S2372, S4144, S7031, S7924)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Ui/Components/Layout/ReconnectModal.razor.css
+++ b/Source/DotNetWorkQueue.Dashboard.Ui/Components/Layout/ReconnectModal.razor.css
@@ -90,18 +90,18 @@
 
 #components-reconnect-modal button {
     border: 0;
-    background-color: #6b9ed2;
+    background-color: #3b6ea2;
     color: white;
     padding: 4px 24px;
     border-radius: 4px;
 }
 
     #components-reconnect-modal button:hover {
-        background-color: #3b6ea2;
+        background-color: #2c527b;
     }
 
     #components-reconnect-modal button:active {
-        background-color: #6b9ed2;
+        background-color: #3b6ea2;
     }
 
 .components-rejoining-animation {

--- a/Source/DotNetWorkQueue/Queue/ConsumerQueueErrorNotification.cs
+++ b/Source/DotNetWorkQueue/Queue/ConsumerQueueErrorNotification.cs
@@ -1,4 +1,5 @@
-﻿using DotNetWorkQueue.Notifications;
+﻿using System.Diagnostics.CodeAnalysis;
+using DotNetWorkQueue.Notifications;
 
 namespace DotNetWorkQueue.Queue
 {
@@ -23,6 +24,7 @@ namespace DotNetWorkQueue.Queue
             _notifications?.ReceiveMessageError?.Invoke(error);
         }
 
+        [SuppressMessage("Major Code Smell", "S4144:Methods should not have identical implementations", Justification = "distinct domain events (error raised vs. moved to error queue); kept separate so they can diverge without touching callers")]
         public void InvokeMovedToErrorQueue(ErrorNotification error)
         {
             _metrics.IncrementErrored();

--- a/Source/DotNetWorkQueue/TaskScheduling/TaskScheduler.cs
+++ b/Source/DotNetWorkQueue/TaskScheduling/TaskScheduler.cs
@@ -93,6 +93,7 @@ namespace DotNetWorkQueue.TaskScheduling
 
         /// <inheritdoc />
         [SuppressMessage("Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations", Justification = "need to throw exception if scheduler is not running")]
+        [SuppressMessage("Major Code Smell", "S2372:Exceptions should not be thrown from property getters", Justification = "need to throw exception if scheduler is not running")]
         public override RoomForNewTaskResult RoomForNewTask
         {
             get

--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -37,14 +37,13 @@ RUN dotnet publish "Source/DotNetWorkQueue.Dashboard.Ui/DotNetWorkQueue.Dashboar
 # Stage 2: Runtime
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
 
-# Install SQLite native library (required by the SQLite transport)
+# Install the SQLite native library (required by the SQLite transport) and create the
+# libdl.so symlink the System.Data.SQLite native loader expects — on glibc 2.34+ dlopen
+# lives in libc directly, so libdl.so may be absent. Kept in one RUN to avoid extra layers.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libsqlite3-0 \
-    && rm -rf /var/lib/apt/lists/*
-
-# System.Data.SQLite native loader expects libdl.so, but on glibc 2.34+
-# dlopen is in libc directly. Create the symlink it needs.
-RUN if [ ! -e /usr/lib/x86_64-linux-gnu/libdl.so ]; then \
+    && rm -rf /var/lib/apt/lists/* \
+    && if [ ! -e /usr/lib/x86_64-linux-gnu/libdl.so ]; then \
         ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so 2>/dev/null || \
         ln -s /lib/x86_64-linux-gnu/libc.so.6 /usr/lib/x86_64-linux-gnu/libdl.so; \
     fi


### PR DESCRIPTION
## What

The four **fixable** of the last eight SonarCloud code smells. The other four (S2139 ×3 log-and-rethrow with required transaction cleanup, JS S2486 in Microsoft's verbatim Blazor reconnect template) are being marked *Won't Fix* in SonarCloud with justification — no code change is appropriate for those.

| Rule | Location | Change |
|---|---|---|
| **S7924** (a11y, MAJOR) | `Dashboard.Ui/.../ReconnectModal.razor.css` | Reconnect button was white on `#6b9ed2` (~2.7:1, **fails WCAG AA**). Rest → `#3b6ea2` (**5.4:1**), hover → `#2c527b`; active returns to rest as before. |
| **S7031** | `docker/dashboard/Dockerfile` | Merge the consecutive `apt-get` and `libdl`-symlink `RUN` instructions into one layer. |
| **S2372** | `TaskScheduling/TaskScheduler.cs` | The `RoomForNewTask` getter deliberately throws when the scheduler hasn't started — it already suppresses the equivalent **CA1065**. Added the mirror `[SuppressMessage("…","S2372…")]` with the same justification. **No behavior change.** |
| **S4144** | `Queue/ConsumerQueueErrorNotification.cs` | `InvokeMovedToErrorQueue` and `InvokeError(ErrorNotification)` are coincidentally identical but are distinct domain events kept separate for future divergence; suppressed with justification. |

## Why suppress rather than refactor (S2372 / S4144)

Both are deliberate designs, not defects. S2372's throwing getter is already an accepted CA1065 decision; S4144's two methods represent different events (an error was raised vs. a message was moved to the error queue) — coupling them would misrepresent intent and couple two callers' contracts. Inline `[SuppressMessage]` keeps the justification in-source and permanent through rescans.

## Verification

- Core Debug build — clean
- `NoTests.sln -c Release -p:CI=true` — **0 warnings, 0 errors**
- Dockerfile committed as LF (normalized via `.gitattributes text=auto`), only the merged-RUN region changed
- `.cs` files retain their UTF-8 BOM

After this merges + the Won't-Fix pass on the remaining four, SonarCloud **code_smells → 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the dashboard reconnect modal button with a darker, more consistent color scheme.
  * Improved visual feedback for hover and active states, making button interactions clearer.

* **Bug Fixes**
  * Improved dashboard runtime packaging to support more reliable operation in environments using SQLite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->