### PR TITLE
codecov: widen project threshold to 0.5% for measurement noise

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -41,17 +41,23 @@ coverage:
   status:
     project:
       default:
-        # Ratchet: never drop below the parent commit. `auto` with a 0% threshold means
-        # any decrease fails, so coverage can go up or stay flat but never slide.
+        # Ratchet: coverage may rise or stay flat, but must not slide below the parent
+        # commit by more than the measurement noise floor.
         #
-        # The previous 2% threshold is what let coverage drift downward unnoticed --
-        # `auto` rebaselines each merge, so 2% of slack compounded. 0% removes the slack
-        # without having to guess a fixed number.
+        # The original 2% threshold is what let coverage drift downward unnoticed --
+        # `auto` rebaselines each merge, so 2% of slack compounded silently.
         #
-        # This hardens to `target: 90%` once Dashboard.Ui is covered; that project alone
-        # is the whole gap between today's ~87.5% and the 90% goal. See docs/code-coverage.md.
+        # 0.5% rather than 0%: the same commit has been observed reporting different
+        # totals (78bf5839 read 29,373 then 29,512 hits -- +0.41 points) because repeat
+        # uploads are unioned and the integration suite covers slightly different paths
+        # run to run. A 0% threshold turns that noise into spurious failures. Real
+        # regressions are far larger than 0.5% (the Dashboard.Ui shortfall is ~2.5
+        # points), so this still catches what it needs to.
+        #
+        # Hardens to `target: 90%` once Dashboard.Ui is covered -- that project alone is
+        # the whole gap between today's ~87.5% and the goal. See docs/code-coverage.md.
         target: auto
-        threshold: 0%
+        threshold: 0.5%
     patch:
       default:
         # Hard, non-ratcheting floor: new/changed lines in a PR must be >=90% covered.

--- a/docs/code-coverage.md
+++ b/docs/code-coverage.md
@@ -32,13 +32,20 @@ Codecov to Codecov.
 
 | Check | Rule | Status |
 |---|---|---|
-| `patch` | new/changed lines in a PR must be **≥90%** covered | live |
-| `project` | `auto` + **0% threshold** — coverage may rise or stay flat, but **never drop below the parent commit** | live |
+| `patch` | new/changed lines in a PR must be **≥90%** covered | live, **required** |
+| `project` | `auto` + **0.5% threshold** — coverage must not fall below the parent commit by more than the measurement noise floor | live, **required** |
 
-The 0% threshold is the anti-erosion mechanism. The previous `auto` + **2%** allowed 2
+The tight threshold is the anti-erosion mechanism. The original `auto` + **2%** allowed 2
 points of slack per merge, and because `auto` rebaselines to the prior commit every time,
 that slack compounded downward silently. `patch` grades only the lines a PR touches, so it
 never punishes a PR for pre-existing debt.
+
+**Why 0.5% and not 0%:** the measurement is not deterministic. Commit `78bf5839` was
+observed reporting 29,373 hits and later 29,512 (+0.41 points) with no code change —
+repeat uploads are unioned, and the integration suite covers slightly different paths run
+to run. A 0% threshold converts that noise into spurious failures on a *required* check.
+Real regressions are far larger (the Dashboard.Ui shortfall is ~2.5 points), so 0.5% still
+catches what matters.
 
 `project` hardens to a fixed **`target: 90%`** once Dashboard.Ui is covered (see below).
 


### PR DESCRIPTION
Follow-up to #211, now that `codecov/project` is a **required** check on master.

### Problem
`project` was set to `auto` + **0% threshold** — any decrease fails. But the measurement is not deterministic: commit `78bf5839` was observed reporting **29,373 hits, then 29,512** (+0.41 points) with **no code change**. Repeat uploads get unioned, and the integration suite covers slightly different paths run to run.

With `project` required, that noise blocks PRs for no reason.

### Change
`threshold: 0%` → **`0.5%`**.

Still far tighter than the original `2%` (which is what allowed coverage to drift downward unnoticed, since `auto` rebaselines every merge), and comfortably below the size of a real regression — the Dashboard.Ui shortfall this gate exists to prevent is ~2.5 points.

Docs updated with the reasoning so the number isn't mistaken for arbitrary slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code coverage policy guidance to require patch coverage checks.
  * Clarified project coverage thresholds and their relationship to measurement variability.

* **Chores**
  * Tightened the project coverage ratchet to prevent coverage declines beyond a 0.5% tolerance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->