### PR TITLE
test: relax heartbeat timings and dump surviving rows on count failures

### DIFF
--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/Route/Implementation/RouteMultiTests.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/Route/Implementation/RouteMultiTests.cs
@@ -34,12 +34,19 @@ namespace DotNetWorkQueue.IntegrationTests.Shared.Route.Implementation
                     Assert.IsTrue(result.Success, result.ErrorMessage);
                     scope = oCreation.Scope;
 
+                    //Heartbeat settings match the rest of the suite (update every 10s, dead at
+                    //30s, swept at 35s) rather than the far tighter 3s/10s/12s used before. This
+                    //test runs several consumers against one database, and on SQLite every
+                    //heartbeat write queues behind the single write lock along with the dequeue
+                    //updates and the deletes. Tight timings there buy nothing - the subject here
+                    //is message routing, not the heartbeat - and cost a leftover row when a
+                    //commit is still waiting on that lock as the consumer shuts down.
                     var routeTest = new RouteMultiTestsShared();
                     routeTest.RunTest<TTransportInit, FakeMessageA>(queueConnection,
                         true, messageCount, logProvider, generateData, verify, false,
                         GenerateRoutes(routeCount, 1), GenerateRoutes(routeCount, routeCount + 1), runtime,
-                        timeOut, readerCount, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(12), oCreation.Scope,
-                        "*/3 * * * * *", enableChaos);
+                        timeOut, readerCount, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(35), oCreation.Scope,
+                        "*/10 * * * * *", enableChaos);
 
                     verifyQueueCount(queueConnection, oCreation.BaseTransportOptions, scope, 0, false, false);
                 }

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/Route/Implementation/RouteTests.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/Route/Implementation/RouteTests.cs
@@ -34,11 +34,18 @@ namespace DotNetWorkQueue.IntegrationTests.Shared.Route.Implementation
                     Assert.IsTrue(result.Success, result.ErrorMessage);
                     scope = oCreation.Scope;
 
+                    //Heartbeat settings match the rest of the suite (update every 10s, dead at
+                    //30s, swept at 35s) rather than the far tighter 3s/10s/12s used before. This
+                    //test runs several consumers against one database, and on SQLite every
+                    //heartbeat write queues behind the single write lock along with the dequeue
+                    //updates and the deletes. Tight timings there buy nothing - the subject here
+                    //is message routing, not the heartbeat - and cost a leftover row when a
+                    //commit is still waiting on that lock as the consumer shuts down.
                     var routeTest = new RouteTestsShared();
                     routeTest.RunTest<TTransportInit, FakeMessageA>(queueConnection,
                         true, messageCount, logProvider, generateData, verify, false,
-                        GenerateRoutes(routeCount), runtime, timeOut, readerCount, TimeSpan.FromSeconds(10),
-                        TimeSpan.FromSeconds(12), oCreation.Scope, "*/3 * * * * *", enableChaos);
+                        GenerateRoutes(routeCount), runtime, timeOut, readerCount, TimeSpan.FromSeconds(30),
+                        TimeSpan.FromSeconds(35), oCreation.Scope, "*/10 * * * * *", enableChaos);
 
                     verifyQueueCount(queueConnection, oCreation.BaseTransportOptions, scope, 0, false, false);
 

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/UserDequeue/Implementation/UserDeQueueTests.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/UserDequeue/Implementation/UserDeQueueTests.cs
@@ -35,11 +35,18 @@ namespace DotNetWorkQueue.IntegrationTests.Shared.UserDequeue.Implementation
                     Assert.IsTrue(result.Success, result.ErrorMessage);
                     scope = oCreation.Scope;
 
+                    //Heartbeat settings match the rest of the suite (update every 10s, dead at
+                    //30s, swept at 35s) rather than the far tighter 3s/10s/12s used before. This
+                    //test runs several consumers against one database, and on SQLite every
+                    //heartbeat write queues behind the single write lock along with the dequeue
+                    //updates and the deletes. Tight timings there buy nothing - the subject here
+                    //is the dequeue filter, not the heartbeat - and cost a leftover row when a
+                    //commit is still waiting on that lock as the consumer shuts down.
                     var test = new UserDeQueueTestsShared();
                     test.RunTest<TTransportInit, FakeMessageA>(queueConnection,
                         true, messageCount, logProvider, generateData, verify, false,
-                        GenerateUserData(valueCount), runtime, timeOut, readerCount, TimeSpan.FromSeconds(10),
-                        TimeSpan.FromSeconds(12), oCreation.Scope, "*/3 * * * * *", enableChaos, setQueueOptions);
+                        GenerateUserData(valueCount), runtime, timeOut, readerCount, TimeSpan.FromSeconds(30),
+                        TimeSpan.FromSeconds(35), oCreation.Scope, "*/10 * * * * *", enableChaos, setQueueOptions);
 
                     verifyQueueCount(queueConnection, oCreation.BaseTransportOptions, scope, 0, false, false);
 

--- a/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/VerifyQueueData.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/VerifyQueueData.cs
@@ -4,8 +4,10 @@ using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using System;
+using System.Data;
 using System.Data.SQLite;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #endregion
@@ -205,8 +207,6 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests
             AllTablesRecordCount(recordCount, ignoreMeta, ignoreErrorTracking);
         }
 
-        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
-        [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query Ok")]
         private void AllTablesRecordCount(int recordCount, bool ignoreMeta, bool ignoreErrorTracking)
         {
             using (var conn = new SQLiteConnection(_connection.ConnectionString))
@@ -215,55 +215,75 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests
                 using (var command = conn.CreateCommand())
                 {
                     if (!ignoreMeta)
-                    {
-                        command.CommandText = $"select count(*) from {_tableNameHelper.MetaDataName}";
-                        using (var reader = command.ExecuteReader())
-                        {
-                            Assert.IsTrue(reader.Read());
-                            var records = reader.GetInt32(0);
-                            Assert.AreEqual(recordCount, records);
-                        }
-                    }
+                        AssertRecordCount(command, _tableNameHelper.MetaDataName, recordCount);
 
                     if (!ignoreErrorTracking)
-                    {
-                        command.CommandText = $"select count(*) from {_tableNameHelper.ErrorTrackingName}";
-                        using (var reader = command.ExecuteReader())
-                        {
-                            Assert.IsTrue(reader.Read());
-                            var records = reader.GetInt32(0);
-                            Assert.AreEqual(recordCount, records);
-                        }
-                    }
+                        AssertRecordCount(command, _tableNameHelper.ErrorTrackingName, recordCount);
 
-                    command.CommandText = $"select count(*) from {_tableNameHelper.MetaDataErrorsName}";
-                    using (var reader = command.ExecuteReader())
-                    {
-                        Assert.IsTrue(reader.Read());
-                        var records = reader.GetInt32(0);
-                        Assert.AreEqual(recordCount, records);
-                    }
-
-                    command.CommandText = $"select count(*) from {_tableNameHelper.QueueName}";
-                    using (var reader = command.ExecuteReader())
-                    {
-                        Assert.IsTrue(reader.Read());
-                        var records = reader.GetInt32(0);
-                        Assert.AreEqual(recordCount, records);
-                    }
+                    AssertRecordCount(command, _tableNameHelper.MetaDataErrorsName, recordCount);
+                    AssertRecordCount(command, _tableNameHelper.QueueName, recordCount);
 
                     if (_options.EnableStatusTable)
-                    {
-                        command.CommandText = $"select count(*) from {_tableNameHelper.StatusName}";
-                        using (var reader = command.ExecuteReader())
-                        {
-                            Assert.IsTrue(reader.Read());
-                            var records = reader.GetInt32(0);
-                            Assert.AreEqual(recordCount, records);
-                        }
-                    }
+                        AssertRecordCount(command, _tableNameHelper.StatusName, recordCount);
                 }
             }
+        }
+
+        /// <summary>
+        /// A bare count mismatch says nothing about which message survived, and these failures are
+        /// intermittent and load dependent - the run that produced one is long gone by the time
+        /// anyone looks at it. Dump the surviving rows with the failure so a single occurrence is
+        /// enough to diagnose.
+        /// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query Ok")]
+        private static void AssertRecordCount(IDbCommand command, string tableName, int expected)
+        {
+            command.CommandText = $"select count(*) from {tableName}";
+            int records;
+            using (var reader = command.ExecuteReader())
+            {
+                Assert.IsTrue(reader.Read());
+                records = reader.GetInt32(0);
+            }
+
+            if (records == expected)
+                return;
+
+            Assert.Fail($"Expected {expected} record(s) in {tableName}, found {records}.{Environment.NewLine}" +
+                        DumpRows(command, tableName));
+        }
+
+        [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query Ok")]
+        private static string DumpRows(IDbCommand command, string tableName, int maxRows = 10)
+        {
+            var output = new StringBuilder();
+            command.CommandText = $"select * from {tableName} limit {maxRows}";
+            using (var reader = command.ExecuteReader())
+            {
+                var row = 0;
+                while (reader.Read())
+                {
+                    var columns = new string[reader.FieldCount];
+                    for (var i = 0; i < reader.FieldCount; i++)
+                        columns[i] = $"{reader.GetName(i)}={Describe(reader, i)}";
+
+                    output.AppendLine($"  row {++row}: {string.Join(", ", columns)}");
+                }
+
+                if (row == 0)
+                    output.AppendLine("  <no rows>");
+            }
+            return output.ToString();
+        }
+
+        private static string Describe(IDataRecord reader, int ordinal)
+        {
+            if (reader.IsDBNull(ordinal))
+                return "<null>";
+
+            //the message body is a blob; its bytes are noise here, its presence is not
+            var value = reader.GetValue(ordinal);
+            return value is byte[] bytes ? $"<{bytes.Length} bytes>" : value.ToString();
         }
     }
     public class VerifyErrorCounts


### PR DESCRIPTION
## The failure

The SQLite `UserDequeue` integration test has been failing intermittently with:

```
Assert.AreEqual failed. Expected:<0>. Actual:<1>.
  at VerifyQueueRecordCount.AllTablesRecordCount  // the MetaData table
```

`RunConsumer` asserts `IdError == null` and `ProcessedCount == messageCount` **before** the record-count check, and both pass. So this is not double delivery and not a heartbeat reset — every message was processed exactly once and a row still survived.

## Why

`ProcessMessage.Handle` runs the user handler and *then* commits:

```csharp
_methodToRun.Handle(transportMessage, context.WorkerNotification);  // sets waitForFinish
_commitMessage.Commit(context);                                     // the DELETE
```

`HandleFakeMessages` sets `waitForFinish` from inside the handler, so the test releases its `using` and starts disposing the queue before the last message's delete has committed. Shutdown allows `TimeToWaitForWorkersToStop` 5s, then cancels at 10s. A commit still queued behind SQLite's single write lock at that moment is cancelled — `OperationCanceledException` is rethrown rather than routed through the exception handler, so nothing is logged and `CheckForErrors` stays clean. Count says N, ids say N distinct, one row remains.

Three tests made that far more likely than the rest of the suite:

| | UserDequeue / Route / RouteMulti | every other consumer test |
|---|---|---|
| `HeartBeat.UpdateTime` | `*/3 * * * * *` | `*/10 * * * * *` |
| `HeartBeat.Time` | 10s | 30s |
| `HeartBeat.MonitorTime` | 12s | 35s |
| concurrent consumers, one database | 4 | 1 |

Four consumers with up to eight in-flight messages each writing a heartbeat every 3s, plus four full-table reset sweeps every 12s — all serialized behind the one write lock, alongside the dequeue updates and the deletes. The heartbeat is not the subject of any of these three tests.

## Changes

- `UserDeQueueTests`, `RouteTests`, `RouteMultiTests` now use the suite-standard `*/10` / 30s / 35s, with a comment recording why.
- `VerifyQueueRecordCount` reports the surviving rows with the failure instead of a bare count, so a single occurrence of a load-dependent failure is diagnosable:

```
Assert.Fail failed. Expected 0 record(s) in I17fc…, found 400.
  row 1: QueueID=1, Body=<229 bytes>, Headers=<666 bytes>
```

  Blob columns are summarised by length, `NULL` renders as `<null>`, capped at 10 rows.

## Verification

- 16 runs of `UserDequeue` on the previous head before this change — 12 idle, 4 with 40 CPU burners saturating all 32 cores — all green, so the flake does not reproduce locally on demand and the diagnosis above is the explanation that fits the evidence rather than one reproduced under a debugger. That is what the row dump is for.
- After the change: `UserDequeue` + `Route` on SQLite, 8/8 green.
- The diagnostic itself was exercised end to end in both directions (empty table → `<no rows>`; populated table → the row dump above) by temporarily forcing the assert, then reverted.

Test-only; no library code and no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Test Improvements**
  * Improved integration test reliability by allowing more time for heartbeat updates and timeout processing.
  * Enhanced queue data validation with clearer failure diagnostics, including details from remaining records.
  * Standardized record-count verification across queue tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->