### PR TITLE
Fix SonarCloud S8970 null-forgiving smell (1 real, 23 FP)

### DIFF
--- a/Source/DotNetWorkQueue.Dashboard.Api/DashboardExtensions.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Api/DashboardExtensions.cs
@@ -173,7 +173,7 @@ namespace DotNetWorkQueue.Dashboard.Api
                     if (string.IsNullOrEmpty(connectionString))
                         throw new ArgumentException($"Dashboard connection '{displayName}' must specify a ConnectionString.");
 
-                    AddConnectionByTransport(options, transport, connectionString, displayName!, queues, interceptorOptions);
+                    AddConnectionByTransport(options, transport, connectionString, displayName, queues, interceptorOptions);
                 }
             });
         }


### PR DESCRIPTION
## What

SonarCloud rolled out two new rules that flagged existing code:

- **S8970** (redundant null-forgiving `!`) — 24 hits
- **S8949** (pass CancellationToken) — 1 hit

Of the 24 S8970 hits, only **one is real**: `DashboardExtensions.cs:176`. That file is in a **nullable-disabled** context (`Dashboard.Api` has no `<Nullable>enable>`), so the `!` on `displayName` was a genuine no-op. Removed it.

The other **23 S8970 hits are analyzer false positives**. They live in `Dashboard.Ui` razor files, and that project sets `<Nullable>enable</Nullable>` — the razor `@code` blocks honor it, so those `!` operators are load-bearing. Proven empirically: removing `MessageId!` produces `CS8604 (possible null reference argument)`. Sonar mis-detects the nullable context of razor-generated code. Marked false-positive in SonarCloud.

The **1 S8949 bug** is also a false positive and marked accordingly: the `_monitorCompleted.Wait(30s)` in `BaseMonitor.Cancel()` runs *after* `CancelToken.Cancel()` — passing the (already-cancelled) token would abort the safety-net wait immediately, defeating its purpose.

## Result

- Code: 1 line changed, Release build clean (0 warnings, net8.0 + net10.0).
- SonarCloud: 24 issues transitioned to false-positive; this PR clears the last one on rescan → back to 0 bugs / 0 open smells from this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability handling during dashboard connection setup without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->