### PR TITLE
Trust the coverage number: fix stale Codecov upload + hard patch gate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -454,13 +454,12 @@ pipeline {
         }
 
         stage('Codecov Upload') {
-            // Only upload coverage when the build is clean. A failed stage above
-            // marks currentBuild.currentResult as FAILURE, which skips this step
-            // while still letting the local HTML report (above) publish for the
-            // failed build's coverage view.
-            when {
-                expression { currentBuild.currentResult == 'SUCCESS' }
-            }
+            // Upload coverage whenever a merged Cobertura report exists — regardless of
+            // whether a flaky stage flipped currentBuild.currentResult to FAILURE via
+            // catchError. Codecov is informational, not a build gate; gating the upload
+            // on build SUCCESS caused Codecov to silently skip uploads on any flaky run
+            // and drift stale behind master. The `if [ ! -f ... ]` guard below makes the
+            // step a no-op when no report was produced.
             agent { label 'docker' }
             steps {
                 script {

--- a/codecov.yml
+++ b/codecov.yml
@@ -31,15 +31,23 @@ ignore:
   - "Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/**"
   - "Source/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests/**"
   - "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/**"
+  # Dashboard UI + remaining test-support / distributed-scheduler test projects
+  - "Source/DotNetWorkQueue.Dashboard.Ui.Tests/**"
+  - "Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/**"
+  - "Source/DotNetWorkQueue.Tests.Shared.Tests/**"
+  - "Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/**"
 
 coverage:
   status:
     project:
       default:
         # Allow a 2% drift before failing the project status check.
+        # NOTE: this ratcheting `auto` baseline hardens to `target: 90%, threshold: 1%`
+        # in Phase 2c once remediation coverage is banked. See docs/code-coverage.md.
         target: auto
         threshold: 2%
     patch:
       default:
-        target: auto
-        threshold: 2%
+        # Hard, non-ratcheting floor: new/changed lines in a PR must be >=90% covered.
+        # No threshold — a hard target intentionally omits "close enough" slack.
+        target: 90%

--- a/docs/code-coverage.md
+++ b/docs/code-coverage.md
@@ -1,0 +1,63 @@
+# Code Coverage Policy
+
+DotNetWorkQueue targets a **90% line-coverage floor** across its product assemblies.
+Both unit and integration tests count toward the number.
+
+## Authoritative report
+
+The source of truth is the **ReportGenerator-merged Cobertura report**,
+`coverage/report/Cobertura.xml`, produced by the Jenkins pipeline from the 14
+coverage-bearing stages. It contains product assemblies only — every test assembly is
+stripped at collection time by the repo-wide Coverlet `Exclude` filter in
+`Source/Directory.Build.props` (`[*.Tests]*`, `[*.IntegrationTests]*`, …).
+
+**Codecov is a convenience mirror, not the authority.** It has a demonstrated
+skipped-upload failure mode (see below), so when the two disagree, the merged Cobertura
+report wins.
+
+## The staged gate
+
+Coverage is enforced by two Codecov status checks (`codecov.yml`), turned on in stages so
+the remediation work that restores the floor is not failed by the gate it is fixing:
+
+| Check | Rule | Status |
+|---|---|---|
+| `patch` | new/changed lines in a PR must be **≥90%** covered (hard target, no threshold) | **live now (Phase 0)** |
+| `project` | whole-repo coverage must be **≥90%** (`threshold: 1%`) | hardens at **Phase 2c**; currently still `auto`/`2%` |
+
+`patch` grades only the lines a PR touches, so it never punishes a PR for pre-existing
+debt — it just stops new uncovered code from shipping. The ratcheting `auto` project
+baseline is what allowed the floor to erode from 90% to ~87% unnoticed (each merge
+rebaselines to the prior commit, and 2% of slack compounds downward); it is replaced by
+a hard 90% once the remediation coverage is banked.
+
+## Reconciliation finding (2026-07)
+
+A ~3-point gap was observed: the merged Cobertura report read **89.9%** while Codecov
+reported **87%**. It is **not** a counting/denominator difference — it is a **stale
+Codecov snapshot**.
+
+The Jenkins `Codecov Upload` stage was gated on `currentBuild.currentResult == 'SUCCESS'`,
+while all parallel test stages wrap their steps in `catchError(buildResult: 'FAILURE')`.
+So any single flaky test anywhere in the build (e.g. the Redis SNTP flake, #199) flipped
+the build to FAILURE and **silently skipped the upload** — leaving Codecov displaying
+whatever the last fully-green build reported, lagging master by an unknown number of
+merged PRs.
+
+**Fix:** the upload stage is decoupled from the build result — it now runs whenever a
+merged `Cobertura.xml` exists (an `if [ ! -f … ]` guard makes it a no-op otherwise).
+Codecov is informational, not a build gate, so a flaky stage no longer suppresses it.
+
+## Maintainer verification checklist (Codecov UI only)
+
+Codecov data cannot be exported; confirm health from the UI:
+
+1. Compare Codecov's latest **processed commit SHA** against master `HEAD` — they should
+   be at or very near the same commit.
+2. Confirm **exactly one unflagged upload** per commit (the pipeline uploads a single
+   merged report, no flags).
+3. Scan recent master commits for any with **no coverage data** — those are skipped
+   uploads and should stop appearing now that the gate is removed.
+4. Spot-check the **file tree**: 12 product packages present, **no `*.Tests` packages**
+   (they are Exclude-stripped before upload).
+5. Confirm the **Flags** page is empty (uploads are unflagged by design).


### PR DESCRIPTION
## Phase 0 — Trust the number (coverage recovery)

Fixes the silent erosion of code coverage from ~90% to ~87% and makes the reported number trustworthy. **No product-code changes** — CI config + docs only.

### Root cause
The `Codecov Upload` Jenkins stage was gated on `currentBuild.currentResult == 'SUCCESS'`, but every parallel test stage wraps its steps in `catchError(buildResult: 'FAILURE')`. So **one flaky test anywhere** (e.g. the Redis SNTP flake #199) flipped the build to FAILURE and silently skipped the upload — leaving Codecov showing a stale number lagging master by an unknown number of PRs. That, not a denominator/counting difference, is the ~3-point Cobertura(89.9%) vs Codecov(87%) gap. (Denominator theory ruled out empirically: `Directory.Build.props` Coverlet `Exclude` strips test assemblies pre-upload; the merged report has 12 product packages only.)

### Changes
- **Jenkinsfile** — remove the build-SUCCESS gate on `Codecov Upload` so the merged Cobertura report uploads whenever it exists (the `if [ ! -f … ]` guard makes it a no-op otherwise). Codecov is informational, not a build gate. Upload command, credentials, file guard, and all 16 parallel stages unchanged.
- **codecov.yml** — `patch.default` becomes a hard, non-ratcheting `target: 90%` (new/changed lines must be ≥90% covered), replacing the `auto`/`2%` baseline that let coverage erode unnoticed. `project.default` intentionally left on `auto` — it hardens to `target: 90%, threshold: 1%` in a later phase once remediation coverage is banked. Added 4 test-project `ignore:` entries (26→30, hygiene).
- **docs/code-coverage.md** — new coverage policy: the 90% floor, that the ReportGenerator-merged Cobertura report is authoritative and why, the staged gate, the stale-upload finding, and a maintainer Codecov-UI verification checklist.

### Follow-up (maintainer, after merge)
Once this is on master and a build has uploaded, run the `docs/code-coverage.md` checklist to confirm Codecov converged, then mark `codecov/patch` as a **required** check in branch protection. Do **not** mark it required before this merges — a required check that can't post yet would block every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documented 90% code coverage policy covering unit and integration tests.
  * Coverage reporting now remains available when a merged report exists, even if other build stages fail.

* **Bug Fixes**
  * Improved reliability of coverage uploads during flaky or partially failed builds.
  * Added clearer coverage checks and exclusions for test-only projects.

* **Documentation**
  * Documented coverage sources, enforcement rules, Codecov behavior, and validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->