### PR TITLE
ci: add Release build-through-pack gate (#197)

### DIFF
--- a/.github/workflows/build-pack.yml
+++ b/.github/workflows/build-pack.yml
@@ -17,7 +17,6 @@ env:
 
 jobs:
   build:
-    name: Build, pack, and (optionally) upload NuGet packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build-pack.yml
+++ b/.github/workflows/build-pack.yml
@@ -1,0 +1,87 @@
+name: Build and pack
+
+on:
+  workflow_call:
+    inputs:
+      upload_artifacts:
+        description: "Upload the packed nupkg/snupkg as the nuget-packages artifact"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: true
+
+jobs:
+  build:
+    name: Build, pack, and (optionally) upload NuGet packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore Source/DotNetWorkQueueNoTests.sln
+
+      - name: Build
+        run: dotnet build Source/DotNetWorkQueueNoTests.sln -c Release -p:CI=true --no-restore
+
+      - name: Pack (solution)
+        run: dotnet pack Source/DotNetWorkQueueNoTests.sln -c Release -p:CI=true --no-build -o deploy/
+
+      - name: Pack (Dashboard.Ui -- Web SDK not auto-packed by solution)
+        run: dotnet pack Source/DotNetWorkQueue.Dashboard.Ui/DotNetWorkQueue.Dashboard.Ui.csproj -c Release -p:CI=true --no-build -o deploy/
+
+      - name: Assert package counts (12 nupkg + 12 snupkg)
+        run: |
+          set -euo pipefail
+          nupkg_count=$(ls deploy/*.nupkg 2>/dev/null | wc -l)
+          snupkg_count=$(ls deploy/*.snupkg 2>/dev/null | wc -l)
+          echo "nupkg_count=${nupkg_count} snupkg_count=${snupkg_count}"
+          if [[ "${nupkg_count}" -ne 12 ]]; then
+            echo "::error::Expected 12 .nupkg files in deploy/, got ${nupkg_count}"
+            ls -la deploy/ || true
+            exit 1
+          fi
+          if [[ "${snupkg_count}" -ne 12 ]]; then
+            echo "::error::Expected 12 .snupkg files in deploy/, got ${snupkg_count}"
+            ls -la deploy/ || true
+            exit 1
+          fi
+
+      - name: Job summary
+        run: |
+          {
+            echo "## Build-pack summary"
+            echo ""
+            echo "- Tag/ref: ${{ github.ref_name }}"
+            echo "- SHA: ${{ github.sha }}"
+            echo "- Packages: 12 .nupkg + 12 .snupkg"
+            echo ""
+            echo "### Packed files"
+            echo ""
+            echo '```'
+            ls -la deploy/ | sed 's/^/    /'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifact
+        if: inputs.upload_artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: nuget-packages
+          path: deploy/*
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,7 @@ jobs:
 
       - name: Integration Tests - TaskScheduler Distributed
         run: dotnet test "Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests.csproj" --no-build -c Debug
+
+  build-release:
+    name: build-release
+    uses: ./.github/workflows/build-pack.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,72 +68,9 @@ jobs:
   build-pack:
     name: Build, pack, and upload NuGet packages
     needs: verify-gate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
-
-      - name: Restore
-        run: dotnet restore Source/DotNetWorkQueueNoTests.sln
-
-      - name: Build
-        run: dotnet build Source/DotNetWorkQueueNoTests.sln -c Release -p:CI=true --no-restore
-
-      - name: Pack (solution)
-        run: dotnet pack Source/DotNetWorkQueueNoTests.sln -c Release -p:CI=true --no-build -o deploy/
-
-      - name: Pack (Dashboard.Ui -- Web SDK not auto-packed by solution)
-        run: dotnet pack Source/DotNetWorkQueue.Dashboard.Ui/DotNetWorkQueue.Dashboard.Ui.csproj -c Release -p:CI=true --no-build -o deploy/
-
-      - name: Assert package counts (12 nupkg + 12 snupkg)
-        run: |
-          set -euo pipefail
-          nupkg_count=$(ls deploy/*.nupkg 2>/dev/null | wc -l)
-          snupkg_count=$(ls deploy/*.snupkg 2>/dev/null | wc -l)
-          echo "nupkg_count=${nupkg_count} snupkg_count=${snupkg_count}"
-          if [[ "${nupkg_count}" -ne 12 ]]; then
-            echo "::error::Expected 12 .nupkg files in deploy/, got ${nupkg_count}"
-            ls -la deploy/ || true
-            exit 1
-          fi
-          if [[ "${snupkg_count}" -ne 12 ]]; then
-            echo "::error::Expected 12 .snupkg files in deploy/, got ${snupkg_count}"
-            ls -la deploy/ || true
-            exit 1
-          fi
-
-      - name: Job summary
-        run: |
-          {
-            echo "## Build-pack summary"
-            echo ""
-            echo "- Tag/ref: ${{ github.ref_name }}"
-            echo "- SHA: ${{ github.sha }}"
-            echo "- Packages: 12 .nupkg + 12 .snupkg"
-            echo ""
-            echo "### Packed files"
-            echo ""
-            echo '```'
-            ls -la deploy/ | sed 's/^/    /'
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v5
-        with:
-          name: nuget-packages
-          path: deploy/*
-          retention-days: 90
-          if-no-files-found: error
+    uses: ./.github/workflows/build-pack.yml
+    with:
+      upload_artifacts: true
 
   publish:
     name: Push to NuGet.org and create GitHub Release


### PR DESCRIPTION
## What / why

Closes #197.

None of our automated gates build in **Release**, so Release-only compile errors are invisible until a
tag-triggered publish. Release enables `GenerateDocumentationFile` **and** `TreatWarningsAsErrors`, so stale
XML-doc tags (CS1572/CS1573/CS1574), obsolete-API warnings, etc. are warnings-as-errors in Release but silent
in Debug — Jenkins, `ci.yml`, and `sonarcloud.yml` all build Debug. Only `publish.yml` builds Release, so
these break the build **at release time** (e.g. #196: 76 CS1572 on clean master, invisible to every Debug gate).

This adds a **Release build-through-pack gate** that runs on every PR:

- **New reusable workflow `.github/workflows/build-pack.yml`** (`on: workflow_call`, input `upload_artifacts`
  default `false`, `permissions: contents: read`, job `build`) — the Release `restore → build -c Release
  -p:CI=true → pack (solution + Dashboard.Ui) → assert 12 nupkg + 12 snupkg` steps, lifted verbatim from
  `publish.yml`'s old inline `build-pack` job. Upload step gated on `upload_artifacts`.
- **`ci.yml`** gains a `build-release` job that calls the reusable workflow (no upload), in parallel with
  `build-and-test`, on every PR + push.
- **`publish.yml`** refactored: its inline `build-pack` job is now a thin caller of the same reusable workflow
  (`upload_artifacts: true`). Single source of truth ⇒ "green CI implies publishable", by construction rather
  than by maintenance discipline. `verify-gate`, `publish`, and `docker-publish` are unchanged; the `publish`
  job still `needs: build-pack` and downloads the `nuget-packages` artifact.

Diff is **3 workflow files only** — no product code, no Jenkinsfile change, no `sonarcloud.yml` change.

## Manual branch-protection follow-up (maintainer)

After this PR merges (or after its first successful run), mark the new status check **`build-release / build`**
as a **required** status check in branch protection for `master`. (The check renders as `<caller-job> /
<reusable-job-id>`; confirmed live on this PR.)

## Evidence (Phase 2 proofs)

- **Local CS1572 red-proof:** ✅ A stale XML `<param name="disposing">` on the parameterless
  `QueueCancelWork.ThrowIfDisposed()` makes `dotnet build NoTests.sln -c Release -p:CI=true` fail
  `error CS1572` on both net8.0 and net10.0 (`TreatWarningsAsErrors`), proving the gate catches the #196 error
  class. Reproduced locally and reverted — never pushed.
- **`build-release` green run:** ✅ The `build-release / build` check passes on this PR's clean head
  (Release build + pack, ~1 min).
- **Pack 12/12 proof:** ✅ implied by the green `build-release` run — it executes the *same* reusable
  `build-pack.yml` job (build → pack → **assert 12 nupkg + 12 snupkg**, an unconditional step); the only
  difference from the publish caller is `upload_artifacts`.
- **Release-path safety (`Publish → dry_run=true`):** deferred to **post-merge on `master`** — by design,
  `publish.yml`'s `verify-gate` requires the `continuous-integration/jenkins/branch` status, which only exists
  on `master`/`*.*.x` branch builds, never on a PR commit (`pr-merge`). After merge, run the standard
  operational dry-run **before cutting the release**:
  `gh workflow run publish.yml --ref master -f dry_run=true` — expect verify-gate pass, build-pack 12/12,
  `nuget-packages` uploaded, `publish` + `docker-publish` skipped.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
