### PR TITLE
review: clear the five SonarCloud findings from #225

### DIFF
--- a/Source/DotNetWorkQueue.Benchmarks/ReceivePathBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/ReceivePathBenchmarks.cs
@@ -68,12 +68,9 @@ namespace DotNetWorkQueue.Benchmarks
         private string _connectionString;
 
         private QueueCreationContainer<SqLiteMessageQueueInit> _creation;
-        private QueueContainer<SqLiteMessageQueueInit> _container;
-        private IConsumerQueue _consumer;
 
         private TableNameHelper _tableNames;
         private SqLiteMessageQueueTransportOptions _options;
-        private QueueConsumerConfiguration _configuration;
 
         private SQLiteConnection _connection;
         private IDbFactory _dbFactory;
@@ -97,12 +94,6 @@ namespace DotNetWorkQueue.Benchmarks
                 if (!result.Success)
                     throw new InvalidOperationException($"CreateQueue failed: {result.Status} {result.ErrorMessage}");
             }
-
-            _container = new QueueContainer<SqLiteMessageQueueInit>();
-            _consumer = _container.CreateConsumer(queueConnection);
-
-            //the live consumer configuration, so the generated SQL matches what a consumer runs
-            _configuration = _consumer.Configuration;
 
             //the queue above was created with default options, so these are the options it has
             _options = new SqLiteMessageQueueTransportOptions();
@@ -132,8 +123,6 @@ namespace DotNetWorkQueue.Benchmarks
             (_dbFactory as IDisposable)?.Dispose();
             _reusedCommand?.Dispose();
             _connection?.Dispose();
-            _consumer?.Dispose();
-            _container?.Dispose();
             _creation?.Dispose();
             SQLiteConnection.ClearAllPools();
             try

--- a/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/UserDequeue/UserDequeueFromFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/UserDequeue/UserDequeueFromFactory.cs
@@ -40,15 +40,15 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.UserDequeue
             //that the factories were consulted repeatedly rather than once and cached. Without them
             //this test would pass even if the clause and the parameter list were both cached, since
             //each consumer has its own handler and its own values.
-            Assert.AreEqual(valueCount, _clauseCalls.Count, "every consumer should have used its clause factory");
-            Assert.AreEqual(valueCount, _parameterCalls.Count, "every consumer should have used its parameter factory");
+            Assert.HasCount(valueCount, _clauseCalls, "every consumer should have used its clause factory");
+            Assert.HasCount(valueCount, _parameterCalls, "every consumer should have used its parameter factory");
 
             foreach (var calls in _clauseCalls)
-                Assert.IsTrue(calls.Value > 1,
+                Assert.IsGreaterThan(1, calls.Value,
                     $"the clause factory for order {calls.Key} was called {calls.Value} time(s); it must be consulted per dequeue");
 
             foreach (var calls in _parameterCalls)
-                Assert.IsTrue(calls.Value > 1,
+                Assert.IsGreaterThan(1, calls.Value,
                     $"the parameter factory for order {calls.Key} was called {calls.Value} time(s); it must be consulted per dequeue");
         }
 


### PR DESCRIPTION
The five findings from #225, which were merged as minor. Four are, one isn't quite.

**`S4487` (Critical) — a field nothing reads**

`ReceivePathBenchmarks` still held a `QueueConsumerConfiguration`. #225 changed `GetDeQueueCommand` to take the caller's clause rather than reaching into the configuration, and I left the field behind.

Following it through: the consumer existed only to supply that configuration, and the container only to create the consumer. All three are removed, so the benchmark setup no longer stands up a consumer it never uses.

**`MSTEST0037` ×4 (Info) — assertion style**

`Assert.HasCount` and `Assert.IsGreaterThan` in place of `AreEqual`-on-`.Count` and `IsTrue`-on-comparison in `UserDequeueFromFactory`. These give better failure messages, which matters for the count assertions since the number is the point.

## Verification

- `NoTests.sln` Release with `-p:CI=true`: 0 warnings, 0 errors.
- Benchmark harness still runs after the removals (dry run, all six receive rungs).
- `UserDequeueFromFactory`: 2/2, so the rewritten assertions still hold.

Benchmark and test code only; no production changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to use newer assertion syntax without changing test coverage or behavior.
* **Benchmarks**
  * Simplified benchmark setup and cleanup by removing unnecessary consumer infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->