### PR TITLE
Give the changelog rule a shape it can be held to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,4 +145,14 @@ Historical engineering notes have been moved to [`docs/lessons-learned.md`](docs
 
 ## Changelog.md
 
-- Prefer consise entries instead of verbose; too much detail just makes the log harder to read
+The changelog is for **consumers of the queue, not for us**. An entry answers "what changed, and does it affect me?" — if a reader wants the how or why, the commit history is a better record of it than a bullet will ever be.
+
+Test every entry: **does a consumer act differently knowing this?** If not, it belongs in the commit message.
+
+- One bullet per user-visible change, not one per aspect of it
+- Target 200 characters; over 300 needs a reason
+- Performance entries get one before/after pair — the practical effect, never the methodology that produced it
+- ⚠️ only where a consumer must change configuration or expectations
+- No implementation internals, no measurement narration, no "here is what we tried"
+
+The detail has homes already: reasoning → the commit message; measurement methodology and dead ends → `Source/DotNetWorkQueue.Benchmarks/README.md`; implementation detail → code comments, next to the code.


### PR DESCRIPTION
`CLAUDE.md` already asked for concise changelog entries. It did not hold: the `Unreleased` section reached 38 bullets at a median of **514** characters, 30 of them over 300, carrying benchmark methodology, measurement narration and transport internals. Older sections sit near 195.

A rule with no stated audience and no limit is a preference, not a rule. This gives it both.

**What to look at:** whether the limits are the right ones to hold future entries to — particularly "target 200 characters" and the performance-entry rule, since the performance passes are where the drift came from and #233 is still to be written.

The rule states who the changelog is for (consumers of the queue, not us), gives one test that settles most entries — *does a consumer act differently knowing this?* — and points the detail at the homes the pull-request section already names: commit messages for reasoning, the benchmarks README for measurement dead ends, code comments for implementation detail.

Docs only, no code change. Cleanup of the entries already written is #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog guidance to prioritize clear, concise descriptions of user-visible changes.
  * Added recommendations for documenting consumer impact, performance comparisons, configuration changes, reasoning, measurement methods, and implementation details in the appropriate locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->