### PR TITLE
Dashboard.Ui test coverage: 23.6% -> ~97% (restores the 90% Codecov floor)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/EmptyLayoutTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/EmptyLayoutTests.cs
@@ -37,8 +37,10 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Layout
                     builder.CloseElement();
                 })));
 
-            StringAssert.Contains(cut.Markup, "layout-body-marker");
-            StringAssert.Contains(cut.Markup, "mud-theme-dark");
+            // Assert against the themed wrapper's inner HTML, not the whole markup, so the
+            // test fails if the body is ever rendered outside it.
+            var themed = cut.Find("div.mud-theme-dark");
+            StringAssert.Contains(themed.InnerHtml, "layout-body-marker");
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/EmptyLayoutTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Layout/EmptyLayoutTests.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Layout;
+using Microsoft.AspNetCore.Components;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Layout
+{
+    [TestClass]
+    public class EmptyLayoutTests : BunitTestBase
+    {
+        [TestMethod]
+        public void RendersBodyInsideDarkThemeContainer()
+        {
+            var cut = Render<EmptyLayout>(ps => ps
+                .Add(p => p.Body, (RenderFragment)(builder =>
+                {
+                    builder.OpenElement(0, "span");
+                    builder.AddContent(1, "layout-body-marker");
+                    builder.CloseElement();
+                })));
+
+            StringAssert.Contains(cut.Markup, "layout-body-marker");
+            StringAssert.Contains(cut.Markup, "mud-theme-dark");
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/ConnectionDetailTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/ConnectionDetailTests.cs
@@ -1,0 +1,305 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bunit;
+using Bunit.TestDoubles;
+using DotNetWorkQueue.Dashboard.Ui.Components.Pages;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
+{
+    [TestClass]
+    public class ConnectionDetailTests : BunitTestBase
+    {
+        private const string SourceSlug = "acme";
+        private static readonly Guid ConnectionId = Guid.NewGuid();
+        private static readonly Guid QueueId = Guid.NewGuid();
+
+        [TestMethod]
+        public void ShowsSourceNotFound_WhenSlugDoesNotResolve()
+        {
+            var api = CreateApi();
+
+            var cut = RenderPage(api, sourceNotFound: true);
+
+            StringAssert.Contains(cut.Markup, "not found");
+        }
+
+        [TestMethod]
+        public void RendersQueueRows_WhenQueuesReturned()
+        {
+            var api = CreateApi(queues: new List<QueueInfoResponse>
+            {
+                new() { Id = QueueId, QueueName = "OrdersQueue" }
+            });
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "OrdersQueue");
+        }
+
+        [TestMethod]
+        public void ShowsNoQueuesMessage_WhenQueueListEmpty()
+        {
+            var api = CreateApi();
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "No queues found for this connection.");
+        }
+
+        [TestMethod]
+        public void ShowsNoJobsMessage_WhenJobListEmpty()
+        {
+            var api = CreateApi();
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "No scheduled jobs found for this connection.");
+        }
+
+        [TestMethod]
+        public void RendersJobRows_WithFormattedTimes()
+        {
+            var eventTime = new DateTimeOffset(2026, 3, 4, 5, 6, 7, TimeSpan.Zero);
+            var api = CreateApi(jobs: new List<JobResponse>
+            {
+                new() { JobName = "NightlyRollup", JobEventTime = eventTime, JobScheduledTime = eventTime }
+            });
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "NightlyRollup");
+            StringAssert.Contains(cut.Markup, eventTime.LocalDateTime.ToString("G"));
+        }
+
+        [TestMethod]
+        public void RendersDashes_WhenJobTimesAreNull()
+        {
+            var api = CreateApi(jobs: new List<JobResponse>
+            {
+                new() { JobName = "NeverRan" }
+            });
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "NeverRan");
+            StringAssert.Contains(cut.Markup, "<td>-</td>");
+        }
+
+        [TestMethod]
+        public void RendersConsumerCountChip_WhenQueueHasConsumers()
+        {
+            var api = CreateApi(
+                queues: new List<QueueInfoResponse> { new() { Id = QueueId, QueueName = "Busy" } },
+                consumerCounts: new Dictionary<Guid, int> { [QueueId] = 3 });
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "mud-chip");
+            StringAssert.Contains(cut.Markup, "3");
+        }
+
+        [TestMethod]
+        public void RendersZero_WhenQueueHasNoConsumers()
+        {
+            var api = CreateApi(
+                queues: new List<QueueInfoResponse> { new() { Id = QueueId, QueueName = "Idle" } },
+                consumerCounts: new Dictionary<Guid, int>());
+
+            var cut = RenderPage(api);
+
+            Assert.DoesNotContain("mud-chip", cut.Markup);
+            StringAssert.Contains(cut.Markup, "0");
+        }
+
+        [TestMethod]
+        public void ShowsErrorAlert_WhenLoadThrows()
+        {
+            var api = CreateApi();
+            api.GetQueuesAsync(Arg.Any<Guid>())
+                .Returns<Task<List<QueueInfoResponse>>>(_ => throw new InvalidOperationException("boom"));
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "boom");
+        }
+
+        [TestMethod]
+        public void ClickingRetry_AfterFailure_ReloadsAndRendersQueues()
+        {
+            var callCount = 0;
+            var api = CreateApi();
+            api.GetQueuesAsync(Arg.Any<Guid>()).Returns<Task<List<QueueInfoResponse>>>(_ =>
+            {
+                callCount++;
+                if (callCount == 1) throw new InvalidOperationException("first load boom");
+                return Task.FromResult(new List<QueueInfoResponse>
+                {
+                    new() { Id = QueueId, QueueName = "RecoveredQueue" }
+                });
+            });
+
+            var cut = RenderPage(api);
+            StringAssert.Contains(cut.Markup, "first load boom");
+
+            cut.Find("button").Click();
+
+            Assert.DoesNotContain("first load boom", cut.Markup);
+            StringAssert.Contains(cut.Markup, "RecoveredQueue");
+        }
+
+        [TestMethod]
+        public void NavigatesToQueue_WithConnectionContext_WhenQueueRowClicked()
+        {
+            var api = CreateApi(
+                queues: new List<QueueInfoResponse> { new() { Id = QueueId, QueueName = "Orders Queue" } },
+                connections: new List<ConnectionResponse>
+                {
+                    new() { Id = ConnectionId, DisplayName = "Prod Conn" }
+                });
+            var cut = RenderPage(api);
+            cut.FindAll("tbody tr")[0].Click();
+
+            var nav = Services.GetRequiredService<BunitNavigationManager>();
+            StringAssert.Contains(nav.Uri, $"/source/{SourceSlug}/queues/{QueueId}");
+            StringAssert.Contains(nav.Uri, "conn=Prod%20Conn");
+            StringAssert.Contains(nav.Uri, $"connId={ConnectionId}");
+            StringAssert.Contains(nav.Uri, "queue=Orders%20Queue");
+        }
+
+        [TestMethod]
+        public void NavigatesWithFallbackNames_WhenConnectionAndQueueNamesMissing()
+        {
+            var api = CreateApi(queues: new List<QueueInfoResponse> { new() { Id = QueueId } });
+
+            var cut = RenderPage(api);
+            cut.FindAll("tbody tr")[0].Click();
+
+            var nav = Services.GetRequiredService<BunitNavigationManager>();
+            StringAssert.Contains(nav.Uri, "conn=Connection");
+            StringAssert.Contains(nav.Uri, "queue=Queue");
+        }
+
+        [TestMethod]
+        public void ShowsSourceCrumb_WhenMultipleSourcesConfigured()
+        {
+            var api = CreateApi(connections: new List<ConnectionResponse>
+            {
+                new() { Id = ConnectionId, DisplayName = "Prod Conn" }
+            });
+
+            var cut = RenderPage(api, extraSource: new DashboardApiSourceConfig { Name = "Other", BaseUrl = "http://other" });
+
+            StringAssert.Contains(cut.Markup, "Acme");
+            StringAssert.Contains(cut.Markup, "Prod Conn");
+        }
+
+        [TestMethod]
+        public void OmitsSourceCrumb_WhenSingleSourceConfigured()
+        {
+            var api = CreateApi();
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "Connections");
+            Assert.DoesNotContain("Acme", cut.Markup);
+        }
+
+        [TestMethod]
+        public void SkipsReload_WhenSameSlugAndConnectionRenderedAgain()
+        {
+            var api = CreateApi();
+
+            var cut = RenderPage(api);
+            cut.Render(ps => ps
+                .Add(p => p.SourceSlug, SourceSlug)
+                .Add(p => p.ConnectionId, ConnectionId));
+
+            api.Received(1).GetQueuesAsync(ConnectionId);
+        }
+
+        [TestMethod]
+        public void Reloads_WhenConnectionIdChanges()
+        {
+            var api = CreateApi();
+            var otherConnection = Guid.NewGuid();
+
+            var cut = RenderPage(api);
+            cut.Render(ps => ps
+                .Add(p => p.SourceSlug, SourceSlug)
+                .Add(p => p.ConnectionId, otherConnection));
+
+            api.Received(1).GetQueuesAsync(ConnectionId);
+            api.Received(1).GetQueuesAsync(otherConnection);
+        }
+
+        private static IDashboardApiClient CreateApi(
+            List<QueueInfoResponse>? queues = null,
+            List<JobResponse>? jobs = null,
+            List<ConnectionResponse>? connections = null,
+            Dictionary<Guid, int>? consumerCounts = null)
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConnectionsAsync().Returns(connections ?? new List<ConnectionResponse>());
+            api.GetQueuesAsync(Arg.Any<Guid>()).Returns(queues ?? new List<QueueInfoResponse>());
+            api.GetJobsAsync(Arg.Any<Guid>()).Returns(jobs ?? new List<JobResponse>());
+            api.GetConsumerCountsAsync().Returns(consumerCounts ?? new Dictionary<Guid, int>());
+            return api;
+        }
+
+        private IRenderedComponent<ConnectionDetail> RenderPage(
+            IDashboardApiClient api,
+            bool sourceNotFound = false,
+            DashboardApiSourceConfig? extraSource = null)
+        {
+            var multiSource = Substitute.For<IMultiSourceDashboardApiClient>();
+            if (sourceNotFound)
+            {
+                multiSource.GetClientForSource(Arg.Any<string>())
+                    .Returns<IDashboardApiClient>(_ => throw new KeyNotFoundException());
+            }
+            else
+            {
+                multiSource.GetClientForSource(SourceSlug).Returns(api);
+            }
+
+            var sourceConfig = new DashboardApiSourceConfig { Name = "Acme", BaseUrl = "http://acme.example" };
+            var sources = new List<DashboardApiSourceConfig> { sourceConfig };
+            if (extraSource != null) sources.Add(extraSource);
+
+            var sourceRegistry = Substitute.For<ISourceRegistry>();
+            sourceRegistry.GetAll().Returns(sources);
+            sourceRegistry.GetBySlug(SourceSlug).Returns(sourceConfig);
+
+            Services.AddSingleton(multiSource);
+            Services.AddSingleton(sourceRegistry);
+
+            return Render<ConnectionDetail>(ps => ps
+                .Add(p => p.SourceSlug, SourceSlug)
+                .Add(p => p.ConnectionId, ConnectionId));
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/HomeTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/HomeTests.cs
@@ -112,17 +112,23 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
         {
             var sources = TwoSources();
             var clients = RegisterDependenciesWithPerSourceClients(sources);
-            clients["primary"].GetConnectionsAsync()
-                .Returns<Task<List<ConnectionResponse>>>(_ => throw new InvalidOperationException("boom"));
+            // A single stub that throws once then succeeds — re-stubbing after the throw is
+            // configured would re-invoke the throwing setup on the substitute.
+            var callCount = 0;
+            clients["primary"].GetConnectionsAsync().Returns<Task<List<ConnectionResponse>>>(_ =>
+            {
+                callCount++;
+                if (callCount == 1) throw new InvalidOperationException("boom");
+                return Task.FromResult(new List<ConnectionResponse>
+                {
+                    new() { Id = Guid.NewGuid(), DisplayName = "Conn1", QueueCount = 1 }
+                });
+            });
 
             var cut = Render<Home>(ps => ps.Add(p => p.SourceSlug, "primary"));
 
             StringAssert.Contains(cut.Markup, "Failed to load connections: boom");
 
-            clients["primary"].GetConnectionsAsync().Returns(new List<ConnectionResponse>
-            {
-                new() { Id = Guid.NewGuid(), DisplayName = "Conn1", QueueCount = 1 }
-            });
             cut.Find("button").Click();
 
             StringAssert.Contains(cut.Markup, "Conn1");

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/HomeTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/HomeTests.cs
@@ -16,10 +16,13 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Bunit;
 using Bunit.TestDoubles;
 using DotNetWorkQueue.Dashboard.Ui.Components.Pages;
+using DotNetWorkQueue.Dashboard.Ui.Models;
 using DotNetWorkQueue.Dashboard.Ui.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -74,6 +77,222 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             StringAssert.Contains(cut.Markup, "Alpha");
             StringAssert.Contains(cut.Markup, "Beta");
+        }
+
+        [TestMethod]
+        public void RendersConnectionsTable_WhenSlugResolvesWithConnections()
+        {
+            var sources = TwoSources();
+            var clients = RegisterDependenciesWithPerSourceClients(sources);
+            clients["primary"].GetConnectionsAsync().Returns(new List<ConnectionResponse>
+            {
+                new() { Id = Guid.NewGuid(), DisplayName = "Conn1", QueueCount = 3 }
+            });
+
+            var cut = Render<Home>(ps => ps.Add(p => p.SourceSlug, "primary"));
+
+            StringAssert.Contains(cut.Markup, "Conn1");
+            StringAssert.Contains(cut.Markup, "Primary");
+        }
+
+        [TestMethod]
+        public void ShowsNoConnectionsMessage_WhenSourceHasNoConnections()
+        {
+            var sources = TwoSources();
+            var clients = RegisterDependenciesWithPerSourceClients(sources);
+            clients["primary"].GetConnectionsAsync().Returns(new List<ConnectionResponse>());
+
+            var cut = Render<Home>(ps => ps.Add(p => p.SourceSlug, "primary"));
+
+            StringAssert.Contains(cut.Markup, "No connections registered");
+        }
+
+        [TestMethod]
+        public void ShowsErrorMessage_WhenLoadConnectionsThrows()
+        {
+            var sources = TwoSources();
+            var clients = RegisterDependenciesWithPerSourceClients(sources);
+            clients["primary"].GetConnectionsAsync()
+                .Returns<Task<List<ConnectionResponse>>>(_ => throw new InvalidOperationException("boom"));
+
+            var cut = Render<Home>(ps => ps.Add(p => p.SourceSlug, "primary"));
+
+            StringAssert.Contains(cut.Markup, "Failed to load connections: boom");
+
+            clients["primary"].GetConnectionsAsync().Returns(new List<ConnectionResponse>
+            {
+                new() { Id = Guid.NewGuid(), DisplayName = "Conn1", QueueCount = 1 }
+            });
+            cut.Find("button").Click();
+
+            StringAssert.Contains(cut.Markup, "Conn1");
+        }
+
+        [TestMethod]
+        public void NavigatesToConnection_WhenConnectionRowClicked()
+        {
+            var sources = TwoSources();
+            var clients = RegisterDependenciesWithPerSourceClients(sources);
+            var connectionId = Guid.NewGuid();
+            clients["primary"].GetConnectionsAsync().Returns(new List<ConnectionResponse>
+            {
+                new() { Id = connectionId, DisplayName = "Conn1", QueueCount = 1 }
+            });
+            var nav = Services.GetRequiredService<BunitNavigationManager>();
+
+            var cut = Render<Home>(ps => ps.Add(p => p.SourceSlug, "primary"));
+            cut.FindAll("tr")[1].Click();
+
+            StringAssert.EndsWith(nav.Uri, $"/source/primary/connections/{connectionId}");
+        }
+
+        [TestMethod]
+        public void SkipsReload_WhenSameSlugRenderedAgain()
+        {
+            var sources = TwoSources();
+            var clients = RegisterDependenciesWithPerSourceClients(sources);
+            clients["primary"].GetConnectionsAsync().Returns(new List<ConnectionResponse>());
+
+            var cut = Render<Home>(ps => ps.Add(p => p.SourceSlug, "primary"));
+            cut.Render(ps => ps.Add(p => p.SourceSlug, "primary"));
+
+            clients["primary"].Received(1).GetConnectionsAsync();
+        }
+
+        [TestMethod]
+        public void ShowsSourceUnreachable_WhenGroupUnhealthyWithNoConnectionsOrError()
+        {
+            var sources = TwoNamedSources("Alpha", "Beta");
+            var healthBySlug = new Dictionary<string, SourceHealthStatus>
+            {
+                ["alpha"] = SourceHealthStatus.Unhealthy,
+                ["beta"] = SourceHealthStatus.Healthy
+            };
+            var clients = RegisterDependenciesWithPerSourceClients(sources, healthBySlug);
+            clients["alpha"].GetConnectionsAsync().Returns((List<ConnectionResponse>)null!);
+            clients["beta"].GetConnectionsAsync().Returns(new List<ConnectionResponse>());
+
+            var cut = Render<Home>();
+
+            StringAssert.Contains(cut.Markup, "Source unreachable");
+
+            clients["alpha"].GetConnectionsAsync().Returns(new List<ConnectionResponse>
+            {
+                new() { Id = Guid.NewGuid(), DisplayName = "Recovered", QueueCount = 2 }
+            });
+            cut.Find("button").Click();
+
+            StringAssert.Contains(cut.Markup, "Recovered");
+        }
+
+        [TestMethod]
+        public void ShowsErrorMessage_WhenGroupLoadThrows()
+        {
+            var sources = TwoNamedSources("Alpha", "Beta");
+            var clients = RegisterDependenciesWithPerSourceClients(sources);
+            clients["alpha"].GetConnectionsAsync()
+                .Returns<Task<List<ConnectionResponse>>>(_ => throw new InvalidOperationException("group boom"));
+            clients["beta"].GetConnectionsAsync().Returns(new List<ConnectionResponse>());
+
+            var cut = Render<Home>();
+
+            StringAssert.Contains(cut.Markup, "group boom");
+        }
+
+        [TestMethod]
+        public void NavigatesToGroupConnection_WhenConnectionRowClicked()
+        {
+            var sources = TwoNamedSources("Alpha", "Beta");
+            var clients = RegisterDependenciesWithPerSourceClients(sources);
+            var connectionId = Guid.NewGuid();
+            clients["alpha"].GetConnectionsAsync().Returns(new List<ConnectionResponse>
+            {
+                new() { Id = connectionId, DisplayName = "Conn1", QueueCount = 1 }
+            });
+            clients["beta"].GetConnectionsAsync().Returns(new List<ConnectionResponse>());
+            var nav = Services.GetRequiredService<BunitNavigationManager>();
+
+            var cut = Render<Home>();
+            cut.Find("tbody tr").Click();
+
+            StringAssert.EndsWith(nav.Uri, $"/source/alpha/connections/{connectionId}");
+        }
+
+        [TestMethod]
+        public void RendersDefaultHealthIcon_WhenStatusUnknown()
+        {
+            var sources = new List<DashboardApiSourceConfig>
+            {
+                new() { Name = "Alpha", BaseUrl = "https://a" },
+                new() { Name = "Beta", BaseUrl = "https://b" }
+            };
+            var healthBySlug = new Dictionary<string, SourceHealthStatus>
+            {
+                ["alpha"] = SourceHealthStatus.Unknown
+            };
+            var clients = RegisterDependenciesWithPerSourceClients(sources, healthBySlug);
+            clients["alpha"].GetConnectionsAsync().Returns(new List<ConnectionResponse>());
+            clients["beta"].GetConnectionsAsync().Returns(new List<ConnectionResponse>());
+
+            var cut = Render<Home>();
+
+            StringAssert.Contains(cut.Markup, "Alpha");
+        }
+
+        private static List<DashboardApiSourceConfig> TwoSources() => new()
+        {
+            new() { Name = "Primary", BaseUrl = "https://a" },
+            new() { Name = "Secondary", BaseUrl = "https://b" }
+        };
+
+        private static List<DashboardApiSourceConfig> TwoNamedSources(string first, string second) => new()
+        {
+            new() { Name = first, BaseUrl = "https://a" },
+            new() { Name = second, BaseUrl = "https://b" }
+        };
+
+        /// <summary>
+        /// Like <see cref="RegisterDependencies"/>, but hands back a distinct
+        /// <see cref="IDashboardApiClient"/> substitute per source slug so tests
+        /// can drive per-source success/error/retry behavior independently, and
+        /// optionally override the per-source health status.
+        /// </summary>
+        private Dictionary<string, IDashboardApiClient> RegisterDependenciesWithPerSourceClients(
+            IReadOnlyList<DashboardApiSourceConfig> sources,
+            IReadOnlyDictionary<string, SourceHealthStatus>? healthBySlug = null)
+        {
+            var registry = Substitute.For<ISourceRegistry>();
+            registry.GetAll().Returns(sources);
+            foreach (var src in sources)
+                registry.GetBySlug(src.Slug).Returns(src);
+
+            var health = Substitute.For<ISourceHealthMonitor>();
+            foreach (var src in sources)
+            {
+                var status = healthBySlug != null && healthBySlug.TryGetValue(src.Slug, out var s)
+                    ? s
+                    : SourceHealthStatus.Healthy;
+                health.GetHealth(src.Slug).Returns(new SourceHealthState { Status = status });
+            }
+
+            var clients = new Dictionary<string, IDashboardApiClient>();
+            foreach (var src in sources)
+                clients[src.Slug] = Substitute.For<IDashboardApiClient>();
+
+            var multi = Substitute.For<IMultiSourceDashboardApiClient>();
+            multi.GetClientForSource(Arg.Any<string>()).Returns(call =>
+            {
+                var slug = call.Arg<string>();
+                if (clients.TryGetValue(slug, out var client))
+                    return client;
+                throw new KeyNotFoundException();
+            });
+
+            Services.AddSingleton(registry);
+            Services.AddSingleton(health);
+            Services.AddSingleton(multi);
+
+            return clients;
         }
 
         private void RegisterDependencies(IReadOnlyList<DashboardApiSourceConfig> sources)

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
@@ -1,4 +1,4 @@
-// ---------------------------------------------------------------------
+﻿// ---------------------------------------------------------------------
 //This file is part of DotNetWorkQueue
 //Copyright © 2015-2026 Brian Lehnen
 //
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Linq;
+using System.Threading.Tasks;
 using Bunit;
 using Bunit.TestDoubles;
 using DotNetWorkQueue.Dashboard.Ui.Components.Pages;
@@ -76,62 +77,62 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
         }
 
         [TestMethod]
-        public void SubmitButton_PostsCredentials_WhenBothFieldsFilled()
+        public async Task SubmitButton_PostsCredentials_WhenBothFieldsFilled()
         {
             Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
             var invocation = JSInterop.SetupVoid("dashboardSubmitLogin", "/auth/login", "alice", "s3cret");
 
             var cut = Render<Login>();
-            SetCredentials(cut, "alice", "s3cret");
+            await SetCredentials(cut, "alice", "s3cret");
             cut.Find("button").Click();
 
             Assert.HasCount(1, invocation.Invocations);
         }
 
         [TestMethod]
-        public void SubmitButton_DoesNothing_WhenCredentialsIncomplete()
+        public async Task SubmitButton_DoesNothing_WhenCredentialsIncomplete()
         {
             Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
             var invocation = JSInterop.SetupVoid("dashboardSubmitLogin", _ => true);
 
             var cut = Render<Login>();
-            SetCredentials(cut, "alice", "   ");
+            await SetCredentials(cut, "alice", "   ");
             cut.Find("button").Click();
 
             Assert.HasCount(0, invocation.Invocations);
         }
 
         [TestMethod]
-        public void EnterKey_SubmitsCredentials()
+        public async Task EnterKey_SubmitsCredentials()
         {
             Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
             var invocation = JSInterop.SetupVoid("dashboardSubmitLogin", "/auth/login", "bob", "hunter2");
 
             var cut = Render<Login>();
-            SetCredentials(cut, "bob", "hunter2");
+            await SetCredentials(cut, "bob", "hunter2");
             cut.FindAll("input")[0].KeyDown(new KeyboardEventArgs { Key = "Enter" });
 
             Assert.HasCount(1, invocation.Invocations);
         }
 
         [TestMethod]
-        public void NonEnterKey_DoesNotSubmit()
+        public async Task NonEnterKey_DoesNotSubmit()
         {
             Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
             var invocation = JSInterop.SetupVoid("dashboardSubmitLogin", _ => true);
 
             var cut = Render<Login>();
-            SetCredentials(cut, "bob", "hunter2");
+            await SetCredentials(cut, "bob", "hunter2");
             cut.FindAll("input")[0].KeyDown(new KeyboardEventArgs { Key = "a" });
 
             Assert.HasCount(0, invocation.Invocations);
         }
 
-        private static void SetCredentials(IRenderedComponent<Login> cut, string username, string password)
+        private static async Task SetCredentials(IRenderedComponent<Login> cut, string username, string password)
         {
             var fields = cut.FindComponents<MudTextField<string>>();
-            cut.InvokeAsync(() => fields[0].Instance.ValueChanged.InvokeAsync(username));
-            cut.InvokeAsync(() => fields[1].Instance.ValueChanged.InvokeAsync(password));
+            await cut.InvokeAsync(() => fields[0].Instance.ValueChanged.InvokeAsync(username));
+            await cut.InvokeAsync(() => fields[1].Instance.ValueChanged.InvokeAsync(password));
         }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
@@ -16,12 +16,15 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Linq;
 using Bunit;
 using Bunit.TestDoubles;
 using DotNetWorkQueue.Dashboard.Ui.Components.Pages;
 using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudBlazor;
 
 namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 {

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/LoginTests.cs
@@ -74,5 +74,64 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
 
             Assert.AreEqual(nav.BaseUri, nav.Uri);
         }
+
+        [TestMethod]
+        public void SubmitButton_PostsCredentials_WhenBothFieldsFilled()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+            var invocation = JSInterop.SetupVoid("dashboardSubmitLogin", "/auth/login", "alice", "s3cret");
+
+            var cut = Render<Login>();
+            SetCredentials(cut, "alice", "s3cret");
+            cut.Find("button").Click();
+
+            Assert.HasCount(1, invocation.Invocations);
+        }
+
+        [TestMethod]
+        public void SubmitButton_DoesNothing_WhenCredentialsIncomplete()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+            var invocation = JSInterop.SetupVoid("dashboardSubmitLogin", _ => true);
+
+            var cut = Render<Login>();
+            SetCredentials(cut, "alice", "   ");
+            cut.Find("button").Click();
+
+            Assert.HasCount(0, invocation.Invocations);
+        }
+
+        [TestMethod]
+        public void EnterKey_SubmitsCredentials()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+            var invocation = JSInterop.SetupVoid("dashboardSubmitLogin", "/auth/login", "bob", "hunter2");
+
+            var cut = Render<Login>();
+            SetCredentials(cut, "bob", "hunter2");
+            cut.FindAll("input")[0].KeyDown(new KeyboardEventArgs { Key = "Enter" });
+
+            Assert.HasCount(1, invocation.Invocations);
+        }
+
+        [TestMethod]
+        public void NonEnterKey_DoesNotSubmit()
+        {
+            Services.AddSingleton(new DashboardAuthConfig { IsEnabled = true });
+            var invocation = JSInterop.SetupVoid("dashboardSubmitLogin", _ => true);
+
+            var cut = Render<Login>();
+            SetCredentials(cut, "bob", "hunter2");
+            cut.FindAll("input")[0].KeyDown(new KeyboardEventArgs { Key = "a" });
+
+            Assert.HasCount(0, invocation.Invocations);
+        }
+
+        private static void SetCredentials(IRenderedComponent<Login> cut, string username, string password)
+        {
+            var fields = cut.FindComponents<MudTextField<string>>();
+            cut.InvokeAsync(() => fields[0].Instance.ValueChanged.InvokeAsync(username));
+            cut.InvokeAsync(() => fields[1].Instance.ValueChanged.InvokeAsync(password));
+        }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/QueueDetailTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/QueueDetailTests.cs
@@ -1,4 +1,4 @@
-// ---------------------------------------------------------------------
+﻿// ---------------------------------------------------------------------
 //This file is part of DotNetWorkQueue
 //Copyright © 2015-2026 Brian Lehnen
 //
@@ -29,6 +29,7 @@ using DotNetWorkQueue.Dashboard.Ui.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudBlazor;
 using NSubstitute;
 
 namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
@@ -257,6 +258,86 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
             var updatedDrawer = cut.FindComponent<MessageDetailDrawer>().Instance;
             Assert.IsFalse(updatedDrawer.Open);
             Assert.IsNull(updatedDrawer.MessageId);
+        }
+
+        [TestMethod]
+        public void ShowsSpinner_WhileInitialLoadIsInFlight()
+        {
+            var gate = new TaskCompletionSource<QueueStatusResponse?>();
+            var api = CreateDefaultApi();
+            api.GetQueueStatusAsync(Arg.Any<Guid>()).Returns(gate.Task);
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "mud-progress-circular");
+
+            gate.SetResult(new QueueStatusResponse { Waiting = 1 });
+            cut.WaitForAssertion(() => StringAssert.Contains(cut.Markup, "Waiting"));
+        }
+
+        [TestMethod]
+        public async Task TabChange_UpdatesActiveTab()
+        {
+            var api = CreateDefaultApi();
+
+            var cut = RenderPage(api);
+            var tabs = cut.FindComponent<MudTabs>();
+            await cut.InvokeAsync(() => tabs.Instance.ActivePanelIndexChanged.InvokeAsync(4));
+
+            Assert.AreEqual(4, GetActiveTab(cut));
+        }
+
+        [TestMethod]
+        public async Task RefreshCounts_ViaTabDataChanged_RefetchesStatusStaleAndConsumers()
+        {
+            var api = CreateDefaultApi();
+
+            var cut = RenderPage(api);
+            var drawer = cut.FindComponent<MessageDetailDrawer>();
+            await cut.InvokeAsync(() => drawer.Instance.OnDataChanged.InvokeAsync());
+
+            api.Received(2).GetQueueStatusAsync(TestQueueId);
+            api.Received(2).GetStaleMessagesAsync(TestQueueId, 60, 0, 1);
+            api.Received(2).GetConsumersAsync(TestQueueId);
+        }
+
+        [TestMethod]
+        public async Task RefreshCounts_SwallowsFailures_AndKeepsPriorValues()
+        {
+            var callCount = 0;
+            var api = CreateDefaultApi(waiting: 9);
+            api.GetQueueStatusAsync(Arg.Any<Guid>()).Returns<Task<QueueStatusResponse?>>(_ =>
+            {
+                callCount++;
+                if (callCount > 1) throw new InvalidOperationException("refresh boom");
+                return Task.FromResult<QueueStatusResponse?>(new QueueStatusResponse { Waiting = 9 });
+            });
+
+            var cut = RenderPage(api);
+            var drawer = cut.FindComponent<MessageDetailDrawer>();
+            await cut.InvokeAsync(() => drawer.Instance.OnDataChanged.InvokeAsync());
+
+            Assert.DoesNotContain("refresh boom", cut.Markup);
+            StringAssert.Contains(cut.Markup, "9");
+        }
+
+        [TestMethod]
+        public void ManualRefresh_SwallowsFailures_AndKeepsPriorValues()
+        {
+            var callCount = 0;
+            var api = CreateDefaultApi(waiting: 9);
+            api.GetQueueStatusAsync(Arg.Any<Guid>()).Returns<Task<QueueStatusResponse?>>(_ =>
+            {
+                callCount++;
+                if (callCount > 1) throw new InvalidOperationException("manual boom");
+                return Task.FromResult<QueueStatusResponse?>(new QueueStatusResponse { Waiting = 9 });
+            });
+
+            var cut = RenderPage(api);
+            cut.Find("button[aria-label='Refresh']").Click();
+
+            Assert.DoesNotContain("manual boom", cut.Markup);
+            StringAssert.Contains(cut.Markup, "9");
         }
 
         private static IDashboardApiClient CreateDefaultApi(long waiting = 0, long processing = 0, long error = 0, long total = 0)

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/QueueDetailTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/QueueDetailTests.cs
@@ -231,13 +231,13 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
         }
 
         [TestMethod]
-        public void OpenMessageDrawer_ViaMessagesTabCallback_OpensDrawerWithMessageId()
+        public async Task OpenMessageDrawer_ViaMessagesTabCallback_OpensDrawerWithMessageId()
         {
             var api = CreateDefaultApi();
             var cut = RenderPage(api);
 
             var messagesTab = cut.FindComponent<MessagesTab>();
-            cut.InvokeAsync(() => messagesTab.Instance.OnMessageSelected.InvokeAsync("msg-123"));
+            await cut.InvokeAsync(() => messagesTab.Instance.OnMessageSelected.InvokeAsync("msg-123"));
 
             var drawer = cut.FindComponent<MessageDetailDrawer>().Instance;
             Assert.IsTrue(drawer.Open);
@@ -245,15 +245,15 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
         }
 
         [TestMethod]
-        public void ClosingDrawer_ViaOpenChangedCallback_ClearsSelectedMessage()
+        public async Task ClosingDrawer_ViaOpenChangedCallback_ClearsSelectedMessage()
         {
             var api = CreateDefaultApi();
             var cut = RenderPage(api);
             var messagesTab = cut.FindComponent<MessagesTab>();
-            cut.InvokeAsync(() => messagesTab.Instance.OnMessageSelected.InvokeAsync("msg-123"));
+            await cut.InvokeAsync(() => messagesTab.Instance.OnMessageSelected.InvokeAsync("msg-123"));
 
             var drawer = cut.FindComponent<MessageDetailDrawer>();
-            cut.InvokeAsync(() => drawer.Instance.OpenChanged.InvokeAsync(false));
+            await cut.InvokeAsync(() => drawer.Instance.OpenChanged.InvokeAsync(false));
 
             var updatedDrawer = cut.FindComponent<MessageDetailDrawer>().Instance;
             Assert.IsFalse(updatedDrawer.Open);
@@ -296,9 +296,9 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
             var drawer = cut.FindComponent<MessageDetailDrawer>();
             await cut.InvokeAsync(() => drawer.Instance.OnDataChanged.InvokeAsync());
 
-            api.Received(2).GetQueueStatusAsync(TestQueueId);
-            api.Received(2).GetStaleMessagesAsync(TestQueueId, 60, 0, 1);
-            api.Received(2).GetConsumersAsync(TestQueueId);
+            await api.Received(2).GetQueueStatusAsync(TestQueueId);
+            await api.Received(2).GetStaleMessagesAsync(TestQueueId, 60, 0, 1);
+            await api.Received(2).GetConsumersAsync(TestQueueId);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/QueueDetailTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/QueueDetailTests.cs
@@ -212,7 +212,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
             var api = CreateDefaultApi();
             var cut = RenderPage(api);
 
-            cut.FindAll("div.mud-paper")[0].Click();
+            cut.FindAll(StatusCardSelector)[0].Click();
 
             api.Received().GetMessagesAsync(TestQueueId, 0, 25, 0);
             Assert.AreEqual(0, GetActiveTab(cut));
@@ -224,7 +224,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
             var api = CreateDefaultApi();
             var cut = RenderPage(api);
 
-            cut.FindAll("div.mud-paper")[2].Click();
+            cut.FindAll(StatusCardSelector)[2].Click();
 
             Assert.AreEqual(1, GetActiveTab(cut));
         }
@@ -312,9 +312,15 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
                 (nameof(QueueDetail.QueueId), TestQueueId));
         }
 
+        /// <summary>
+        /// The four clickable status cards. Plain "div.mud-paper" also matches the two
+        /// popover containers MudPopoverProvider renders ahead of the page content.
+        /// </summary>
+        private const string StatusCardSelector = "div.mud-paper.mud-elevation-2";
+
         private static int GetActiveTab(IRenderedComponent<IComponent> cut) =>
             (int)typeof(QueueDetail)
                 .GetField("_activeTab", BindingFlags.NonPublic | BindingFlags.Instance)!
-                .GetValue(cut.Instance)!;
+                .GetValue(cut.FindComponent<QueueDetail>().Instance)!;
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/QueueDetailTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Pages/QueueDetailTests.cs
@@ -1,0 +1,320 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Pages;
+using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Pages
+{
+    [TestClass]
+    public class QueueDetailTests : BunitTestBase
+    {
+        private const string SourceSlug = "acme";
+        private static readonly Guid TestQueueId = Guid.NewGuid();
+
+        [TestMethod]
+        public void LoadsQueueData_OnInitialRender()
+        {
+            var api = CreateDefaultApi(waiting: 1, processing: 2, error: 3, total: 6);
+
+            RenderPage(api);
+
+            api.Received(1).GetQueueStatusAsync(TestQueueId);
+            api.Received(1).GetQueueFeaturesAsync(TestQueueId);
+            api.Received(1).GetStaleMessagesAsync(TestQueueId, 60, 0, 1);
+            api.Received(1).GetConsumersAsync(TestQueueId);
+            api.Received(1).GetSettingsAsync();
+        }
+
+        [TestMethod]
+        public void RendersStatusCounts_AfterLoad()
+        {
+            var api = CreateDefaultApi(waiting: 1, processing: 2, error: 3, total: 6);
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "Waiting");
+            StringAssert.Contains(cut.Markup, "Processing");
+            StringAssert.Contains(cut.Markup, "Total");
+        }
+
+        [TestMethod]
+        public void RendersQueueName_FromQueryString()
+        {
+            var api = CreateDefaultApi();
+
+            var cut = RenderPage(api, queryString: "?conn=Acme%20Prod&connId=" + Guid.NewGuid() + "&queue=OrdersQueue");
+
+            StringAssert.Contains(cut.Markup, "OrdersQueue");
+            StringAssert.Contains(cut.Markup, "Acme Prod");
+        }
+
+        [TestMethod]
+        public void ResolvesQueueName_ViaConnectionLookup_WhenQueryStringMissing()
+        {
+            var api = CreateDefaultApi();
+            var connectionId = Guid.NewGuid();
+            api.GetConnectionsAsync().Returns(new List<ConnectionResponse>
+            {
+                new() { Id = connectionId, DisplayName = "Looked Up Conn", QueueCount = 1 }
+            });
+            api.GetQueuesAsync(connectionId).Returns(new List<QueueInfoResponse>
+            {
+                new() { Id = TestQueueId, QueueName = "LookedUpQueue" }
+            });
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "LookedUpQueue");
+            StringAssert.Contains(cut.Markup, "Looked Up Conn");
+        }
+
+        [TestMethod]
+        public void ShowsSourceError_WhenSourceNotFound()
+        {
+            var api = CreateDefaultApi();
+
+            var cut = RenderPage(api, sourceNotFound: true);
+
+            StringAssert.Contains(cut.Markup, "not found");
+        }
+
+        [TestMethod]
+        public void ShowsErrorAlert_WhenLoadThrows()
+        {
+            var api = CreateDefaultApi();
+            api.GetQueueStatusAsync(Arg.Any<Guid>())
+                .Returns<Task<QueueStatusResponse?>>(_ => throw new InvalidOperationException("load boom"));
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "load boom");
+            StringAssert.Contains(cut.Markup, "Retry");
+        }
+
+        [TestMethod]
+        public void RendersWithoutThrowing_WhenApiCallsAreUnconfigured()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+
+            var cut = RenderPage(api);
+
+            Assert.IsNotNull(cut.Markup);
+        }
+
+        // ---- Sections / tabs ----
+
+        [TestMethod]
+        public void RendersFeatureChips_ForEnabledFeatures()
+        {
+            var api = CreateDefaultApi();
+            api.GetQueueFeaturesAsync(Arg.Any<Guid>()).Returns(new QueueFeaturesResponse
+            {
+                EnablePriority = true,
+                EnableHeartBeat = true
+            });
+
+            var cut = RenderPage(api);
+
+            StringAssert.Contains(cut.Markup, "Priority");
+            StringAssert.Contains(cut.Markup, "HeartBeat");
+            Assert.DoesNotContain("Routing", cut.Markup);
+        }
+
+        [TestMethod]
+        public void OmitsFeatureChips_WhenFeaturesUnavailable()
+        {
+            var api = CreateDefaultApi();
+            api.GetQueueFeaturesAsync(Arg.Any<Guid>()).Returns((QueueFeaturesResponse?)null);
+
+            var cut = RenderPage(api);
+
+            Assert.DoesNotContain("Priority", cut.Markup);
+        }
+
+        [TestMethod]
+        public void IncludesSourceName_InBreadcrumbs_WhenMultipleSourcesConfigured()
+        {
+            var api = CreateDefaultApi();
+
+            var cut = RenderPage(api, extraSource: new DashboardApiSourceConfig { Name = "Other", BaseUrl = "http://other.example" });
+
+            StringAssert.Contains(cut.Markup, "Acme");
+        }
+
+        // ---- Actions ----
+
+        [TestMethod]
+        public void ClickingRefreshButton_ReloadsCountsOnly()
+        {
+            var api = CreateDefaultApi(waiting: 1, processing: 2, error: 3, total: 6);
+            var cut = RenderPage(api);
+
+            cut.Find("button[aria-label='Refresh']").Click();
+
+            api.Received(2).GetQueueStatusAsync(TestQueueId);
+            api.Received(2).GetStaleMessagesAsync(TestQueueId, 60, 0, 1);
+            api.Received(2).GetConsumersAsync(TestQueueId);
+            api.Received(1).GetQueueFeaturesAsync(TestQueueId);
+            api.Received(1).GetSettingsAsync();
+        }
+
+        [TestMethod]
+        public void ClickingRetryButton_AfterLoadFailure_RecoversAndRendersStatus()
+        {
+            var callCount = 0;
+            var api = CreateDefaultApi();
+            api.GetQueueStatusAsync(Arg.Any<Guid>()).Returns<Task<QueueStatusResponse?>>(_ =>
+            {
+                callCount++;
+                if (callCount == 1) throw new InvalidOperationException("first load boom");
+                return Task.FromResult<QueueStatusResponse?>(new QueueStatusResponse { Waiting = 5 });
+            });
+            var cut = RenderPage(api);
+            StringAssert.Contains(cut.Markup, "first load boom");
+
+            cut.Find("button").Click();
+
+            Assert.DoesNotContain("first load boom", cut.Markup);
+            StringAssert.Contains(cut.Markup, "Waiting");
+        }
+
+        [TestMethod]
+        public void ClickingWaitingCard_FiltersMessagesTab_ToWaitingStatus()
+        {
+            var api = CreateDefaultApi();
+            var cut = RenderPage(api);
+
+            cut.FindAll("div.mud-paper")[0].Click();
+
+            api.Received().GetMessagesAsync(TestQueueId, 0, 25, 0);
+            Assert.AreEqual(0, GetActiveTab(cut));
+        }
+
+        [TestMethod]
+        public void ClickingErrorCard_SwitchesActiveTabToErrors()
+        {
+            var api = CreateDefaultApi();
+            var cut = RenderPage(api);
+
+            cut.FindAll("div.mud-paper")[2].Click();
+
+            Assert.AreEqual(1, GetActiveTab(cut));
+        }
+
+        [TestMethod]
+        public void OpenMessageDrawer_ViaMessagesTabCallback_OpensDrawerWithMessageId()
+        {
+            var api = CreateDefaultApi();
+            var cut = RenderPage(api);
+
+            var messagesTab = cut.FindComponent<MessagesTab>();
+            cut.InvokeAsync(() => messagesTab.Instance.OnMessageSelected.InvokeAsync("msg-123"));
+
+            var drawer = cut.FindComponent<MessageDetailDrawer>().Instance;
+            Assert.IsTrue(drawer.Open);
+            Assert.AreEqual("msg-123", drawer.MessageId);
+        }
+
+        [TestMethod]
+        public void ClosingDrawer_ViaOpenChangedCallback_ClearsSelectedMessage()
+        {
+            var api = CreateDefaultApi();
+            var cut = RenderPage(api);
+            var messagesTab = cut.FindComponent<MessagesTab>();
+            cut.InvokeAsync(() => messagesTab.Instance.OnMessageSelected.InvokeAsync("msg-123"));
+
+            var drawer = cut.FindComponent<MessageDetailDrawer>();
+            cut.InvokeAsync(() => drawer.Instance.OpenChanged.InvokeAsync(false));
+
+            var updatedDrawer = cut.FindComponent<MessageDetailDrawer>().Instance;
+            Assert.IsFalse(updatedDrawer.Open);
+            Assert.IsNull(updatedDrawer.MessageId);
+        }
+
+        private static IDashboardApiClient CreateDefaultApi(long waiting = 0, long processing = 0, long error = 0, long total = 0)
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetQueueStatusAsync(Arg.Any<Guid>())
+                .Returns(new QueueStatusResponse { Waiting = waiting, Processing = processing, Error = error, Total = total });
+            api.GetQueueFeaturesAsync(Arg.Any<Guid>()).Returns(new QueueFeaturesResponse());
+            api.GetStaleMessagesAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(new PagedResponse<MessageResponse> { Items = new List<MessageResponse>(), TotalCount = 0 });
+            api.GetConsumersAsync(Arg.Any<Guid?>()).Returns(new List<ConsumerInfoResponse>());
+            api.GetSettingsAsync().Returns(new DashboardSettingsResponse { ReadOnly = false });
+            api.GetConnectionsAsync().Returns(new List<ConnectionResponse>());
+            return api;
+        }
+
+        private IRenderedComponent<IComponent> RenderPage(
+            IDashboardApiClient api,
+            bool sourceNotFound = false,
+            string? queryString = null,
+            DashboardApiSourceConfig? extraSource = null)
+        {
+            var multiSource = Substitute.For<IMultiSourceDashboardApiClient>();
+            if (sourceNotFound)
+            {
+                multiSource.GetClientForSource(Arg.Any<string>())
+                    .Returns<IDashboardApiClient>(_ => throw new KeyNotFoundException());
+            }
+            else
+            {
+                multiSource.GetClientForSource(SourceSlug).Returns(api);
+            }
+
+            var sourceConfig = new DashboardApiSourceConfig { Name = "Acme", BaseUrl = "http://acme.example" };
+            var sources = new List<DashboardApiSourceConfig> { sourceConfig };
+            if (extraSource != null) sources.Add(extraSource);
+
+            var sourceRegistry = Substitute.For<ISourceRegistry>();
+            sourceRegistry.GetAll().Returns(sources);
+            sourceRegistry.GetBySlug(SourceSlug).Returns(sourceConfig);
+
+            Services.AddSingleton(multiSource);
+            Services.AddSingleton(sourceRegistry);
+
+            if (queryString != null)
+            {
+                var nav = Services.GetRequiredService<NavigationManager>();
+                nav.NavigateTo($"http://localhost/source/{SourceSlug}/queues/{TestQueueId}{queryString}");
+            }
+
+            return RenderWithMudProvider<QueueDetail>(
+                (nameof(QueueDetail.SourceSlug), SourceSlug),
+                (nameof(QueueDetail.QueueId), TestQueueId));
+        }
+
+        private static int GetActiveTab(IRenderedComponent<IComponent> cut) =>
+            (int)typeof(QueueDetail)
+                .GetField("_activeTab", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(cut.Instance)!;
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/AutoRefreshTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/AutoRefreshTests.cs
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
+using Microsoft.AspNetCore.Components;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudBlazor;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
+{
+    [TestClass]
+    public class AutoRefreshTests : BunitTestBase
+    {
+        [TestMethod]
+        public void InitialRender_UsesDefaultIntervalSeconds()
+        {
+            var cut = RenderWithMudProvider<AutoRefresh>(
+                (nameof(AutoRefresh.DefaultIntervalSeconds), 30));
+
+            StringAssert.Contains(cut.Markup, "30s");
+        }
+
+        [TestMethod]
+        public void TogglingOn_StartsTimer()
+        {
+            var refreshCount = 0;
+            var callback = EventCallback.Factory.Create(this, () => refreshCount++);
+            var cut = RenderWithMudProvider<AutoRefresh>(
+                (nameof(AutoRefresh.OnRefresh), callback));
+
+            var toggle = cut.FindComponent<MudToggleIconButton>();
+            toggle.InvokeAsync(() => toggle.Instance.ToggledChanged.InvokeAsync(true));
+
+            Assert.AreEqual(0, refreshCount);
+        }
+
+        [TestMethod]
+        public void TogglingOff_StopsTimer()
+        {
+            var cut = RenderWithMudProvider<AutoRefresh>();
+
+            var toggle = cut.FindComponent<MudToggleIconButton>();
+            toggle.InvokeAsync(() => toggle.Instance.ToggledChanged.InvokeAsync(true));
+            toggle.InvokeAsync(() => toggle.Instance.ToggledChanged.InvokeAsync(false));
+
+            Assert.IsFalse(toggle.Instance.Toggled);
+        }
+
+        [TestMethod]
+        public void ChangingInterval_WhileEnabled_RestartsTimer()
+        {
+            var cut = RenderWithMudProvider<AutoRefresh>();
+
+            var toggle = cut.FindComponent<MudToggleIconButton>();
+            toggle.InvokeAsync(() => toggle.Instance.ToggledChanged.InvokeAsync(true));
+
+            var select = cut.FindComponent<MudSelect<int>>();
+            select.InvokeAsync(() => select.Instance.ValueChanged.InvokeAsync(60));
+
+            StringAssert.Contains(cut.Markup, "60s");
+        }
+
+        [TestMethod]
+        public void ChangingInterval_WhileDisabled_DoesNotStartTimer()
+        {
+            var cut = RenderWithMudProvider<AutoRefresh>();
+
+            var select = cut.FindComponent<MudSelect<int>>();
+            select.InvokeAsync(() => select.Instance.ValueChanged.InvokeAsync(60));
+
+            var toggle = cut.FindComponent<MudToggleIconButton>();
+            Assert.IsFalse(toggle.Instance.Toggled);
+        }
+
+        [TestMethod]
+        public void Dispose_CalledTwice_IsSafe()
+        {
+            var cut = RenderWithMudProvider<AutoRefresh>();
+
+            var toggle = cut.FindComponent<MudToggleIconButton>();
+            toggle.InvokeAsync(() => toggle.Instance.ToggledChanged.InvokeAsync(true));
+
+            var instance = cut.FindComponent<AutoRefresh>().Instance;
+            ((IDisposable)instance).Dispose();
+            ((IDisposable)instance).Dispose();
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/ConfigTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/ConfigTabTests.cs
@@ -1,0 +1,133 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Threading.Tasks;
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
+{
+    [TestClass]
+    public class ConfigTabTests : BunitTestBase
+    {
+        private static readonly Guid TestQueueId = Guid.NewGuid();
+
+        [TestMethod]
+        public void LoadsConfig_OnInitialization()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetQueueConfigurationAsync(TestQueueId).Returns(new ConfigurationResponse { ConfigurationJson = "{}" });
+
+            RenderConfigTab(api);
+
+            api.Received(1).GetQueueConfigurationAsync(TestQueueId);
+        }
+
+        [TestMethod]
+        public void RendersFormattedJson_WhenConfigurationPresent()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetQueueConfigurationAsync(TestQueueId).Returns(new ConfigurationResponse { ConfigurationJson = "{\"key\":\"value\"}" });
+
+            var cut = RenderConfigTab(api);
+
+            StringAssert.Contains(cut.Markup, "\"key\"");
+            StringAssert.Contains(cut.Markup, "\"value\"");
+        }
+
+        [TestMethod]
+        public void RendersPlaceholder_WhenConfigurationJsonMissing()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetQueueConfigurationAsync(TestQueueId).Returns(new ConfigurationResponse { ConfigurationJson = null });
+
+            var cut = RenderConfigTab(api);
+
+            StringAssert.Contains(cut.Markup, "(no configuration)");
+        }
+
+        [TestMethod]
+        public void RendersPlaceholder_WhenConfigResponseIsNull()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetQueueConfigurationAsync(TestQueueId).Returns((ConfigurationResponse?)null);
+
+            var cut = RenderConfigTab(api);
+
+            StringAssert.Contains(cut.Markup, "(no configuration)");
+        }
+
+        [TestMethod]
+        public void RendersRawJson_WhenConfigurationJsonIsMalformed()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetQueueConfigurationAsync(TestQueueId).Returns(new ConfigurationResponse { ConfigurationJson = "not-json" });
+
+            var cut = RenderConfigTab(api);
+
+            StringAssert.Contains(cut.Markup, "not-json");
+        }
+
+        [TestMethod]
+        public void ShowsErrorAlertAndRetryButton_WhenLoadFails()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetQueueConfigurationAsync(Arg.Any<Guid>())
+                .Returns<Task<ConfigurationResponse?>>(_ => throw new InvalidOperationException("config-load-failed"));
+
+            var cut = RenderConfigTab(api);
+
+            StringAssert.Contains(cut.Markup, "config-load-failed");
+            StringAssert.Contains(cut.Markup, "Retry");
+        }
+
+        [TestMethod]
+        public void Retry_ReloadsConfig_AfterFailure()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            var callCount = 0;
+            api.GetQueueConfigurationAsync(Arg.Any<Guid>()).Returns(_ =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    throw new InvalidOperationException("first-failure");
+                return Task.FromResult<ConfigurationResponse?>(new ConfigurationResponse { ConfigurationJson = "{}" });
+            });
+
+            var cut = RenderConfigTab(api);
+            StringAssert.Contains(cut.Markup, "first-failure");
+
+            var retryButton = cut.Find("button");
+            retryButton.Click();
+
+            api.Received(2).GetQueueConfigurationAsync(TestQueueId);
+        }
+
+        private IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> RenderConfigTab(IDashboardApiClient api)
+        {
+            return RenderWithMudProvider<ConfigTab>(
+                (nameof(ConfigTab.QueueId), TestQueueId),
+                (nameof(ConfigTab.Api), api));
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/ConsumersTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/ConsumersTabTests.cs
@@ -1,0 +1,155 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
+{
+    [TestClass]
+    public class ConsumersTabTests : BunitTestBase
+    {
+        private static readonly Guid TestQueueId = Guid.NewGuid();
+
+        [TestMethod]
+        public void LoadsConsumers_OnInitialization()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConsumersAsync(TestQueueId).Returns(new List<ConsumerInfoResponse>());
+
+            RenderConsumersTab(api);
+
+            api.Received(1).GetConsumersAsync(TestQueueId);
+        }
+
+        [TestMethod]
+        public void ShowsEmptyMessage_WhenNoConsumers()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConsumersAsync(TestQueueId).Returns(new List<ConsumerInfoResponse>());
+
+            var cut = RenderConsumersTab(api);
+
+            StringAssert.Contains(cut.Markup, "No consumers currently connected to this queue.");
+        }
+
+        [TestMethod]
+        public void RendersConsumerRow_WhenConsumersPresent()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConsumersAsync(TestQueueId).Returns(new List<ConsumerInfoResponse>
+            {
+                new()
+                {
+                    ConsumerId = Guid.NewGuid(),
+                    FriendlyName = "consumer-one",
+                    MachineName = "machine-a",
+                    ProcessId = 1234,
+                    RegisteredAt = DateTimeOffset.UtcNow.AddHours(-2),
+                    LastHeartbeat = DateTimeOffset.UtcNow,
+                    MessagesProcessed = 10,
+                    MessagesErrored = 1,
+                    MessagesRolledBack = 2,
+                    PoisonMessages = 0
+                }
+            });
+
+            var cut = RenderConsumersTab(api);
+
+            StringAssert.Contains(cut.Markup, "consumer-one");
+            StringAssert.Contains(cut.Markup, "machine-a");
+        }
+
+        [TestMethod]
+        public void RendersConsumerIdPrefix_WhenFriendlyNameMissing()
+        {
+            var consumerId = Guid.NewGuid();
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConsumersAsync(TestQueueId).Returns(new List<ConsumerInfoResponse>
+            {
+                new()
+                {
+                    ConsumerId = consumerId,
+                    FriendlyName = null,
+                    MachineName = "machine-b",
+                    ProcessId = 5678,
+                    RegisteredAt = DateTimeOffset.UtcNow,
+                    LastHeartbeat = DateTimeOffset.UtcNow,
+                    MessagesProcessed = 0,
+                    MessagesErrored = 0,
+                    MessagesRolledBack = 0,
+                    PoisonMessages = 0
+                }
+            });
+
+            var cut = RenderConsumersTab(api);
+
+            StringAssert.Contains(cut.Markup, consumerId.ToString("N")[..8]);
+        }
+
+        [TestMethod]
+        public void ShowsErrorAlertAndRetryButton_WhenLoadFails()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConsumersAsync(Arg.Any<Guid?>())
+                .Returns<Task<List<ConsumerInfoResponse>>>(_ => throw new InvalidOperationException("consumer-load-failed"));
+
+            var cut = RenderConsumersTab(api);
+
+            StringAssert.Contains(cut.Markup, "consumer-load-failed");
+            StringAssert.Contains(cut.Markup, "Retry");
+        }
+
+        [TestMethod]
+        public void Retry_ReloadsConsumers_AfterFailure()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            var callCount = 0;
+            api.GetConsumersAsync(Arg.Any<Guid?>()).Returns(_ =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    throw new InvalidOperationException("first-failure");
+                return Task.FromResult(new List<ConsumerInfoResponse>());
+            });
+
+            var cut = RenderConsumersTab(api);
+            StringAssert.Contains(cut.Markup, "first-failure");
+
+            var retryButton = cut.Find("button");
+            retryButton.Click();
+
+            StringAssert.Contains(cut.Markup, "No consumers currently connected to this queue.");
+            api.Received(2).GetConsumersAsync(TestQueueId);
+        }
+
+        private IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> RenderConsumersTab(IDashboardApiClient api)
+        {
+            return RenderWithMudProvider<ConsumersTab>(
+                (nameof(ConsumersTab.QueueId), TestQueueId),
+                (nameof(ConsumersTab.Api), api));
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/ConsumersTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/ConsumersTabTests.cs
@@ -145,6 +145,79 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             api.Received(2).GetConsumersAsync(TestQueueId);
         }
 
+        [TestMethod]
+        public void ShowsSpinner_WhileLoadIsInFlight()
+        {
+            var gate = new TaskCompletionSource<List<ConsumerInfoResponse>>();
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConsumersAsync(Arg.Any<Guid?>()).Returns(gate.Task);
+
+            var cut = RenderConsumersTab(api);
+
+            StringAssert.Contains(cut.Markup, "mud-progress-circular");
+
+            gate.SetResult(new List<ConsumerInfoResponse>());
+            cut.WaitForAssertion(() =>
+                StringAssert.Contains(cut.Markup, "No consumers currently connected to this queue."));
+        }
+
+        [TestMethod]
+        public void FormatsUptimeInDays_WhenConsumerRegisteredOverADayAgo()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConsumersAsync(TestQueueId).Returns(new List<ConsumerInfoResponse>
+            {
+                new()
+                {
+                    ConsumerId = Guid.NewGuid(),
+                    FriendlyName = "long-running",
+                    MachineName = "machine-c",
+                    RegisteredAt = DateTimeOffset.Now.AddDays(-2).AddHours(-3),
+                    LastHeartbeat = DateTimeOffset.UtcNow
+                }
+            });
+
+            var cut = RenderConsumersTab(api);
+
+            StringAssert.Contains(cut.Markup, "2d 3h");
+        }
+
+        [TestMethod]
+        public void FormatsUptimeInMinutes_WhenConsumerRegisteredRecently()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConsumersAsync(TestQueueId).Returns(new List<ConsumerInfoResponse>
+            {
+                new()
+                {
+                    ConsumerId = Guid.NewGuid(),
+                    FriendlyName = "just-started",
+                    MachineName = "machine-d",
+                    RegisteredAt = DateTimeOffset.Now.AddMinutes(-5),
+                    LastHeartbeat = DateTimeOffset.UtcNow
+                }
+            });
+
+            var cut = RenderConsumersTab(api);
+
+            StringAssert.Contains(cut.Markup, "5m");
+        }
+
+        [TestMethod]
+        public void RefreshVersionChange_ReloadsConsumers()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetConsumersAsync(TestQueueId).Returns(new List<ConsumerInfoResponse>());
+
+            var tab = RenderConsumersTab(api).FindComponent<ConsumersTab>();
+            tab.Render(ps => ps
+                .Add(p => p.QueueId, TestQueueId)
+                .Add(p => p.Api, api)
+                .Add(p => p.RefreshVersion, 1));
+
+            api.Received(2).GetConsumersAsync(TestQueueId);
+        }
+
         private IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> RenderConsumersTab(IDashboardApiClient api)
         {
             return RenderWithMudProvider<ConsumersTab>(

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/ErrorsTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/ErrorsTabTests.cs
@@ -1,0 +1,264 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudBlazor;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
+{
+    [TestClass]
+    public class ErrorsTabTests : BunitTestBase
+    {
+        private static readonly Guid TestQueueId = Guid.NewGuid();
+        private const string TestErrorMessageId = "err-msg-0001";
+
+        [TestMethod]
+        public void LoadsErrors_OnInitialization()
+        {
+            var api = CreateApiWithErrors();
+            var snackbar = Substitute.For<ISnackbar>();
+
+            RenderErrorsTab(api, snackbar);
+
+            api.Received(1).GetErrorsAsync(TestQueueId, 0, 25);
+        }
+
+        [TestMethod]
+        public void RendersRows_WhenErrorsPresent()
+        {
+            var api = CreateApiWithErrors();
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "boom-exception");
+        }
+
+        [TestMethod]
+        public void ShowsNoRecordsContent_WhenEmpty()
+        {
+            var api = CreateApiWithErrors(totalCount: 0, includeItem: false);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "No error messages.");
+        }
+
+        [TestMethod]
+        public void ShowsErrorAlert_WhenLoadErrorsThrows()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetErrorsAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns<Task<PagedResponse<ErrorMessageResponse>>>(_ => throw new InvalidOperationException("boom"));
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "boom");
+        }
+
+        [TestMethod]
+        public void HidesActionButtons_WhenReadOnly()
+        {
+            var api = CreateApiWithErrors(totalCount: 3);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar, readOnly: true);
+
+            Assert.DoesNotContain("Requeue", cut.Markup);
+            Assert.DoesNotContain("Delete All", cut.Markup);
+        }
+
+        [TestMethod]
+        public void ShowsActionButtons_WhenWritable()
+        {
+            var api = CreateApiWithErrors(totalCount: 3);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "Requeue All");
+            StringAssert.Contains(cut.Markup, "Delete All");
+            StringAssert.Contains(cut.Markup, "Requeue");
+            StringAssert.Contains(cut.Markup, "Delete");
+        }
+
+        [TestMethod]
+        public void RequeueMessage_Success_ShowsSuccessSnackbarAndReloads()
+        {
+            var api = CreateApiWithErrors();
+            api.RequeueMessageAsync(TestQueueId, TestErrorMessageId).Returns(true);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+            FindButton(cut, "Requeue").Click();
+
+            snackbar.Received(1).Add("Message requeued.", Severity.Success);
+            api.Received(2).GetErrorsAsync(TestQueueId, 0, 25);
+        }
+
+        [TestMethod]
+        public void RequeueMessage_Failure_ShowsErrorSnackbar()
+        {
+            var api = CreateApiWithErrors();
+            api.RequeueMessageAsync(TestQueueId, TestErrorMessageId).Returns(false);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+            FindButton(cut, "Requeue").Click();
+
+            snackbar.Received(1).Add("Failed to requeue.", Severity.Error);
+        }
+
+        [TestMethod]
+        public void DeleteMessage_Success_ShowsSuccessSnackbarAndReloads()
+        {
+            var api = CreateApiWithErrors();
+            api.DeleteMessageAsync(TestQueueId, TestErrorMessageId).Returns(true);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+            FindButton(cut, "Delete").Click();
+            FindButton(cut, "Confirm?").Click();
+
+            snackbar.Received(1).Add("Message deleted.", Severity.Success);
+            api.Received(2).GetErrorsAsync(TestQueueId, 0, 25);
+        }
+
+        [TestMethod]
+        public void DeleteMessage_Failure_ShowsErrorSnackbar()
+        {
+            var api = CreateApiWithErrors();
+            api.DeleteMessageAsync(TestQueueId, TestErrorMessageId).Returns(false);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+            FindButton(cut, "Delete").Click();
+            FindButton(cut, "Confirm?").Click();
+
+            snackbar.Received(1).Add("Failed to delete.", Severity.Error);
+        }
+
+        [TestMethod]
+        public void RequeueAllErrors_Success_ShowsSuccessSnackbarAndReloads()
+        {
+            var api = CreateApiWithErrors(totalCount: 3);
+            api.RequeueAllErrorsAsync(TestQueueId).Returns(new BulkActionResponse { Count = 3 });
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+            FindButton(cut, "Requeue All").Click();
+            FindButton(cut, "Click Again to Confirm").Click();
+
+            snackbar.Received(1).Add("Requeued 3 error(s).", Severity.Success);
+            api.Received(2).GetErrorsAsync(TestQueueId, 0, 25);
+        }
+
+        [TestMethod]
+        public void RequeueAllErrors_Failure_ShowsErrorSnackbar()
+        {
+            var api = CreateApiWithErrors(totalCount: 3);
+            api.RequeueAllErrorsAsync(TestQueueId)
+                .Returns<Task<BulkActionResponse>>(_ => throw new InvalidOperationException("requeue-all-boom"));
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+            FindButton(cut, "Requeue All").Click();
+            FindButton(cut, "Click Again to Confirm").Click();
+
+            snackbar.Received(1).Add("Failed: requeue-all-boom", Severity.Error);
+        }
+
+        [TestMethod]
+        public void DeleteAllErrors_Success_ShowsSuccessSnackbarAndReloads()
+        {
+            var api = CreateApiWithErrors(totalCount: 3);
+            api.DeleteAllErrorsAsync(TestQueueId).Returns(new DeleteAllResponse { Deleted = 3 });
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+            FindButton(cut, "Delete All").Click();
+            FindButton(cut, "Click Again to Confirm").Click();
+
+            snackbar.Received(1).Add("Deleted 3 error(s).", Severity.Success);
+            api.Received(2).GetErrorsAsync(TestQueueId, 0, 25);
+        }
+
+        [TestMethod]
+        public void DeleteAllErrors_Failure_ShowsErrorSnackbar()
+        {
+            var api = CreateApiWithErrors(totalCount: 3);
+            api.DeleteAllErrorsAsync(TestQueueId)
+                .Returns<Task<DeleteAllResponse>>(_ => throw new InvalidOperationException("delete-all-boom"));
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderErrorsTab(api, snackbar);
+            FindButton(cut, "Delete All").Click();
+            FindButton(cut, "Click Again to Confirm").Click();
+
+            snackbar.Received(1).Add("Failed: delete-all-boom", Severity.Error);
+        }
+
+        private static AngleSharp.Dom.IElement FindButton(IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> cut, string text)
+        {
+            return cut.FindAll("button").First(b => b.TextContent.Trim() == text);
+        }
+
+        private IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> RenderErrorsTab(IDashboardApiClient api, ISnackbar snackbar, bool readOnly = false)
+        {
+            return RenderWithMudProvider<ErrorsTab>(
+                (nameof(ErrorsTab.QueueId), TestQueueId),
+                (nameof(ErrorsTab.Api), api),
+                (nameof(ErrorsTab.Snackbar), snackbar),
+                (nameof(ErrorsTab.ReadOnly), readOnly));
+        }
+
+        private static IDashboardApiClient CreateApiWithErrors(long totalCount = 1, bool includeItem = true)
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            var items = includeItem
+                ? new List<ErrorMessageResponse>
+                {
+                    new()
+                    {
+                        QueueId = TestErrorMessageId,
+                        LastException = "boom-exception",
+                        LastExceptionDate = DateTimeOffset.UtcNow
+                    }
+                }
+                : new List<ErrorMessageResponse>();
+            api.GetErrorsAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(new PagedResponse<ErrorMessageResponse>
+                {
+                    Items = items,
+                    TotalCount = totalCount
+                });
+            return api;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
@@ -1,4 +1,4 @@
-// ---------------------------------------------------------------------
+﻿// ---------------------------------------------------------------------
 //This file is part of DotNetWorkQueue
 //Copyright © 2015-2026 Brian Lehnen
 //
@@ -201,7 +201,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             var select = cut.FindComponent<MudSelect<int?>>();
             await cut.InvokeAsync(() => select.Instance.ValueChanged.InvokeAsync(3));
 
-            api.Received(1).GetHistoryAsync(TestQueueId, 0, 25, 3);
+            await api.Received(1).GetHistoryAsync(TestQueueId, 0, 25, 3);
         }
 
         [TestMethod]
@@ -214,7 +214,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             var pagination = cut.FindComponent<MudPagination>();
             await cut.InvokeAsync(() => pagination.Instance.SelectedChanged.InvokeAsync(3));
 
-            api.Received(1).GetHistoryAsync(TestQueueId, 2, 25, null);
+            await api.Received(1).GetHistoryAsync(TestQueueId, 2, 25, null);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/HistoryTabTests.cs
@@ -117,6 +117,185 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             StringAssert.Contains(cut.Markup, "Expand exception");
         }
 
+        [TestMethod]
+        public void RendersNoRecordsContent_WhenEmpty()
+        {
+            var api = CreateApiWithRecords(totalCount: 0);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "No history records found.");
+        }
+
+        [TestMethod]
+        public void RendersRowValues_ForAllStatusesAndDurationRanges()
+        {
+            var api = CreateApiWithItems(new List<HistoryResponse>
+            {
+                Record("enq-0000000001", 0, durationMs: null),
+                Record("proc-000000001", 1, durationMs: 0),
+                Record("comp-000000001", 2, durationMs: 250),
+                Record("err-0000000001", 3, durationMs: 1500, retryCount: 2, route: "route-x", messageType: "Acme.Order"),
+                Record("del-0000000001", 4, durationMs: 120000),
+                Record("exp-0000000001", 5, durationMs: 59999),
+                Record("unk-0000000001", 9, durationMs: 999)
+            });
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "Enqueued");
+            StringAssert.Contains(cut.Markup, "Complete");
+            StringAssert.Contains(cut.Markup, "Expired");
+            StringAssert.Contains(cut.Markup, "Unknown");
+            StringAssert.Contains(cut.Markup, "&lt; 1 ms");
+            StringAssert.Contains(cut.Markup, "250ms");
+            StringAssert.Contains(cut.Markup, "1.5s");
+            StringAssert.Contains(cut.Markup, "2.0m");
+            StringAssert.Contains(cut.Markup, "route-x");
+            StringAssert.Contains(cut.Markup, "Acme.Order");
+            StringAssert.Contains(cut.Markup, "enq-00000000...");
+        }
+
+        [TestMethod]
+        public void RendersDash_WhenQueueIdMissing()
+        {
+            var api = CreateApiWithItems(new List<HistoryResponse>
+            {
+                new() { QueueId = null, Status = 2, EnqueuedUtc = DateTime.UtcNow }
+            });
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "-");
+        }
+
+        [TestMethod]
+        public void ExpandingRow_ShowsExceptionText_AndCollapsingHidesIt()
+        {
+            var api = CreateApiWithItems(new List<HistoryResponse>
+            {
+                Record("err-0000000001", 3, exceptionText: "SpecificErrorMarker")
+            });
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+            cut.Find("button[aria-label='Expand exception']").Click();
+
+            StringAssert.Contains(cut.Markup, "SpecificErrorMarker");
+
+            cut.Find("button[aria-label='Collapse exception']").Click();
+
+            Assert.DoesNotContain("SpecificErrorMarker", cut.Markup);
+        }
+
+        [TestMethod]
+        public async Task ChangingStatusFilter_RequeriesFromFirstPage()
+        {
+            var api = CreateApiWithRecords(totalCount: 1);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+            var select = cut.FindComponent<MudSelect<int?>>();
+            await cut.InvokeAsync(() => select.Instance.ValueChanged.InvokeAsync(3));
+
+            api.Received(1).GetHistoryAsync(TestQueueId, 0, 25, 3);
+        }
+
+        [TestMethod]
+        public async Task ChangingPage_RequeriesWithZeroBasedIndex()
+        {
+            var api = CreateApiWithRecords(totalCount: 60);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+            var pagination = cut.FindComponent<MudPagination>();
+            await cut.InvokeAsync(() => pagination.Instance.SelectedChanged.InvokeAsync(3));
+
+            api.Received(1).GetHistoryAsync(TestQueueId, 2, 25, null);
+        }
+
+        [TestMethod]
+        public void RefreshVersionChange_ReloadsHistory()
+        {
+            var api = CreateApiWithRecords();
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar).FindComponent<HistoryTab>();
+            cut.Render(ps => ps
+                .Add(p => p.QueueId, TestQueueId)
+                .Add(p => p.Api, api)
+                .Add(p => p.Snackbar, snackbar)
+                .Add(p => p.RefreshVersion, 1));
+
+            api.Received(2).GetHistoryAsync(TestQueueId, 0, 25, null);
+        }
+
+        [TestMethod]
+        public void PurgeHistory_RequiresConfirmation_ThenPurgesAndReloads()
+        {
+            var api = CreateApiWithRecords(totalCount: 3);
+            api.PurgeHistoryAsync(Arg.Any<Guid>(), Arg.Any<int?>()).Returns(new DeleteAllResponse { Deleted = 7 });
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+            cut.Find("button.mud-button-filled").Click();
+
+            api.DidNotReceive().PurgeHistoryAsync(Arg.Any<Guid>(), Arg.Any<int?>());
+            StringAssert.Contains(cut.Markup, "Click Again to Confirm");
+
+            cut.Find("button.mud-button-filled").Click();
+
+            api.Received(1).PurgeHistoryAsync(TestQueueId, 30);
+            snackbar.Received().Add("Purged 7 record(s).", Severity.Success, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+            api.Received(2).GetHistoryAsync(TestQueueId, 0, 25, null);
+        }
+
+        [TestMethod]
+        public void PurgeHistory_Failure_ShowsErrorSnackbar()
+        {
+            var api = CreateApiWithRecords(totalCount: 3);
+            api.PurgeHistoryAsync(Arg.Any<Guid>(), Arg.Any<int?>())
+                .Returns<Task<DeleteAllResponse>>(_ => throw new InvalidOperationException("purge boom"));
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderHistoryTab(api, snackbar);
+            cut.Find("button.mud-button-filled").Click();
+            cut.Find("button.mud-button-filled").Click();
+
+            snackbar.Received().Add("Failed: purge boom", Severity.Error, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+        }
+
+        private static HistoryResponse Record(
+            string queueId,
+            int status,
+            long? durationMs = null,
+            int retryCount = 0,
+            string? route = null,
+            string? messageType = null,
+            string? exceptionText = null) =>
+            new()
+            {
+                QueueId = queueId,
+                Status = status,
+                EnqueuedUtc = DateTime.UtcNow,
+                DurationMs = durationMs,
+                RetryCount = retryCount,
+                Route = route,
+                MessageType = messageType,
+                ExceptionText = exceptionText
+            };
+
+        private static IDashboardApiClient CreateApiWithItems(List<HistoryResponse> items)
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetHistoryAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int?>())
+                .Returns(new PagedResponse<HistoryResponse> { Items = items, TotalCount = items.Count });
+            return api;
+        }
+
         private IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> RenderHistoryTab(IDashboardApiClient api, ISnackbar snackbar, bool readOnly = false)
         {
             return RenderWithMudProvider<HistoryTab>(

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessageDetailDrawerTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessageDetailDrawerTests.cs
@@ -1,0 +1,605 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AngleSharp.Dom;
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudBlazor;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
+{
+    [TestClass]
+    public class MessageDetailDrawerTests : BunitTestBase
+    {
+        private static readonly Guid TestQueueId = Guid.NewGuid();
+        private const string TestMessageId = "msg-0001";
+
+        [TestMethod]
+        public void DoesNotLoad_WhenDrawerClosed()
+        {
+            var api = CreateApi();
+
+            RenderDrawer(api, open: false);
+
+            api.DidNotReceive().GetMessageDetailAsync(Arg.Any<Guid>(), Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public void DoesNotLoad_WhenMessageIdNull()
+        {
+            var api = CreateApi();
+
+            RenderDrawer(api, messageId: null);
+
+            api.DidNotReceive().GetMessageDetailAsync(Arg.Any<Guid>(), Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public void RendersMetadata_WhenMessageLoaded()
+        {
+            var api = CreateApi(message: new MessageResponse
+            {
+                QueueId = TestMessageId,
+                CorrelationId = "corr-99",
+                Status = 0,
+                Priority = 4,
+                QueuedDateTime = DateTimeOffset.UtcNow
+            });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, TestMessageId);
+            StringAssert.Contains(cut.Markup, "corr-99");
+            StringAssert.Contains(cut.Markup, "Waiting");
+            StringAssert.Contains(cut.Markup, "4");
+        }
+
+        [TestMethod]
+        public void RendersPlaceholders_WhenOptionalMetadataMissing()
+        {
+            var api = CreateApi(message: new MessageResponse { QueueId = TestMessageId, Status = 3 });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "Processed");
+            Assert.DoesNotContain("Process Time", cut.Markup);
+            Assert.DoesNotContain("Expires", cut.Markup);
+            Assert.DoesNotContain("Route", cut.Markup);
+        }
+
+        [TestMethod]
+        public void RendersOptionalMetadata_WhenPresent()
+        {
+            var api = CreateApi(message: new MessageResponse
+            {
+                QueueId = TestMessageId,
+                Status = 7,
+                QueueProcessTime = DateTimeOffset.UtcNow,
+                ExpirationTime = DateTimeOffset.UtcNow.AddHours(1),
+                Route = "route-a"
+            });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "Process Time");
+            StringAssert.Contains(cut.Markup, "Expires");
+            StringAssert.Contains(cut.Markup, "route-a");
+            StringAssert.Contains(cut.Markup, "Unknown");
+        }
+
+        [TestMethod]
+        public void ShowsDetailError_WhenDetailLoadThrows()
+        {
+            var api = CreateApi();
+            api.GetMessageDetailAsync(Arg.Any<Guid>(), Arg.Any<string>())
+                .Returns<Task<MessageResponse?>>(_ => throw new InvalidOperationException("detail boom"));
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "detail boom");
+        }
+
+        [TestMethod]
+        public void SwallowsFailures_FromBodyHeadersAndRetries()
+        {
+            var api = CreateApi();
+            api.GetMessageBodyAsync(Arg.Any<Guid>(), Arg.Any<string>())
+                .Returns<Task<MessageBodyResponse?>>(_ => throw new InvalidOperationException("body boom"));
+            api.GetMessageHeadersAsync(Arg.Any<Guid>(), Arg.Any<string>())
+                .Returns<Task<MessageHeadersResponse?>>(_ => throw new InvalidOperationException("headers boom"));
+            api.GetMessageRetriesAsync(Arg.Any<Guid>(), Arg.Any<string>())
+                .Returns<Task<List<ErrorRetryResponse>>>(_ => throw new InvalidOperationException("retries boom"));
+
+            var cut = RenderDrawer(api);
+
+            Assert.DoesNotContain("body boom", cut.Markup);
+            Assert.DoesNotContain("headers boom", cut.Markup);
+            Assert.DoesNotContain("retries boom", cut.Markup);
+            StringAssert.Contains(cut.Markup, "No headers.");
+        }
+
+        [TestMethod]
+        public void PrettyPrintsJsonBody()
+        {
+            var api = CreateApi(body: new MessageBodyResponse { Body = "{\"a\":1}" });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "\"a\": 1");
+        }
+
+        [TestMethod]
+        public void RendersBodyVerbatim_WhenNotValidJson()
+        {
+            var api = CreateApi(body: new MessageBodyResponse { Body = "not json at all" });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "not json at all");
+        }
+
+        [TestMethod]
+        public void RendersEmptyMarker_WhenBodyBlank()
+        {
+            var api = CreateApi(body: new MessageBodyResponse { Body = "   " });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "(empty)");
+        }
+
+        [TestMethod]
+        public void RendersBodyDecodingErrorAndTypeAndInterceptors()
+        {
+            var api = CreateApi(body: new MessageBodyResponse
+            {
+                Body = "{}",
+                DecodingError = "could not decode",
+                TypeName = "Acme.Order",
+                WasIntercepted = true,
+                InterceptorChain = new List<string> { "Gzip", "Aes" }
+            });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "could not decode");
+            StringAssert.Contains(cut.Markup, "Acme.Order");
+            StringAssert.Contains(cut.Markup, "Gzip &gt; Aes");
+        }
+
+        [TestMethod]
+        public void OmitsInterceptorChain_WhenNotIntercepted()
+        {
+            var api = CreateApi(body: new MessageBodyResponse
+            {
+                Body = "{}",
+                WasIntercepted = false,
+                InterceptorChain = new List<string> { "Gzip" }
+            });
+
+            var cut = RenderDrawer(api);
+
+            Assert.DoesNotContain("Interceptors:", cut.Markup);
+        }
+
+        [TestMethod]
+        public void RendersHeaderRows_WhenHeadersPresent()
+        {
+            var api = CreateApi(headers: new MessageHeadersResponse
+            {
+                Headers = new Dictionary<string, object> { ["trace-id"] = "abc123" }
+            });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "trace-id");
+            StringAssert.Contains(cut.Markup, "abc123");
+        }
+
+        [TestMethod]
+        public void RendersHeaderDecodingError_WhenNoHeadersButErrorPresent()
+        {
+            var api = CreateApi(headers: new MessageHeadersResponse { DecodingError = "bad headers" });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "bad headers");
+        }
+
+        [TestMethod]
+        public void RendersRetryRows_WhenRetriesPresent()
+        {
+            var api = CreateApi(retries: new List<ErrorRetryResponse>
+            {
+                new() { ExceptionType = "System.TimeoutException", RetryCount = 3 }
+            });
+
+            var cut = RenderDrawer(api);
+
+            StringAssert.Contains(cut.Markup, "System.TimeoutException");
+            StringAssert.Contains(cut.Markup, "Error Retries");
+        }
+
+        [TestMethod]
+        public void OmitsRetrySection_WhenNoRetries()
+        {
+            var api = CreateApi();
+
+            var cut = RenderDrawer(api);
+
+            Assert.DoesNotContain("Error Retries", cut.Markup);
+        }
+
+        [TestMethod]
+        public void HidesEditAndActions_WhenReadOnly()
+        {
+            var api = CreateApi(message: WaitingMessage());
+
+            var cut = RenderDrawer(api, readOnly: true);
+
+            Assert.DoesNotContain("Edit Body", cut.Markup);
+            Assert.DoesNotContain("Delete", cut.Markup);
+        }
+
+        [TestMethod]
+        public void HidesEditButton_WhenStatusNotEditable()
+        {
+            var api = CreateApi(message: new MessageResponse { QueueId = TestMessageId, Status = 3 });
+
+            var cut = RenderDrawer(api);
+
+            Assert.DoesNotContain("Edit Body", cut.Markup);
+        }
+
+        [TestMethod]
+        public void StartEdit_ShowsEditorPrefilledWithFormattedBody()
+        {
+            var api = CreateApi(message: WaitingMessage(), body: new MessageBodyResponse { Body = "{\"a\":1}" });
+
+            var cut = RenderDrawer(api);
+            ClickButton(cut, "Edit Body");
+
+            var field = cut.FindComponent<MudTextField<string>>();
+            StringAssert.Contains(field.Instance.Value, "\"a\": 1");
+            StringAssert.Contains(cut.Markup, "Cancel");
+        }
+
+        [TestMethod]
+        public void CancelEdit_HidesEditor()
+        {
+            var api = CreateApi(message: WaitingMessage());
+
+            var cut = RenderDrawer(api);
+            ClickButton(cut, "Edit Body");
+            ClickButton(cut, "Cancel");
+
+            Assert.HasCount(0, cut.FindComponents<MudTextField<string>>());
+            StringAssert.Contains(cut.Markup, "Edit Body");
+        }
+
+        [TestMethod]
+        public async Task SaveBody_DoesNothing_WhenEditorBlank()
+        {
+            var api = CreateApi(message: WaitingMessage(), body: new MessageBodyResponse { Body = "{\"a\":1}" });
+
+            var cut = RenderDrawer(api);
+            ClickButton(cut, "Edit Body");
+            var field = cut.FindComponent<MudTextField<string>>();
+            await cut.InvokeAsync(() => field.Instance.ValueChanged.InvokeAsync("   "));
+            ClickButton(cut, "Save");
+
+            api.DidNotReceive().UpdateMessageBodyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<EditMessageBodyRequest>());
+        }
+
+        [TestMethod]
+        public void SaveBody_Success_ClosesEditorAndReloadsBody()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: WaitingMessage(), body: new MessageBodyResponse { Body = "{\"a\":1}" });
+            api.UpdateMessageBodyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<EditMessageBodyRequest>()).Returns(true);
+
+            var cut = RenderDrawer(api, snackbar: snackbar);
+            ClickButton(cut, "Edit Body");
+            ClickButton(cut, "Save");
+
+            snackbar.Received().Add("Body updated.", Severity.Success, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+            api.Received(2).GetMessageBodyAsync(TestQueueId, TestMessageId);
+            StringAssert.Contains(cut.Markup, "Edit Body");
+        }
+
+        [TestMethod]
+        public void SaveBody_Failure_ShowsErrorSnackbar()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: WaitingMessage(), body: new MessageBodyResponse { Body = "{\"a\":1}" });
+            api.UpdateMessageBodyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<EditMessageBodyRequest>()).Returns(false);
+
+            var cut = RenderDrawer(api, snackbar: snackbar);
+            ClickButton(cut, "Edit Body");
+            ClickButton(cut, "Save");
+
+            snackbar.Received().Add(
+                "Failed to update. Message may be processing or JSON invalid.",
+                Severity.Error, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public void SaveBody_Throws_ShowsExceptionSnackbar()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: WaitingMessage(), body: new MessageBodyResponse { Body = "{\"a\":1}" });
+            api.UpdateMessageBodyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<EditMessageBodyRequest>())
+                .Returns<Task<bool>>(_ => throw new InvalidOperationException("save boom"));
+
+            var cut = RenderDrawer(api, snackbar: snackbar);
+            ClickButton(cut, "Edit Body");
+            ClickButton(cut, "Save");
+
+            snackbar.Received().Add("Error: save boom", Severity.Error, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public void Delete_RequiresConfirmationClick()
+        {
+            var api = CreateApi(message: WaitingMessage());
+
+            var cut = RenderDrawer(api);
+            ClickButton(cut, "Delete");
+
+            api.DidNotReceive().DeleteMessageAsync(Arg.Any<Guid>(), Arg.Any<string>());
+            StringAssert.Contains(cut.Markup, "Click to Confirm");
+        }
+
+        [TestMethod]
+        public void Delete_Confirmed_NotifiesAndClosesDrawer()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: WaitingMessage());
+            api.DeleteMessageAsync(Arg.Any<Guid>(), Arg.Any<string>()).Returns(true);
+            var dataChanged = false;
+            bool? openChanged = null;
+
+            var cut = RenderDrawer(api, snackbar: snackbar,
+                onDataChanged: () => dataChanged = true,
+                onOpenChanged: v => openChanged = v);
+            ClickButton(cut, "Delete");
+            ClickButton(cut, "Click to Confirm");
+
+            api.Received(1).DeleteMessageAsync(TestQueueId, TestMessageId);
+            Assert.IsTrue(dataChanged);
+            Assert.AreEqual(false, openChanged);
+        }
+
+        [TestMethod]
+        public void Delete_Failure_ShowsErrorSnackbar()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: WaitingMessage());
+            api.DeleteMessageAsync(Arg.Any<Guid>(), Arg.Any<string>()).Returns(false);
+
+            var cut = RenderDrawer(api, snackbar: snackbar);
+            ClickButton(cut, "Delete");
+            ClickButton(cut, "Click to Confirm");
+
+            snackbar.Received().Add("Failed to delete.", Severity.Error, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public void Requeue_Success_ReloadsMessage()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: ErrorMessage());
+            api.RequeueMessageAsync(Arg.Any<Guid>(), Arg.Any<string>()).Returns(true);
+            var dataChanged = false;
+
+            var cut = RenderDrawer(api, snackbar: snackbar, onDataChanged: () => dataChanged = true);
+            ClickButton(cut, "Requeue");
+
+            Assert.IsTrue(dataChanged);
+            api.Received(2).GetMessageDetailAsync(TestQueueId, TestMessageId);
+        }
+
+        [TestMethod]
+        public void Requeue_Failure_ShowsErrorSnackbar()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: ErrorMessage());
+            api.RequeueMessageAsync(Arg.Any<Guid>(), Arg.Any<string>()).Returns(false);
+
+            var cut = RenderDrawer(api, snackbar: snackbar);
+            ClickButton(cut, "Requeue");
+
+            snackbar.Received().Add("Failed to requeue.", Severity.Error, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public void Reset_Success_ReloadsMessage()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: ProcessingMessage());
+            api.ResetMessageAsync(Arg.Any<Guid>(), Arg.Any<string>()).Returns(true);
+            var dataChanged = false;
+
+            var cut = RenderDrawer(api, snackbar: snackbar, onDataChanged: () => dataChanged = true);
+            ClickButton(cut, "Reset");
+
+            Assert.IsTrue(dataChanged);
+            api.Received(2).GetMessageDetailAsync(TestQueueId, TestMessageId);
+        }
+
+        [TestMethod]
+        public void Reset_Failure_ShowsErrorSnackbar()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: ProcessingMessage());
+            api.ResetMessageAsync(Arg.Any<Guid>(), Arg.Any<string>()).Returns(false);
+
+            var cut = RenderDrawer(api, snackbar: snackbar);
+            ClickButton(cut, "Reset");
+
+            snackbar.Received().Add("Failed to reset.", Severity.Error, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public void Cancel_Success_MarksRequestedAndIgnoresSecondClick()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: ProcessingMessage());
+            api.CancelMessageAsync(Arg.Any<Guid>(), Arg.Any<string>()).Returns(true);
+
+            var cut = RenderDrawer(api, snackbar: snackbar);
+            ClickButton(cut, "Cancel");
+            StringAssert.Contains(cut.Markup, "Requested");
+
+            ClickButton(cut, "Requested");
+
+            api.Received(1).CancelMessageAsync(TestQueueId, TestMessageId);
+        }
+
+        [TestMethod]
+        public void Cancel_Failure_ShowsWarningSnackbar()
+        {
+            var snackbar = Substitute.For<ISnackbar>();
+            var api = CreateApi(message: ProcessingMessage());
+            api.CancelMessageAsync(Arg.Any<Guid>(), Arg.Any<string>()).Returns(false);
+
+            var cut = RenderDrawer(api, snackbar: snackbar);
+            ClickButton(cut, "Cancel");
+
+            snackbar.Received().Add(
+                "Could not cancel — message may not be processing or no consumer is in-process.",
+                Severity.Warning, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+            Assert.DoesNotContain("Requested", cut.Markup);
+        }
+
+        [TestMethod]
+        public void CloseButton_RaisesOpenChangedFalse()
+        {
+            var api = CreateApi(message: WaitingMessage());
+            bool? openChanged = null;
+
+            var cut = RenderDrawer(api, onOpenChanged: v => openChanged = v);
+            cut.FindAll("button")[0].Click();
+
+            Assert.AreEqual(false, openChanged);
+        }
+
+        [TestMethod]
+        public void ReopeningWithSameMessageId_DoesNotReload()
+        {
+            var api = CreateApi(message: WaitingMessage());
+
+            var cut = RenderDrawer(api);
+            cut.Render(ps => ps
+                .Add(p => p.QueueId, TestQueueId)
+                .Add(p => p.MessageId, TestMessageId)
+                .Add(p => p.Open, true)
+                .Add(p => p.Api, api)
+                .Add(p => p.Snackbar, Substitute.For<ISnackbar>()));
+
+            api.Received(1).GetMessageDetailAsync(TestQueueId, TestMessageId);
+        }
+
+        [TestMethod]
+        public void ClosingDrawer_ClearsLoadedIdSoReopenReloads()
+        {
+            var api = CreateApi(message: WaitingMessage());
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderDrawer(api, snackbar: snackbar);
+            cut.Render(ps => ps
+                .Add(p => p.QueueId, TestQueueId)
+                .Add(p => p.MessageId, TestMessageId)
+                .Add(p => p.Open, false)
+                .Add(p => p.Api, api)
+                .Add(p => p.Snackbar, snackbar));
+            cut.Render(ps => ps
+                .Add(p => p.QueueId, TestQueueId)
+                .Add(p => p.MessageId, TestMessageId)
+                .Add(p => p.Open, true)
+                .Add(p => p.Api, api)
+                .Add(p => p.Snackbar, snackbar));
+
+            api.Received(2).GetMessageDetailAsync(TestQueueId, TestMessageId);
+        }
+
+        private static MessageResponse WaitingMessage() =>
+            new() { QueueId = TestMessageId, Status = 0 };
+
+        private static MessageResponse ProcessingMessage() =>
+            new() { QueueId = TestMessageId, Status = 1 };
+
+        private static MessageResponse ErrorMessage() =>
+            new() { QueueId = TestMessageId, Status = 2 };
+
+        private static void ClickButton(IRenderedComponent<MessageDetailDrawer> cut, string text)
+        {
+            var button = cut.FindAll("button")
+                .First(b => b.TextContent.Contains(text, StringComparison.Ordinal));
+            button.Click();
+        }
+
+        private static IDashboardApiClient CreateApi(
+            MessageResponse? message = null,
+            MessageBodyResponse? body = null,
+            MessageHeadersResponse? headers = null,
+            List<ErrorRetryResponse>? retries = null)
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetMessageDetailAsync(Arg.Any<Guid>(), Arg.Any<string>())
+                .Returns(message ?? new MessageResponse { QueueId = TestMessageId, Status = 0 });
+            api.GetMessageBodyAsync(Arg.Any<Guid>(), Arg.Any<string>())
+                .Returns(body ?? new MessageBodyResponse { Body = "{}" });
+            api.GetMessageHeadersAsync(Arg.Any<Guid>(), Arg.Any<string>())
+                .Returns(headers ?? new MessageHeadersResponse());
+            api.GetMessageRetriesAsync(Arg.Any<Guid>(), Arg.Any<string>())
+                .Returns(retries ?? new List<ErrorRetryResponse>());
+            return api;
+        }
+
+        private IRenderedComponent<MessageDetailDrawer> RenderDrawer(
+            IDashboardApiClient api,
+            bool open = true,
+            string? messageId = TestMessageId,
+            bool readOnly = false,
+            ISnackbar? snackbar = null,
+            Action? onDataChanged = null,
+            Action<bool>? onOpenChanged = null)
+        {
+            return Render<MessageDetailDrawer>(ps =>
+            {
+                ps.Add(p => p.QueueId, TestQueueId)
+                  .Add(p => p.MessageId, messageId)
+                  .Add(p => p.Open, open)
+                  .Add(p => p.ReadOnly, readOnly)
+                  .Add(p => p.Api, api)
+                  .Add(p => p.Snackbar, snackbar ?? Substitute.For<ISnackbar>());
+                if (onDataChanged != null) ps.Add(p => p.OnDataChanged, onDataChanged);
+                if (onOpenChanged != null) ps.Add(p => p.OpenChanged, onOpenChanged);
+            });
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessageDetailDrawerTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessageDetailDrawerTests.cs
@@ -1,4 +1,4 @@
-// ---------------------------------------------------------------------
+﻿// ---------------------------------------------------------------------
 //This file is part of DotNetWorkQueue
 //Copyright © 2015-2026 Brian Lehnen
 //
@@ -282,8 +282,9 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             var cut = RenderDrawer(api);
             ClickButton(cut, "Edit Body");
 
-            var field = cut.FindComponent<MudTextField<string>>();
-            StringAssert.Contains(field.Instance.Value, "\"a\": 1");
+            // Read the editor's rendered content rather than MudTextField.Value, which the
+            // MudBlazor analyzer (MUD0012) forbids reading from outside the component.
+            StringAssert.Contains(cut.Find("textarea").TextContent, "\"a\": 1");
             StringAssert.Contains(cut.Markup, "Cancel");
         }
 
@@ -311,7 +312,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             await cut.InvokeAsync(() => field.Instance.ValueChanged.InvokeAsync("   "));
             ClickButton(cut, "Save");
 
-            api.DidNotReceive().UpdateMessageBodyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<EditMessageBodyRequest>());
+            await api.DidNotReceive().UpdateMessageBodyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<EditMessageBodyRequest>());
         }
 
         [TestMethod]
@@ -390,7 +391,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
 
             api.Received(1).DeleteMessageAsync(TestQueueId, TestMessageId);
             Assert.IsTrue(dataChanged);
-            Assert.AreEqual(false, openChanged);
+            Assert.IsNotNull(openChanged);
+            Assert.IsFalse(openChanged.Value);
         }
 
         [TestMethod]
@@ -504,7 +506,8 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             var cut = RenderDrawer(api, onOpenChanged: v => openChanged = v);
             cut.FindAll("button")[0].Click();
 
-            Assert.AreEqual(false, openChanged);
+            Assert.IsNotNull(openChanged);
+            Assert.IsFalse(openChanged.Value);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessagesTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessagesTabTests.cs
@@ -83,7 +83,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
 
             var cut = RenderMessagesTab(api);
             var select = cut.FindComponent<MudSelect<int?>>();
-            await cut.InvokeAsync(async () => await select.Instance.SelectOption(2));
+            await cut.InvokeAsync(() => select.Instance.ValueChanged.InvokeAsync(2));
 
             api.Received(1).GetMessagesAsync(TestQueueId, 0, 25, 2);
         }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessagesTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessagesTabTests.cs
@@ -23,6 +23,8 @@ using Bunit;
 using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
 using DotNetWorkQueue.Dashboard.Ui.Models;
 using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudBlazor;
 using NSubstitute;
@@ -84,6 +86,134 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             var cut = RenderMessagesTab(api);
             var select = cut.FindComponent<MudSelect<int?>>();
             await cut.InvokeAsync(() => select.Instance.ValueChanged.InvokeAsync(2));
+
+            api.Received(1).GetMessagesAsync(TestQueueId, 0, 25, 2);
+        }
+
+        [TestMethod]
+        public void TruncatesLongQueueId_AndRendersDashWhenMissing()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetMessagesAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int?>())
+                .Returns(new PagedResponse<MessageResponse>
+                {
+                    Items = new List<MessageResponse>
+                    {
+                        new() { QueueId = "0123456789abcdef", Status = 1, QueuedDateTime = DateTimeOffset.UtcNow },
+                        new() { QueueId = null, Status = 3 }
+                    },
+                    TotalCount = 2
+                });
+
+            var cut = RenderMessagesTab(api);
+
+            StringAssert.Contains(cut.Markup, "0123456789ab...");
+            StringAssert.Contains(cut.Markup, "Processing");
+            StringAssert.Contains(cut.Markup, "Processed");
+        }
+
+        [TestMethod]
+        public void RendersDelayedChip_ForFutureScheduledWaitingMessage()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetMessagesAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int?>())
+                .Returns(new PagedResponse<MessageResponse>
+                {
+                    Items = new List<MessageResponse>
+                    {
+                        new()
+                        {
+                            QueueId = "delayed-1",
+                            Status = 0,
+                            QueuedDateTime = DateTimeOffset.UtcNow,
+                            QueueProcessTime = DateTimeOffset.Now.AddHours(1)
+                        }
+                    },
+                    TotalCount = 1
+                });
+
+            var cut = RenderWithMudProvider<MessagesTab>(
+                (nameof(MessagesTab.QueueId), TestQueueId),
+                (nameof(MessagesTab.Api), api),
+                (nameof(MessagesTab.Features), new QueueFeaturesResponse { EnableDelayedProcessing = true }));
+
+            StringAssert.Contains(cut.Markup, "Delayed");
+            StringAssert.Contains(cut.Markup, "Scheduled");
+        }
+
+        [TestMethod]
+        public async Task ChangingPage_RequeriesWithZeroBasedIndex()
+        {
+            var api = CreateApiWithMessages(totalCount: 60);
+
+            var cut = RenderMessagesTab(api);
+            var pagination = cut.FindComponent<MudPagination>();
+            await cut.InvokeAsync(() => pagination.Instance.SelectedChanged.InvokeAsync(3));
+
+            api.Received(1).GetMessagesAsync(TestQueueId, 2, 25, null);
+        }
+
+        [TestMethod]
+        public async Task RowClick_RaisesOnMessageSelected_WithQueueId()
+        {
+            var api = CreateApiWithMessages();
+            string? selected = null;
+
+            var cut = RenderWithMudProvider<MessagesTab>(
+                (nameof(MessagesTab.QueueId), TestQueueId),
+                (nameof(MessagesTab.Api), api),
+                (nameof(MessagesTab.OnMessageSelected), EventCallback.Factory.Create<string>(this, s => selected = s)));
+
+            var table = cut.FindComponent<MudTable<MessageResponse>>();
+            await cut.InvokeAsync(() => table.Instance.OnRowClick.InvokeAsync(
+                new TableRowClickEventArgs<MessageResponse>(new MouseEventArgs(), null!, new MessageResponse { QueueId = "abc-123" })));
+
+            Assert.AreEqual("abc-123", selected);
+        }
+
+        [TestMethod]
+        public async Task RowClick_Ignored_WhenMessageHasNoQueueId()
+        {
+            var api = CreateApiWithMessages();
+            string? selected = null;
+
+            var cut = RenderWithMudProvider<MessagesTab>(
+                (nameof(MessagesTab.QueueId), TestQueueId),
+                (nameof(MessagesTab.Api), api),
+                (nameof(MessagesTab.OnMessageSelected), EventCallback.Factory.Create<string>(this, s => selected = s)));
+
+            var table = cut.FindComponent<MudTable<MessageResponse>>();
+            await cut.InvokeAsync(() => table.Instance.OnRowClick.InvokeAsync(
+                new TableRowClickEventArgs<MessageResponse>(new MouseEventArgs(), null!, new MessageResponse())));
+
+            Assert.IsNull(selected);
+        }
+
+        [TestMethod]
+        public void RefreshVersionChange_ReloadsMessages()
+        {
+            var api = CreateApiWithMessages();
+
+            var tab = RenderMessagesTab(api).FindComponent<MessagesTab>();
+            tab.Render(ps => ps
+                .Add(p => p.QueueId, TestQueueId)
+                .Add(p => p.Api, api)
+                .Add(p => p.RefreshVersion, 1));
+
+            api.Received(2).GetMessagesAsync(TestQueueId, 0, 25, null);
+        }
+
+        [TestMethod]
+        public void StatusFilterVersionChange_AppliesNewFilterFromFirstPage()
+        {
+            var api = CreateApiWithMessages();
+
+            var tab = RenderMessagesTab(api).FindComponent<MessagesTab>();
+            tab.Render(ps => ps
+                .Add(p => p.QueueId, TestQueueId)
+                .Add(p => p.Api, api)
+                .Add(p => p.StatusFilter, 2)
+                .Add(p => p.StatusFilterVersion, 1));
 
             api.Received(1).GetMessagesAsync(TestQueueId, 0, 25, 2);
         }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessagesTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessagesTabTests.cs
@@ -1,4 +1,4 @@
-// ---------------------------------------------------------------------
+﻿// ---------------------------------------------------------------------
 //This file is part of DotNetWorkQueue
 //Copyright © 2015-2026 Brian Lehnen
 //
@@ -87,7 +87,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             var select = cut.FindComponent<MudSelect<int?>>();
             await cut.InvokeAsync(() => select.Instance.ValueChanged.InvokeAsync(2));
 
-            api.Received(1).GetMessagesAsync(TestQueueId, 0, 25, 2);
+            await api.Received(1).GetMessagesAsync(TestQueueId, 0, 25, 2);
         }
 
         [TestMethod]
@@ -150,7 +150,7 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
             var pagination = cut.FindComponent<MudPagination>();
             await cut.InvokeAsync(() => pagination.Instance.SelectedChanged.InvokeAsync(3));
 
-            api.Received(1).GetMessagesAsync(TestQueueId, 2, 25, null);
+            await api.Received(1).GetMessagesAsync(TestQueueId, 2, 25, null);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessagesTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/MessagesTabTests.cs
@@ -1,0 +1,121 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudBlazor;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
+{
+    [TestClass]
+    public class MessagesTabTests : BunitTestBase
+    {
+        private static readonly Guid TestQueueId = Guid.NewGuid();
+
+        [TestMethod]
+        public void LoadsMessages_OnInitialization_WithUnfilteredStatus()
+        {
+            var api = CreateApiWithMessages();
+
+            RenderMessagesTab(api);
+
+            api.Received(1).GetMessagesAsync(TestQueueId, 0, 25, null);
+        }
+
+        [TestMethod]
+        public void RendersRows_WhenMessagesPresent()
+        {
+            var api = CreateApiWithMessages();
+
+            var cut = RenderMessagesTab(api);
+
+            StringAssert.Contains(cut.Markup, "abc-123");
+        }
+
+        [TestMethod]
+        public void ShowsNoRecordsContent_WhenEmpty()
+        {
+            var api = CreateApiWithMessages(totalCount: 0, includeItem: false);
+
+            var cut = RenderMessagesTab(api);
+
+            StringAssert.Contains(cut.Markup, "No messages found.");
+        }
+
+        [TestMethod]
+        public void ShowsErrorAlert_WhenLoadMessagesThrows()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetMessagesAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int?>())
+                .Returns<Task<PagedResponse<MessageResponse>>>(_ => throw new InvalidOperationException("boom"));
+
+            var cut = RenderMessagesTab(api);
+
+            StringAssert.Contains(cut.Markup, "boom");
+        }
+
+        [TestMethod]
+        public async Task ChangingStatusFilter_RequeriesWithSelectedValue()
+        {
+            var api = CreateApiWithMessages();
+
+            var cut = RenderMessagesTab(api);
+            var select = cut.FindComponent<MudSelect<int?>>();
+            await cut.InvokeAsync(async () => await select.Instance.SelectOption(2));
+
+            api.Received(1).GetMessagesAsync(TestQueueId, 0, 25, 2);
+        }
+
+        private IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> RenderMessagesTab(IDashboardApiClient api)
+        {
+            return RenderWithMudProvider<MessagesTab>(
+                (nameof(MessagesTab.QueueId), TestQueueId),
+                (nameof(MessagesTab.Api), api));
+        }
+
+        private static IDashboardApiClient CreateApiWithMessages(long totalCount = 1, bool includeItem = true)
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            var items = includeItem
+                ? new List<MessageResponse>
+                {
+                    new()
+                    {
+                        QueueId = "abc-123",
+                        Status = 0,
+                        QueuedDateTime = DateTimeOffset.UtcNow
+                    }
+                }
+                : new List<MessageResponse>();
+            api.GetMessagesAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int?>())
+                .Returns(new PagedResponse<MessageResponse>
+                {
+                    Items = items,
+                    TotalCount = totalCount
+                });
+            return api;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/StaleTabTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Components/Shared/StaleTabTests.cs
@@ -1,0 +1,214 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Bunit;
+using DotNetWorkQueue.Dashboard.Ui.Components.Shared;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudBlazor;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Components.Shared
+{
+    [TestClass]
+    public class StaleTabTests : BunitTestBase
+    {
+        private static readonly Guid TestQueueId = Guid.NewGuid();
+        private const string TestStaleMessageId = "stale-msg-0001";
+
+        [TestMethod]
+        public void LoadsStaleMessages_OnInitialization()
+        {
+            var api = CreateApiWithStaleMessages();
+            var snackbar = Substitute.For<ISnackbar>();
+
+            RenderStaleTab(api, snackbar);
+
+            api.Received(1).GetStaleMessagesAsync(TestQueueId, 60, 0, 25);
+        }
+
+        [TestMethod]
+        public void RendersRows_WhenStaleMessagesPresent()
+        {
+            var api = CreateApiWithStaleMessages();
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "Waiting");
+        }
+
+        [TestMethod]
+        public void ShowsNoRecordsContent_WhenEmpty()
+        {
+            var api = CreateApiWithStaleMessages(totalCount: 0, includeItem: false);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "No stale messages found.");
+        }
+
+        [TestMethod]
+        public void ShowsErrorAlert_WhenLoadStaleMessagesThrows()
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            api.GetStaleMessagesAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns<Task<PagedResponse<MessageResponse>>>(_ => throw new InvalidOperationException("boom"));
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "boom");
+        }
+
+        [TestMethod]
+        public void HidesActionButtons_WhenReadOnly()
+        {
+            var api = CreateApiWithStaleMessages(totalCount: 3);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar, readOnly: true);
+
+            Assert.DoesNotContain("Reset", cut.Markup);
+        }
+
+        [TestMethod]
+        public void ShowsActionButtons_WhenWritable()
+        {
+            var api = CreateApiWithStaleMessages(totalCount: 3);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar);
+
+            StringAssert.Contains(cut.Markup, "Reset All");
+            StringAssert.Contains(cut.Markup, "Reset");
+        }
+
+        [TestMethod]
+        public void ChangingThreshold_RequeriesWithNewValue()
+        {
+            var api = CreateApiWithStaleMessages();
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar);
+            cut.Find("input").Change("120");
+
+            api.Received(1).GetStaleMessagesAsync(TestQueueId, 120, 0, 25);
+        }
+
+        [TestMethod]
+        public void ResetMessage_Success_ShowsSuccessSnackbarAndReloads()
+        {
+            var api = CreateApiWithStaleMessages();
+            api.ResetMessageAsync(TestQueueId, TestStaleMessageId).Returns(true);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar);
+            FindButton(cut, "Reset").Click();
+
+            snackbar.Received(1).Add("Message reset.", Severity.Success);
+            api.Received(2).GetStaleMessagesAsync(TestQueueId, 60, 0, 25);
+        }
+
+        [TestMethod]
+        public void ResetMessage_Failure_ShowsErrorSnackbar()
+        {
+            var api = CreateApiWithStaleMessages();
+            api.ResetMessageAsync(TestQueueId, TestStaleMessageId).Returns(false);
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar);
+            FindButton(cut, "Reset").Click();
+
+            snackbar.Received(1).Add("Failed to reset.", Severity.Error);
+        }
+
+        [TestMethod]
+        public void ResetAllStale_Success_ShowsSuccessSnackbarAndReloads()
+        {
+            var api = CreateApiWithStaleMessages(totalCount: 3);
+            api.ResetAllStaleAsync(TestQueueId).Returns(new BulkActionResponse { Count = 3 });
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar);
+            FindButton(cut, "Reset All").Click();
+            FindButton(cut, "Click Again to Confirm").Click();
+
+            snackbar.Received(1).Add("Reset 3 stale message(s).", Severity.Success);
+            api.Received(2).GetStaleMessagesAsync(TestQueueId, 60, 0, 25);
+        }
+
+        [TestMethod]
+        public void ResetAllStale_Failure_ShowsErrorSnackbar()
+        {
+            var api = CreateApiWithStaleMessages(totalCount: 3);
+            api.ResetAllStaleAsync(TestQueueId)
+                .Returns<Task<BulkActionResponse>>(_ => throw new InvalidOperationException("reset-all-boom"));
+            var snackbar = Substitute.For<ISnackbar>();
+
+            var cut = RenderStaleTab(api, snackbar);
+            FindButton(cut, "Reset All").Click();
+            FindButton(cut, "Click Again to Confirm").Click();
+
+            snackbar.Received(1).Add("Failed: reset-all-boom", Severity.Error);
+        }
+
+        private static AngleSharp.Dom.IElement FindButton(IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> cut, string text)
+        {
+            return cut.FindAll("button").First(b => b.TextContent.Trim() == text);
+        }
+
+        private IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> RenderStaleTab(IDashboardApiClient api, ISnackbar snackbar, bool readOnly = false)
+        {
+            return RenderWithMudProvider<StaleTab>(
+                (nameof(StaleTab.QueueId), TestQueueId),
+                (nameof(StaleTab.Api), api),
+                (nameof(StaleTab.Snackbar), snackbar),
+                (nameof(StaleTab.ReadOnly), readOnly));
+        }
+
+        private static IDashboardApiClient CreateApiWithStaleMessages(long totalCount = 1, bool includeItem = true)
+        {
+            var api = Substitute.For<IDashboardApiClient>();
+            var items = includeItem
+                ? new List<MessageResponse>
+                {
+                    new()
+                    {
+                        QueueId = TestStaleMessageId,
+                        Status = 0,
+                        QueuedDateTime = DateTimeOffset.UtcNow
+                    }
+                }
+                : new List<MessageResponse>();
+            api.GetStaleMessagesAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(new PagedResponse<MessageResponse>
+                {
+                    Items = items,
+                    TotalCount = totalCount
+                });
+            return api;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/DotNetWorkQueue.Dashboard.Ui.Tests.csproj
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/DotNetWorkQueue.Dashboard.Ui.Tests.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <!-- The component under test is Nullable=enable, so its nullable signatures leak into
+         test code. "annotations" lets tests use ? without turning on nullable warnings. -->
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/DashboardApiClientTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/DashboardApiClientTests.cs
@@ -1,0 +1,684 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Dashboard.Ui.Models;
+using DotNetWorkQueue.Dashboard.Ui.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
+{
+    [TestClass]
+    public class DashboardApiClientTests
+    {
+        private const string Base = "api/v1/dashboard";
+
+        private sealed class FakeHttpMessageHandler : HttpMessageHandler
+        {
+            public HttpRequestMessage? LastRequest { get; private set; }
+            public HttpResponseMessage Response { get; set; } = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            };
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                return Task.FromResult(Response);
+            }
+        }
+
+        private static (DashboardApiClient client, FakeHttpMessageHandler handler) CreateSut()
+        {
+            var handler = new FakeHttpMessageHandler();
+            var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+            var client = new DashboardApiClient(http);
+            return (client, handler);
+        }
+
+        private static HttpResponseMessage JsonResponse(HttpStatusCode status, string json)
+        {
+            return new HttpResponseMessage(status)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+        }
+
+        // ------------------------------------------------------------
+        // Happy path
+        // ------------------------------------------------------------
+
+        [TestMethod]
+        public async Task GetSettingsAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetSettingsAsync();
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
+            Assert.AreEqual($"http://localhost/{Base}/settings", handler.LastRequest.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetConnectionsAsync_Returns_Deserialized_List()
+        {
+            var (sut, handler) = CreateSut();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "[{},{}]");
+
+            var result = await sut.GetConnectionsAsync();
+
+            Assert.HasCount(2, result);
+            Assert.AreEqual($"http://localhost/{Base}/connections", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetQueuesAsync_Builds_ConnectionId_Route()
+        {
+            var (sut, handler) = CreateSut();
+            var connectionId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "[{}]");
+
+            var result = await sut.GetQueuesAsync(connectionId);
+
+            Assert.HasCount(1, result);
+            Assert.AreEqual($"http://localhost/{Base}/connections/{connectionId}/queues", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetJobsAsync_Builds_ConnectionId_Route()
+        {
+            var (sut, handler) = CreateSut();
+            var connectionId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "[{}]");
+
+            var result = await sut.GetJobsAsync(connectionId);
+
+            Assert.HasCount(1, result);
+            Assert.AreEqual($"http://localhost/{Base}/connections/{connectionId}/jobs", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetQueueStatusAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetQueueStatusAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/status", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetQueueFeaturesAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetQueueFeaturesAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/features", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetQueueConfigurationAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetQueueConfigurationAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/configuration", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetMessagesAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetMessagesAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages?pageIndex=0&pageSize=25", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetMessageCountAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "42");
+
+            var result = await sut.GetMessageCountAsync(queueId);
+
+            Assert.AreEqual(42L, result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/count", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetMessageDetailAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetMessageDetailAsync(queueId, "msg-1");
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/msg-1", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetMessageBodyAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetMessageBodyAsync(queueId, "msg-1");
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/msg-1/body", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetMessageHeadersAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetMessageHeadersAsync(queueId, "msg-1");
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/msg-1/headers", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetMessageRetriesAsync_Returns_Deserialized_List()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "[{},{},{}]");
+
+            var result = await sut.GetMessageRetriesAsync(queueId, "msg-1");
+
+            Assert.HasCount(3, result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/msg-1/retries", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetStaleMessagesAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetStaleMessagesAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(
+                $"http://localhost/{Base}/queues/{queueId}/messages/stale?thresholdSeconds=60&pageIndex=0&pageSize=25",
+                handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetErrorsAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetErrorsAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/errors?pageIndex=0&pageSize=25", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task DeleteMessageAsync_Returns_True_On_Success()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.NoContent);
+
+            var result = await sut.DeleteMessageAsync(queueId, "msg-1");
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(HttpMethod.Delete, handler.LastRequest!.Method);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/msg-1", handler.LastRequest.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task DeleteAllErrorsAsync_Returns_Deserialized_Value_On_Success()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.DeleteAllErrorsAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(HttpMethod.Delete, handler.LastRequest!.Method);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/errors", handler.LastRequest.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task RequeueMessageAsync_Returns_True_On_Success()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            var result = await sut.RequeueMessageAsync(queueId, "msg-1");
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(HttpMethod.Post, handler.LastRequest!.Method);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/msg-1/requeue", handler.LastRequest.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task ResetMessageAsync_Returns_True_On_Success()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            var result = await sut.ResetMessageAsync(queueId, "msg-1");
+
+            Assert.IsTrue(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/msg-1/reset", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task UpdateMessageBodyAsync_Returns_True_On_Success()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            var result = await sut.UpdateMessageBodyAsync(queueId, "msg-1", new EditMessageBodyRequest { Body = "new body" });
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(HttpMethod.Put, handler.LastRequest!.Method);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/msg-1/body", handler.LastRequest.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task RequeueAllErrorsAsync_Returns_Deserialized_Value_On_Success()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.RequeueAllErrorsAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/errors/requeue-all", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task ResetAllStaleAsync_Returns_Deserialized_Value_On_Success()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.ResetAllStaleAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/reset-all", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetConsumersAsync_Returns_Deserialized_List()
+        {
+            var (sut, handler) = CreateSut();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "[{},{}]");
+
+            var result = await sut.GetConsumersAsync();
+
+            Assert.HasCount(2, result);
+            Assert.AreEqual($"http://localhost/{Base}/consumers", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetConsumerCountsAsync_Returns_Deserialized_Dictionary()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, $"{{\"{queueId}\":5}}");
+
+            var result = await sut.GetConsumerCountsAsync();
+
+            Assert.HasCount(1, result);
+            Assert.AreEqual(5, result[queueId]);
+            Assert.AreEqual($"http://localhost/{Base}/consumers/count", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task CancelMessageAsync_Returns_True_On_Success()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            var result = await sut.CancelMessageAsync(queueId, "msg-1");
+
+            Assert.IsTrue(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/msg-1/cancel", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetHistoryAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetHistoryAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/history?pageIndex=0&pageSize=25", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetHistoryCountAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "7");
+
+            var result = await sut.GetHistoryCountAsync(queueId);
+
+            Assert.AreEqual(7L, result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/history/count", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetHistoryByMessageIdAsync_Returns_Deserialized_Value()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.GetHistoryByMessageIdAsync(queueId, "msg-1");
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/history/msg-1", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task PurgeHistoryAsync_Returns_Deserialized_Value_On_Success()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            var result = await sut.PurgeHistoryAsync(queueId);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(HttpMethod.Delete, handler.LastRequest!.Method);
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/history", handler.LastRequest.RequestUri!.ToString());
+        }
+
+        // ------------------------------------------------------------
+        // Failure branches
+        // ------------------------------------------------------------
+
+        [TestMethod]
+        public async Task GetSettingsAsync_Throws_On_NotFound()
+        {
+            var (sut, handler) = CreateSut();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.NotFound);
+
+            await Assert.ThrowsExactlyAsync<HttpRequestException>(() => sut.GetSettingsAsync());
+        }
+
+        [TestMethod]
+        public async Task GetConnectionsAsync_Throws_On_ServerError()
+        {
+            var (sut, handler) = CreateSut();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+            await Assert.ThrowsExactlyAsync<HttpRequestException>(() => sut.GetConnectionsAsync());
+        }
+
+        [TestMethod]
+        public async Task GetConnectionsAsync_Returns_Empty_List_When_Body_Is_Null()
+        {
+            var (sut, _) = CreateSut();
+            var handler = new FakeHttpMessageHandler { Response = JsonResponse(HttpStatusCode.OK, "null") };
+            var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+            var client = new DashboardApiClient(http);
+
+            var result = await client.GetConnectionsAsync();
+
+            Assert.IsNotNull(result);
+            Assert.IsEmpty(result);
+        }
+
+        [TestMethod]
+        public async Task GetQueueStatusAsync_Returns_Null_When_Body_Is_Null()
+        {
+            var handler = new FakeHttpMessageHandler { Response = JsonResponse(HttpStatusCode.OK, "null") };
+            var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+            var client = new DashboardApiClient(http);
+
+            var result = await client.GetQueueStatusAsync(Guid.NewGuid());
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public async Task DeleteMessageAsync_Returns_False_On_NotFound()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.NotFound);
+
+            var result = await sut.DeleteMessageAsync(queueId, "msg-1");
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public async Task RequeueMessageAsync_Returns_False_On_ServerError()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+            var result = await sut.RequeueMessageAsync(queueId, "msg-1");
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public async Task UpdateMessageBodyAsync_Returns_False_On_NotFound()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.NotFound);
+
+            var result = await sut.UpdateMessageBodyAsync(queueId, "msg-1", new EditMessageBodyRequest { Body = "x" });
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public async Task DeleteAllErrorsAsync_Throws_On_ServerError()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+            await Assert.ThrowsExactlyAsync<HttpRequestException>(() => sut.DeleteAllErrorsAsync(queueId));
+        }
+
+        [TestMethod]
+        public async Task RequeueAllErrorsAsync_Throws_On_ServerError()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+            await Assert.ThrowsExactlyAsync<HttpRequestException>(() => sut.RequeueAllErrorsAsync(queueId));
+        }
+
+        [TestMethod]
+        public async Task ResetAllStaleAsync_Throws_On_ServerError()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+            await Assert.ThrowsExactlyAsync<HttpRequestException>(() => sut.ResetAllStaleAsync(queueId));
+        }
+
+        [TestMethod]
+        public async Task PurgeHistoryAsync_Throws_On_ServerError()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+            await Assert.ThrowsExactlyAsync<HttpRequestException>(() => sut.PurgeHistoryAsync(queueId));
+        }
+
+        // ------------------------------------------------------------
+        // URL / query building
+        // ------------------------------------------------------------
+
+        [TestMethod]
+        public async Task GetMessagesAsync_Appends_Status_When_Provided()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            await sut.GetMessagesAsync(queueId, pageIndex: 2, pageSize: 10, status: 3);
+
+            Assert.AreEqual(
+                $"http://localhost/{Base}/queues/{queueId}/messages?pageIndex=2&pageSize=10&status=3",
+                handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetMessageCountAsync_Appends_Status_When_Provided()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "1");
+
+            await sut.GetMessageCountAsync(queueId, status: 4);
+
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/messages/count?status=4", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetConsumersAsync_Appends_QueueId_When_Provided()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "[]");
+
+            await sut.GetConsumersAsync(queueId);
+
+            Assert.AreEqual($"http://localhost/{Base}/consumers?queueId={queueId}", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetConsumersAsync_Omits_QueueId_When_Not_Provided()
+        {
+            var (sut, handler) = CreateSut();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "[]");
+
+            await sut.GetConsumersAsync();
+
+            Assert.AreEqual($"http://localhost/{Base}/consumers", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetHistoryAsync_Appends_Status_When_Provided()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            await sut.GetHistoryAsync(queueId, pageIndex: 1, pageSize: 5, status: 2);
+
+            Assert.AreEqual(
+                $"http://localhost/{Base}/queues/{queueId}/history?pageIndex=1&pageSize=5&status=2",
+                handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetHistoryCountAsync_Omits_Status_When_Not_Provided()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "0");
+
+            await sut.GetHistoryCountAsync(queueId);
+
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/history/count", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task PurgeHistoryAsync_Appends_OlderThanDays_When_Provided()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            await sut.PurgeHistoryAsync(queueId, olderThanDays: 30);
+
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/history?olderThanDays=30", handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [TestMethod]
+        public async Task PurgeHistoryAsync_Omits_OlderThanDays_When_Not_Provided()
+        {
+            var (sut, handler) = CreateSut();
+            var queueId = Guid.NewGuid();
+            handler.Response = JsonResponse(HttpStatusCode.OK, "{}");
+
+            await sut.PurgeHistoryAsync(queueId);
+
+            Assert.AreEqual($"http://localhost/{Base}/queues/{queueId}/history", handler.LastRequest!.RequestUri!.ToString());
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceHealthMonitorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceHealthMonitorTests.cs
@@ -222,5 +222,67 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             await sut.PollAllSourcesAsync(CancellationToken.None);
             Assert.IsNotEmpty(logger.ReceivedCalls());
         }
+
+        [TestMethod]
+        public async Task PollAsync_Writes_Transition_Messages_When_Information_Enabled()
+        {
+            var source = CreateSource("Local", "http://localhost:5000");
+            var (sut, multiClient, _, logger) = CreateSut(source);
+            logger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
+
+            var shouldThrow = false;
+            var apiClient = Substitute.For<IDashboardApiClient>();
+            apiClient.GetSettingsAsync().Returns<Models.DashboardSettingsResponse?>(_ =>
+            {
+                if (shouldThrow) throw new HttpRequestException("Connection refused");
+                return new Models.DashboardSettingsResponse();
+            });
+            multiClient.GetClientForSource(source.Slug).Returns(apiClient);
+
+            await sut.PollAllSourcesAsync(CancellationToken.None);
+            shouldThrow = true;
+            await sut.PollAllSourcesAsync(CancellationToken.None);
+
+            // One Log call for Unknown -> Healthy, one for Healthy -> Unhealthy.
+            Assert.HasCount(2, logger.ReceivedCalls().Where(c => c.GetMethodInfo().Name == nameof(ILogger.Log)));
+        }
+
+        [TestMethod]
+        public async Task PollAsync_StopsImmediately_WhenCancellationAlreadyRequested()
+        {
+            var source = CreateSource("Local", "http://localhost:5000");
+            var (sut, multiClient, _, _) = CreateSut(source);
+
+            // A call that never completes, so WaitAsync observes the cancelled token
+            // instead of returning the already-completed result.
+            var never = new TaskCompletionSource<Models.DashboardSettingsResponse?>();
+            var apiClient = Substitute.For<IDashboardApiClient>();
+            apiClient.GetSettingsAsync().Returns(never.Task);
+            multiClient.GetClientForSource(source.Slug).Returns(apiClient);
+
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+            await sut.PollAllSourcesAsync(cts.Token);
+
+            Assert.IsEmpty(sut.GetAllHealth());
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_PollsOnStartup_AndExitsGracefullyOnStop()
+        {
+            var source = CreateSource("Local", "http://localhost:5000");
+            var (sut, multiClient, _, _) = CreateSut(source);
+
+            var apiClient = Substitute.For<IDashboardApiClient>();
+            apiClient.GetSettingsAsync().Returns(Task.FromResult<Models.DashboardSettingsResponse?>(new Models.DashboardSettingsResponse()));
+            multiClient.GetClientForSource(source.Slug).Returns(apiClient);
+
+            await sut.StartAsync(CancellationToken.None);
+            await sut.StopAsync(CancellationToken.None);
+
+            Assert.AreEqual(SourceHealthStatus.Healthy, sut.GetHealth(source.Slug).Status);
+            Assert.IsNotNull(sut.ExecuteTask);
+            Assert.IsTrue(sut.ExecuteTask!.IsCompleted);
+        }
     }
 }

--- a/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceHealthMonitorTests.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.Tests/Services/SourceHealthMonitorTests.cs
@@ -273,11 +273,18 @@ namespace DotNetWorkQueue.Dashboard.Ui.Tests.Services
             var source = CreateSource("Local", "http://localhost:5000");
             var (sut, multiClient, _, _) = CreateSut(source);
 
+            // Signalled by the startup poll, so the assertions below can't race it.
+            var polled = new TaskCompletionSource();
             var apiClient = Substitute.For<IDashboardApiClient>();
-            apiClient.GetSettingsAsync().Returns(Task.FromResult<Models.DashboardSettingsResponse?>(new Models.DashboardSettingsResponse()));
+            apiClient.GetSettingsAsync().Returns(_ =>
+            {
+                polled.TrySetResult();
+                return Task.FromResult<Models.DashboardSettingsResponse?>(new Models.DashboardSettingsResponse());
+            });
             multiClient.GetClientForSource(source.Slug).Returns(apiClient);
 
             await sut.StartAsync(CancellationToken.None);
+            await polled.Task.WaitAsync(TimeSpan.FromSeconds(10));
             await sut.StopAsync(CancellationToken.None);
 
             Assert.AreEqual(SourceHealthStatus.Healthy, sut.GetHealth(source.Slug).Status);


### PR DESCRIPTION
## Why

Codecov master sits at **88.09%** against a 90% floor. The shortfall is not erosion — it is one untested project. `DotNetWorkQueue.Dashboard.Ui` was at **23.6%**; removing it from the totals reproduces the historical ~90% exactly. Covering it is the only work that moves the number (the transports and core are already integration-covered).

See `docs/code-coverage.md` for the full rebaseline, including why Codecov and the local ReportGenerator badge differ by ~2.5 points (Codecov excludes partially-covered lines from `hits`; ReportGenerator counts them as covered).

## What

**Test-only change.** `git diff master -- Source/DotNetWorkQueue.Dashboard.Ui/` is empty — no production code was modified.

The test project goes from 66 to **273** test methods across:

| Area | Tests |
|---|---|
| `DashboardApiClient` | 48 |
| `MessageDetailDrawer` | 36 (new) |
| `QueueDetail` | 21 |
| `ConnectionDetail` | 16 (new) |
| `HistoryTab` | 15 |
| `ErrorsTab` | 14 |
| `MessagesTab` | 12 |
| `StaleTab` | 11 |
| `SourceHealthMonitor` | 11 |
| `ConsumersTab` | 10 |
| `Login` | 8 |
| `ConfigTab`, `AutoRefresh`, `Home`, `EmptyLayout`, services | remainder |

Four tests carried over from earlier work were failing. All four were **test** bugs, not component bugs:

- `MudSelect.SelectOption(2)` resolves to the *index* overload rather than the value — invoke `ValueChanged` instead.
- Re-stubbing an NSubstitute method after configuring it to throw re-invokes the throw; replaced with a single call-count stub.
- `div.mud-paper` also matches the two popover containers `MudPopoverProvider` renders ahead of page content — the status cards are selected via `.mud-elevation-2`.
- `cut.Instance` is the `ContainerFragment` wrapper, so private-field reflection has to go through `FindComponent<QueueDetail>().Instance`.

One real coverage trap worth noting: `SourceHealthMonitor`'s state-transition log statements are guarded by `_logger.IsEnabled(LogLevel.Information)`, and an NSubstitute `ILogger` returns `false` by default — so those lines were never being executed by the existing tests.

## Numbers

Local Coverlet, `Source/DotNetWorkQueue.Dashboard.Ui/` only: **23.6% -> 97.24%** line coverage, 66 misses remaining.

Measured Codecov-style (deduped by line, partials excluded from hits): **1096 hits vs the 307 master baseline = +789**. Master needs +639 for 90%, which projects to roughly **90.4%**.

## Verification

- 273 tests pass on **net10.0 and net8.0**
- `dotnet build Source\DotNetWorkQueueNoTests.sln -c Release -p:CI=true` — 0 warnings, 0 errors
- No `Thread.Sleep` in the test project (async waits use `WaitForAssertion`)
- No production-code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded UI coverage with new suites for empty layout theming, connection/queue details, home navigation, login submission behavior, and shared components (auto-refresh, config, consumers, errors, history, stale, messages, and message detail drawer).
  * Added assertions for loading spinners, empty states, error alerts, retry/reload flows, filtering, pagination, drawer open/close, and read-only UI behavior.
  * Added service-level tests for dashboard API client request/response handling, query construction, failure branches, and source health monitor polling/lifecycle behavior.
* **Chores**
  * Enabled nullable annotations in the test project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->