### PR TITLE
test(benchmarks): the relational decorator stack is not a lever (#231, #232)

### DIFF
--- a/Source/DotNetWorkQueue.Benchmarks/README.md
+++ b/Source/DotNetWorkQueue.Benchmarks/README.md
@@ -441,6 +441,26 @@ queues differing only in their connection string.
 | **A dry run of this suite reported it as a five-fold win, and that was nonsense** | 55.8 ms against 10.5 ms, with one invocation per rung and the `off` fixture running first, so it paid the connection and warm-up cost for both. The same order-dependent trap the SQL Server ladder had to correct. Recorded because the number looked spectacular and meant nothing |
 | The DDL risk is real, and only partly evidenced | Prepared statements live on the physical connection, the pool hands it back, and dropping a table invalidates any statement referencing it — and this library creates and drops queues routinely. `AutoPrepareSurvivesDdl` drives create → send past the threshold → drop → recreate under the same name → send, and passes. But Npgsql exposes no public counter for auto-prepared statements, so that is evidence the scenario works rather than proof the invalidation path was exercised. Do not read it as a safety guarantee |
 
+## RelationalDecoratorBenchmarks
+
+What the retry decorator costs per command, separated from the database call it wraps. Both #231
+and #232 ask this, noting that a win here would be shared by all three relational transports rather
+than transport-local.
+
+It cannot be answered from the send ladders — the decorator wraps a call taking milliseconds, so its
+own cost vanishes into the round trip. Here the inner handler does nothing, so what is left between
+the two rungs is the decorator: a registry lookup, Polly's `Execute`, and the closure that
+`pipeline.Execute(_ => _decorated.Handle(command))` allocates by capturing both the command and the
+handler. SQLite is used because it needs no server and carries the same decorator.
+
+### Findings
+
+| finding | evidence |
+|---|---|
+| **The decorator stack is not a lever on a relational transport** | 148.6 ns and 120 B per command, against a SQL Server send of 9,654 us and 30 KB — **0.0015% of the time and 0.4% of the allocation**. Removing the closure would recover a fraction of 120 B. There is nothing here worth changing, and this rung exists to stop the question being asked a fourth time |
+| It would matter if a command were cheap, which on these transports it never is | The floor rung is a handler that returns a constant, and the decorator is 148 ns on top of it. That ratio is what makes the stack look expensive in isolation and irrelevant in place. Measure the thing it wraps before optimising the wrapper |
+| The decorator is triplicated, and the copies differ | SQL Server, PostgreSQL and SQLite each hold their own `RetryCommandHandlerOutputDecorator`. SQL Server and PostgreSQL short-circuit on `IRetrySkippable`; SQLite does not. **This is not a bug**: `SkipRetry` is `ExternalTransaction != null`, and SQLite never builds the shared `RelationalSendMessageCommand` that implements it, so the branch is unreachable there. Worth knowing before someone "fixes" the divergence |
+
 ## Why this exists
 
 A scratch decomposition in August 2026 found that the write transaction was ~3% of the gap

--- a/Source/DotNetWorkQueue.Benchmarks/RelationalDecoratorBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/RelationalDecoratorBenchmarks.cs
@@ -1,0 +1,120 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Transport.SQLite.Decorator;
+
+namespace DotNetWorkQueue.Benchmarks
+{
+    /// <summary>
+    /// What the retry decorator costs per command, separated from the database call it wraps.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both #231 and #232 ask what the decorator stack costs, noting that a win there is shared by
+    /// all three relational transports rather than being transport-local. It cannot be answered
+    /// from the send ladders: the decorator sits around a call that takes milliseconds, so its own
+    /// cost disappears into the noise of the round trip.
+    /// </para>
+    /// <para>
+    /// So the inner handler here does nothing. What is left between the two rungs is the decorator:
+    /// a registry lookup, Polly's <c>Execute</c>, and the closure that
+    /// <c>pipeline.Execute(_ =&gt; _decorated.Handle(command))</c> allocates because it captures
+    /// both the command and the handler.
+    /// </para>
+    /// <para>
+    /// SQLite is used because it needs no server and carries the same decorator. The three
+    /// transports each have their own copy of this class; they differ only in an
+    /// <c>IRetrySkippable</c> short-circuit that SQLite cannot reach, since it never builds the
+    /// shared command that implements it.
+    /// </para>
+    /// </remarks>
+    [MemoryDiagnoser]
+    public class RelationalDecoratorBenchmarks
+    {
+        private string _dir;
+        private QueueCreationContainer<SqLiteMessageQueueInit> _creation;
+        private QueueContainer<SqLiteMessageQueueInit> _container;
+        private IProducerQueue<SendPathBenchmarks.Event> _producer;
+
+        private StubHandler _inner;
+        private ICommandHandlerWithOutput<StubCommand, int> _decorated;
+        private StubCommand _command;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "dnwq-decorators", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            var file = Path.Combine(_dir, "decorators.db3");
+            var connection = new QueueConnection("benchDecorators",
+                $"Data Source={file};Version=3;Synchronous=NORMAL;Pooling=True;");
+
+            _creation = new QueueCreationContainer<SqLiteMessageQueueInit>();
+            using (var creator = _creation.GetQueueCreation<SqLiteMessageQueueCreation>(connection))
+            {
+                var result = creator.CreateQueue();
+                if (!result.Success)
+                    throw new InvalidOperationException($"CreateQueue failed: {result.Status}");
+            }
+
+            //a real queue only so the container hands back the real policies, with whatever retry
+            //pipeline the transport registers - the point is to measure the decorator as configured
+            _container = new QueueContainer<SqLiteMessageQueueInit>();
+            _producer = _container.CreateProducer<SendPathBenchmarks.Event>(connection);
+            var container = ConsumerInternals.ContainerOf(_container);
+
+            _inner = new StubHandler();
+            _decorated = new RetryCommandHandlerOutputDecorator<StubCommand, int>(
+                _inner, container.GetInstance<IPolicies>());
+            _command = new StubCommand();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _producer?.Dispose();
+            _container?.Dispose();
+            _creation?.Dispose();
+            try { Directory.Delete(_dir, true); }
+            catch (IOException) { /* a held file is not worth failing a run over */ }
+            catch (UnauthorizedAccessException) { /* same */ }
+        }
+
+        /// <summary>The floor: the handler on its own.</summary>
+        [Benchmark(Baseline = true, Description = "handler alone (no decorator)")]
+        public int Handler_Direct() => _inner.Handle(_command);
+
+        /// <summary>The same handler through the retry decorator, as the transports register it.</summary>
+        [Benchmark(Description = "handler through the retry decorator")]
+        public int Handler_Decorated() => _decorated.Handle(_command);
+
+        /// <summary>A command with nothing in it; the decorator does not look inside.</summary>
+        public sealed class StubCommand;
+
+        /// <summary>An inner handler that does nothing, so only the decorator is measured.</summary>
+        public sealed class StubHandler : ICommandHandlerWithOutput<StubCommand, int>
+        {
+            public int Handle(StubCommand command) => 1;
+        }
+    }
+}


### PR DESCRIPTION
Benchmark and documentation only — no production code changes.

Both #231 and #232 ask what the shared decorator stack costs per operation, on the grounds that a win there would be shared across SQL Server, PostgreSQL and SQLite rather than transport-local. This answers it.

## The measurement

The send ladders can't answer it: the decorator wraps a call taking milliseconds, so its own cost disappears into the round trip. Here the inner handler does nothing, leaving only the decorator — a registry lookup, Polly's `Execute`, and the closure `pipeline.Execute(_ => _decorated.Handle(command))` allocates by capturing both the command and the handler.

| rung | mean | allocated |
|---|---|---|
| handler alone (no decorator) | ~0 ns | 0 B |
| handler through the retry decorator | **148.6 ns** | **120 B** |

Against a SQL Server send of 9,654 µs and 30 KB, that is **0.0015% of the time and 0.4% of the allocation**.

## Recommendation: leave it alone

The closure is real and could be removed by passing state instead of capturing, but it would recover a fraction of 120 B on an operation costing 9.6 ms. Not worth the change. The rung stays so the question doesn't get asked a fourth time.

SQLite is used for the fixture because it needs no server and carries the same decorator.

## One thing that looks like a defect and isn't

The decorator is **triplicated** — SQL Server, PostgreSQL and SQLite each hold their own `RetryCommandHandlerOutputDecorator` — and the copies differ: the first two short-circuit on `IRetrySkippable`, SQLite does not.

That is not a bug. `SkipRetry` is `ExternalTransaction != null`, and SQLite never builds the shared `RelationalSendMessageCommand` that implements the interface, so the branch is unreachable there. Documented in the benchmarks README so the divergence isn't "fixed" later on a false premise.

Consolidating the three copies into `Transport.RelationalDatabase` is a separate question — they are public-facing types in each transport's namespace, and this PR found no performance reason to touch them.

## What this leaves on the two issues

- **#231**: collapsing the send's four round trips (1,145 µs / 12%, needs a decision on the transaction contract), and parameterising the delay/expiration literals.
- **#232**: round trips per send, and binary vs text `bytea` handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added benchmark documentation explaining how retry overhead is measured independently from database operations.
  - Documented methodology and implementation differences across SQL Server, PostgreSQL, and SQLite.

- **Tests**
  - Added performance benchmarks comparing direct command handling with retry-decorated handling.
  - Benchmarks use a temporary SQLite environment to provide a repeatable measurement of decorator overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->