### PR TITLE
Redis performance pass: measure both paths, no change warranted

### DIFF
--- a/Source/DotNetWorkQueue.Benchmarks/DotNetWorkQueue.Benchmarks.csproj
+++ b/Source/DotNetWorkQueue.Benchmarks/DotNetWorkQueue.Benchmarks.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\DotNetWorkQueue.Transport.LiteDB\DotNetWorkQueue.Transport.LiteDb.csproj" />
     <ProjectReference Include="..\DotNetWorkQueue.Transport.SqlServer\DotNetWorkQueue.Transport.SqlServer.csproj" />
     <ProjectReference Include="..\DotNetWorkQueue.Transport.PostgreSQL\DotNetWorkQueue.Transport.PostgreSQL.csproj" />
+    <ProjectReference Include="..\DotNetWorkQueue.Transport.Redis\DotNetWorkQueue.Transport.Redis.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DotNetWorkQueue.Benchmarks/README.md
+++ b/Source/DotNetWorkQueue.Benchmarks/README.md
@@ -518,7 +518,7 @@ share of wall time would be much larger. The allocation column is the one that t
 | rung | mean | allocated |
 |---|---|---|
 | round trip only: PING | 378.4 us | 128 B |
-| raw: DNWQ shape, separate commands (6 round trips) | 2,384.1 us | 1,489 B |
+| raw: DNWQ shape, separate commands (7 round trips) | 2,384.1 us | 1,489 B |
 | raw: DNWQ shape, one script (EVALSHA, keys/values) | 360.5 us | 881 B |
 | raw: DNWQ shape, one script (object parameters, as the transport calls it) | 341.1 us | 1,161 B |
 | DotNetWorkQueue Redis send (end to end) | 562.6 us | 18,232 B |
@@ -538,7 +538,7 @@ share of wall time would be much larger. The allocation column is the one that t
 
 | finding | evidence |
 |---|---|
-| **The round trips are already collapsed, and that is where the win was** | The same writes as separate commands cost **2,384 us against 341 us** as one script - 6.6x. The transport has always sent them as one Lua script, so this is banked, not available. It is also the only large factor the ladder found on the send path |
+| **The round trips are already collapsed, and that is where the win was** | The same seven writes as separate commands cost **2,384 us against 341 us** as one script - **7.0x**. That is 341 us per command, which is one round trip, so the ladder is measuring round trips and nothing else here. The transport has always sent them as one Lua script, so this is banked, not available. It is also the only large factor the ladder found on the send path |
 | **Argument marshalling is not a lever, which kills the hypothesis this pass opened with** | `BaseLua` passes an anonymous object to `ScriptEvaluate`, so StackExchange.Redis maps `@name` placeholders onto members through its own extractor - the obvious suspect. Measured against the same script invoked by hash with explicit key and value arrays it is **341.1 us / 1,161 B against 360.5 us / 881 B**: no slower in time, and **280 B** more. That is 1.5% of what a send allocates. Rewriting the call sites would buy nothing |
 | **Scripts are loaded once and invoked by hash** | `BaseLua.LoadScript` prepares and loads on first use and holds the `LoadedLuaScript`; `TryExecute` reloads only on a `NOSCRIPT` reply. Confirmed by reading, not measurement - there is nothing to measure, because no script text is re-sent |
 | **The Redis server clock is not a per-de-queue round trip** | `RedisServerUnixTime` looked like one - the receive handler asks `IUnixTimeFactory` for a timestamp on every de-queue, and the transport's default `TimeServer` is `RedisServer`. It caches the offset and only round-trips when `TimeExpired()`, so a de-queue is one round trip, not two. Another hypothesis killed by reading |
@@ -553,8 +553,8 @@ remaining cost is core serialization and message construction, which is shared w
 Redis work, and the throughput ceiling under concurrent synchronous load is the missing async
 receive path in the core - #256, which is a larger piece of work than a transport pass.
 
-#233 closed on the measurements rather than on a change. That was named as a legitimate outcome
-when the issue was written, and it is the one that happened.
+Issue #233 closed on the measurements rather than on a change. That was named as a legitimate
+outcome when the issue was written, and it is the one that happened.
 
 
 ## RelationalDecoratorBenchmarks

--- a/Source/DotNetWorkQueue.Benchmarks/README.md
+++ b/Source/DotNetWorkQueue.Benchmarks/README.md
@@ -498,6 +498,65 @@ queues differing only in their connection string.
 | **A dry run of this suite reported it as a five-fold win, and that was nonsense** | 55.8 ms against 10.5 ms, with one invocation per rung and the `off` fixture running first, so it paid the connection and warm-up cost for both. The same order-dependent trap the SQL Server ladder had to correct. Recorded because the number looked spectacular and meant nothing |
 | The DDL risk is real, and only partly evidenced | Prepared statements live on the physical connection, the pool hands it back, and dropping a table invalidates any statement referencing it — and this library creates and drops queues routinely. `AutoPrepareSurvivesDdl` drives create → send past the threshold → drop → recreate under the same name → send, and passes. But Npgsql exposes no public counter for auto-prepared statements, so that is evidence the scenario works rather than proof the invalidation path was exercised. Do not read it as a safety guarantee |
 
+## RedisPathBenchmarks and RedisReceiveBenchmarks
+
+What a Redis send and de-queue cost, and where. Opens and closes the investigation in #233.
+
+Redis is shaped differently from the relational transports, so the rungs ask different questions.
+There is no connection per operation, no SQL generation and no statement compilation - the three
+costs that dominated the SQLite pass. What is left is round trips, how the Lua script and its
+arguments are marshalled, and thread-pool behaviour.
+
+**Measured against Redis 192.168.0.2:6379 from WSL2, payload 256 bytes, `InvocationCount(16)`,
+default job, `--inProcess` from `/tmp`.** The round trip to that host is ~335-380 us, which is the
+single most important thing to know when reading these tables: it swamps everything else, and every
+single-round-trip rung lands on top of it. On a Redis reachable in tens of microseconds the library
+share of wall time would be much larger. The allocation column is the one that transfers.
+
+### Send
+
+| rung | mean | allocated |
+|---|---|---|
+| round trip only: PING | 378.4 us | 128 B |
+| raw: DNWQ shape, separate commands (6 round trips) | 2,384.1 us | 1,489 B |
+| raw: DNWQ shape, one script (EVALSHA, keys/values) | 360.5 us | 881 B |
+| raw: DNWQ shape, one script (object parameters, as the transport calls it) | 341.1 us | 1,161 B |
+| DotNetWorkQueue Redis send (end to end) | 562.6 us | 18,232 B |
+| DotNetWorkQueue Redis SendAsync (end to end) | 569.6 us | 20,256 B |
+
+### Receive
+
+| rung | mean | allocated |
+|---|---|---|
+| round trip only: PING | 334.7 us | 128 B |
+| raw: de-queue script, empty queue | 343.3 us | 897 B |
+| raw: de-queue script, message waiting | 363.7 us | 1,577 B |
+| DotNetWorkQueue Redis de-queue, empty queue | 367.9 us | 1,329 B |
+| DotNetWorkQueue Redis de-queue, message waiting | 468.3 us | 15,556 B |
+
+### Findings
+
+| finding | evidence |
+|---|---|
+| **The round trips are already collapsed, and that is where the win was** | The same writes as separate commands cost **2,384 us against 341 us** as one script - 6.6x. The transport has always sent them as one Lua script, so this is banked, not available. It is also the only large factor the ladder found on the send path |
+| **Argument marshalling is not a lever, which kills the hypothesis this pass opened with** | `BaseLua` passes an anonymous object to `ScriptEvaluate`, so StackExchange.Redis maps `@name` placeholders onto members through its own extractor - the obvious suspect. Measured against the same script invoked by hash with explicit key and value arrays it is **341.1 us / 1,161 B against 360.5 us / 881 B**: no slower in time, and **280 B** more. That is 1.5% of what a send allocates. Rewriting the call sites would buy nothing |
+| **Scripts are loaded once and invoked by hash** | `BaseLua.LoadScript` prepares and loads on first use and holds the `LoadedLuaScript`; `TryExecute` reloads only on a `NOSCRIPT` reply. Confirmed by reading, not measurement - there is nothing to measure, because no script text is re-sent |
+| **The Redis server clock is not a per-de-queue round trip** | `RedisServerUnixTime` looked like one - the receive handler asks `IUnixTimeFactory` for a timestamp on every de-queue, and the transport's default `TimeServer` is `RedisServer`. It caches the offset and only round-trips when `TimeExpired()`, so a de-queue is one round trip, not two. Another hypothesis killed by reading |
+| **The idle poll is already at the floor** | An empty de-queue through the whole decorated library is **367.9 us / 1,329 B against 343.3 us / 897 B** for the bare script - the library adds ~25 us and **432 B** to a poll that collects nothing. This is where SQLite had its largest win, and Redis has no equivalent of it: there is no SQL to generate, so there is nothing to stop generating |
+| **What is left is the core, not the transport** | A send allocates **18,232 B** where the same Redis work costs 1,161 B, and a de-queue that collects a message allocates **15,556 B** against 1,577 B. That is serialization and message construction - shared by every transport, already decomposed in `CorePathBenchmarks`, and not reachable from inside the Redis transport |
+| Sync and async are the same single-threaded, and that says nothing about concurrency | 562.6 us against 569.6 us; async allocates 2 KB more. The sync path's problem is contention at concurrency, not per-operation cost - see #161 and #256. A single-threaded number cannot show it, which is exactly why it must not be quoted as though it could |
+
+### The conclusion, and why there is no code change
+
+Every lever this issue listed was either already pulled or measured as not worth pulling. The
+remaining cost is core serialization and message construction, which is shared work rather than
+Redis work, and the throughput ceiling under concurrent synchronous load is the missing async
+receive path in the core - #256, which is a larger piece of work than a transport pass.
+
+#233 closed on the measurements rather than on a change. That was named as a legitimate outcome
+when the issue was written, and it is the one that happened.
+
+
 ## RelationalDecoratorBenchmarks
 
 What the retry decorator costs per command, separated from the database call it wraps. Both #231

--- a/Source/DotNetWorkQueue.Benchmarks/RedisPathBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/RedisPathBenchmarks.cs
@@ -43,7 +43,8 @@ namespace DotNetWorkQueue.Benchmarks
     /// </para>
     /// <list type="bullet">
     /// <item><description><b>ping → separate commands</b> is what the round trips cost, and
-    /// therefore what collapsing them into one script is worth.</description></item>
+    /// therefore what collapsing them into one script is worth. An enqueue is seven commands, so
+    /// this rung is seven round trips against the one every rung below it makes.</description></item>
     /// <item><description><b>separate commands → script by hash</b> is that collapse, done the
     /// cheapest way the client offers: <c>EVALSHA</c> with explicit key and value arrays.</description></item>
     /// <item><description><b>script by hash → script with object parameters</b> is the cost of
@@ -101,7 +102,6 @@ namespace DotNetWorkQueue.Benchmarks
 
         private byte[] _scriptHash;
         private LoadedLuaScript _loadedScript;
-        private long _counter;
 
         private string _queueName;
         private QueueConnection _queueConnection;
@@ -154,7 +154,7 @@ namespace DotNetWorkQueue.Benchmarks
 
             _multiplexer = ConnectionMultiplexer.Connect(_connectionString);
             _database = _multiplexer.GetDatabase();
-            _server = _multiplexer.GetServer(_multiplexer.GetEndPoints().First());
+            _server = SingleServer(_multiplexer);
 
             var suffix = Guid.NewGuid().ToString("N");
             _rawPrefix = "{bench_" + suffix + "}";
@@ -309,6 +309,28 @@ namespace DotNetWorkQueue.Benchmarks
         {
             var result = await _producer.SendAsync(new Event { Body = _payload }).ConfigureAwait(false);
             if (result.HasError) throw result.SendingException ?? new InvalidOperationException("send failed");
+        }
+
+        /// <summary>
+        /// The one server this harness supports, or a clear failure.
+        /// </summary>
+        /// <remarks>
+        /// Scripts are loaded on one endpoint and keys are scanned from one endpoint. Against a
+        /// cluster both are wrong: <c>EVALSHA</c> can route to a node that never loaded the
+        /// script, and a scan misses the keys other nodes own - so the per-iteration cleanup would
+        /// silently leave data behind and every later rung would measure a queue that grew. The
+        /// second failure is the dangerous one, because it produces numbers rather than an error.
+        /// Refusing to run is the honest response; this harness measures a single instance.
+        /// </remarks>
+        internal static IServer SingleServer(ConnectionMultiplexer multiplexer)
+        {
+            var endpoints = multiplexer.GetEndPoints();
+            if (endpoints.Length != 1)
+                throw new NotSupportedException(
+                    $"These benchmarks measure a single Redis instance, and the connection names {endpoints.Length} " +
+                    "endpoints. Scripts would be loaded on one node and keys scanned from one node, so the " +
+                    "per-iteration cleanup would miss data and the numbers would drift without failing.");
+            return multiplexer.GetServer(endpoints[0]);
         }
 
         private void DeleteKeys(string pattern)

--- a/Source/DotNetWorkQueue.Benchmarks/RedisPathBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/RedisPathBenchmarks.cs
@@ -1,0 +1,327 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IoC;
+using DotNetWorkQueue.Transport.Redis.Basic;
+using StackExchange.Redis;
+
+namespace DotNetWorkQueue.Benchmarks
+{
+    /// <summary>
+    /// Decomposes a single Redis <c>Send</c>, the way <see cref="PostgreSqlPathBenchmarks"/> does
+    /// for PostgreSQL. Opens the investigation in #233.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Redis is shaped differently from the relational transports, so the rungs ask different
+    /// questions. There is no connection per operation, no SQL generation and no statement
+    /// compilation - the three costs that dominated the SQLite pass. What is left is round trips,
+    /// how the Lua script and its arguments are marshalled, and thread-pool behaviour.
+    /// </para>
+    /// <para>
+    /// The ladder is built so that each gap isolates one of those:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><b>ping → separate commands</b> is what the round trips cost, and
+    /// therefore what collapsing them into one script is worth.</description></item>
+    /// <item><description><b>separate commands → script by hash</b> is that collapse, done the
+    /// cheapest way the client offers: <c>EVALSHA</c> with explicit key and value arrays.</description></item>
+    /// <item><description><b>script by hash → script with object parameters</b> is the cost of
+    /// the way the transport actually calls it. <c>BaseLua</c> passes an anonymous object to
+    /// <c>ScriptEvaluate</c>, so StackExchange.Redis maps <c>@name</c> placeholders onto members
+    /// through its own extractor. Both rungs run the same script and do the same work in Redis,
+    /// so the difference between them is marshalling and nothing else.</description></item>
+    /// <item><description><b>script with object parameters → transport send</b> is the library:
+    /// serialization, message construction, the decorator stack and the producer.</description></item>
+    /// </list>
+    /// <para>
+    /// <b>Sync and async are reported separately, and the separation is the point.</b> Concurrent
+    /// synchronous sends time out on StackExchange.Redis 3.x even when the connection pool is not
+    /// starved - 3.0 removed its dedicated reply-completion pool, and <c>SetMinThreads</c> does not
+    /// help. These rungs are single-threaded so they do not provoke it, but a sync number here
+    /// must not be read as a per-operation cost that would hold at concurrency. See #161.
+    /// </para>
+    /// <para>
+    /// <b>Requires a Redis instance</b> via <c>DNWQ_REDIS_CONNECTION</c>, on a database the harness
+    /// may create and delete keys in.
+    /// </para>
+    /// <para>
+    /// Every rung starts from an empty key set and an iteration is a fixed, small number of
+    /// invocations - the same precaution the relational ladders document, where omitting it made
+    /// the ladder measure the order it ran in rather than the work. Here it matters more than
+    /// usual: the pending list and the values hash both grow per send, and <c>LPUSH</c> onto a
+    /// long list is not what it is onto a short one.
+    /// </para>
+    /// </remarks>
+    [MemoryDiagnoser]
+    [InvocationCount(16)]
+    public class RedisPathBenchmarks
+    {
+        private const int PayloadBytes = 256;
+
+        private string _connectionString;
+        private ConnectionMultiplexer _multiplexer;
+        private IDatabase _database;
+        private IServer _server;
+
+        private byte[] _body;
+        private byte[] _headers;
+        private byte[] _meta;
+        private string _payload;
+
+        /// <summary>Raw-rung keys, in one hash slot the way the transport keeps its own.</summary>
+        private string _rawPrefix;
+        private RedisKey _rawValues;
+        private RedisKey _rawHeaders;
+        private RedisKey _rawPending;
+        private RedisKey _rawMeta;
+        private RedisKey _rawStatus;
+        private RedisKey _rawId;
+        private string _rawChannel;
+
+        private byte[] _scriptHash;
+        private LoadedLuaScript _loadedScript;
+        private long _counter;
+
+        private string _queueName;
+        private QueueConnection _queueConnection;
+        private QueueCreationContainer<RedisQueueInit> _creation;
+        private QueueContainer<RedisQueueInit> _container;
+        private IProducerQueue<Event> _producer;
+
+        /// <summary>
+        /// The transport's enqueue script with the job and route branches removed - an ordinary
+        /// send takes neither, and leaving them in would measure two string comparisons per rung
+        /// rather than the marshalling this is here to isolate.
+        /// </summary>
+        private const string EnqueueScript = @"local id = @field
+                     if id == '' then
+                        id = redis.call('INCR', @IDKey)
+                     end
+                     redis.call('hset', @key, id, @value)
+                     redis.call('hset', @headerskey, id, @headers)
+                     redis.call('lpush', @pendingkey, id)
+                     redis.call('hset', @metakey, id, @metavalue)
+                     redis.call('hset', @StatusKey, id, '0')
+                     redis.call('publish', @channel, '')
+                     return id";
+
+        /// <summary>The same script written for <c>EVALSHA</c> with positional KEYS and ARGV.</summary>
+        private const string EnqueueScriptPositional = @"local id = ARGV[1]
+                     if id == '' then
+                        id = redis.call('INCR', KEYS[6])
+                     end
+                     redis.call('hset', KEYS[1], id, ARGV[2])
+                     redis.call('hset', KEYS[2], id, ARGV[3])
+                     redis.call('lpush', KEYS[3], id)
+                     redis.call('hset', KEYS[4], id, ARGV[4])
+                     redis.call('hset', KEYS[5], id, '0')
+                     redis.call('publish', ARGV[5], '')
+                     return id";
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _connectionString = Environment.GetEnvironmentVariable("DNWQ_REDIS_CONNECTION");
+            if (string.IsNullOrWhiteSpace(_connectionString))
+                throw new InvalidOperationException(
+                    "Set DNWQ_REDIS_CONNECTION to a Redis connection string. See the class remarks.");
+
+            _body = new byte[PayloadBytes];
+            _headers = new byte[64];
+            _meta = new byte[64];
+            _payload = new string('x', PayloadBytes);
+
+            _multiplexer = ConnectionMultiplexer.Connect(_connectionString);
+            _database = _multiplexer.GetDatabase();
+            _server = _multiplexer.GetServer(_multiplexer.GetEndPoints().First());
+
+            var suffix = Guid.NewGuid().ToString("N");
+            _rawPrefix = "{bench_" + suffix + "}";
+            _rawValues = _rawPrefix + "values";
+            _rawHeaders = _rawPrefix + "headers";
+            _rawPending = _rawPrefix + "pending";
+            _rawMeta = _rawPrefix + "meta";
+            _rawStatus = _rawPrefix + "status";
+            _rawId = _rawPrefix + "id";
+            _rawChannel = _rawPrefix + "notify";
+
+            _scriptHash = _server.ScriptLoad(EnqueueScriptPositional);
+            _loadedScript = LuaScript.Prepare(EnqueueScript).Load(_server);
+
+            //the transport's own queue, for the end-to-end rungs
+            _queueName = "bench" + suffix;
+            _queueConnection = new QueueConnection(_queueName, _connectionString);
+            _creation = new QueueCreationContainer<RedisQueueInit>();
+            using (var creator = _creation.GetQueueCreation<RedisQueueCreation>(_queueConnection))
+            {
+                var created = creator.CreateQueue();
+                if (!created.Success)
+                    throw new InvalidOperationException(created.ErrorMessage);
+            }
+
+            _container = new QueueContainer<RedisQueueInit>();
+            _producer = _container.CreateProducer<Event>(_queueConnection);
+        }
+
+        /// <summary>
+        /// An iteration must not pay for what the last one wrote. The pending list and the values
+        /// hash both grow per send, and the raw rungs and the transport rungs write to different
+        /// key sets, so both have to go.
+        /// </summary>
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            DeleteKeys(_rawPrefix + "*");
+            DeleteKeys("*" + _queueName + "*");
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _producer?.Dispose();
+            _container?.Dispose();
+
+            if (_queueConnection != null)
+            {
+                try
+                {
+                    using var creator = _creation.GetQueueCreation<RedisQueueCreation>(_queueConnection);
+                    creator.RemoveQueue();
+                }
+                catch (RedisException)
+                {
+                    //a queue left behind is not worth failing a run over
+                }
+            }
+            _creation?.Dispose();
+
+            try
+            {
+                DeleteKeys(_rawPrefix + "*");
+            }
+            catch (RedisException)
+            {
+                //same
+            }
+
+            _multiplexer?.Dispose();
+        }
+
+        /// <summary>The floor: one round trip that does no work.</summary>
+        [Benchmark(Description = "round trip only: PING")]
+        public TimeSpan Roundtrip_Ping()
+        {
+            return _database.Ping();
+        }
+
+        /// <summary>
+        /// The writes an enqueue makes, as separate commands. Against the script rungs this is
+        /// what collapsing them is worth.
+        /// </summary>
+        [Benchmark(Baseline = true, Description = "raw: DNWQ shape, separate commands")]
+        public long RawWrites_SeparateCommands()
+        {
+            var id = _database.StringIncrement(_rawId);
+            var field = (RedisValue)id;
+            _database.HashSet(_rawValues, field, _body);
+            _database.HashSet(_rawHeaders, field, _headers);
+            _database.ListLeftPush(_rawPending, field);
+            _database.HashSet(_rawMeta, field, _meta);
+            _database.HashSet(_rawStatus, field, "0");
+            _database.Publish(RedisChannel.Literal(_rawChannel), RedisValue.EmptyString);
+            return id;
+        }
+
+        /// <summary>
+        /// The same writes as one script, invoked by hash with positional keys and values - the
+        /// cheapest way the client offers to say this.
+        /// </summary>
+        [Benchmark(Description = "raw: DNWQ shape, one script (EVALSHA, keys/values)")]
+        public RedisResult RawWrites_OneScript_KeysAndValues()
+        {
+            var keys = new RedisKey[] { _rawValues, _rawHeaders, _rawPending, _rawMeta, _rawStatus, _rawId };
+            var values = new RedisValue[] { RedisValue.EmptyString, _body, _headers, _meta, _rawChannel };
+            return _database.ScriptEvaluate(_scriptHash, keys, values);
+        }
+
+        /// <summary>
+        /// The same script and the same work, invoked the way the transport does it: an anonymous
+        /// object whose members the client maps onto the <c>@name</c> placeholders. The gap to the
+        /// rung above is argument marshalling, and nothing else.
+        /// </summary>
+        [Benchmark(Description = "raw: DNWQ shape, one script (object parameters, as the transport calls it)")]
+        public RedisResult RawWrites_OneScript_ObjectParameters()
+        {
+            return _database.ScriptEvaluate(_loadedScript, new
+            {
+                field = (RedisValue)RedisValue.EmptyString,
+                key = _rawValues,
+                value = (RedisValue)_body,
+                headerskey = _rawHeaders,
+                headers = (RedisValue)_headers,
+                pendingkey = _rawPending,
+                metakey = _rawMeta,
+                metavalue = (RedisValue)_meta,
+                StatusKey = _rawStatus,
+                IDKey = _rawId,
+                channel = _rawChannel
+            });
+        }
+
+        /// <summary>
+        /// The whole send, as a caller experiences it. Against the object-parameter rung, what is
+        /// left is the library rather than the client or the server.
+        /// </summary>
+        [Benchmark(Description = "DotNetWorkQueue Redis send (end to end)")]
+        public void Transport_Send()
+        {
+            var result = _producer.Send(new Event { Body = _payload });
+            if (result.HasError) throw result.SendingException ?? new InvalidOperationException("send failed");
+        }
+
+        /// <summary>
+        /// The asynchronous send. Reported separately because the synchronous path carries a
+        /// StackExchange.Redis 3.x constraint the asynchronous one does not - see the remarks.
+        /// </summary>
+        [Benchmark(Description = "DotNetWorkQueue Redis SendAsync (end to end)")]
+        public async Task Transport_SendAsync()
+        {
+            var result = await _producer.SendAsync(new Event { Body = _payload }).ConfigureAwait(false);
+            if (result.HasError) throw result.SendingException ?? new InvalidOperationException("send failed");
+        }
+
+        private void DeleteKeys(string pattern)
+        {
+            foreach (var key in _server.Keys(_database.Database, pattern).ToArray())
+            {
+                _database.KeyDelete(key);
+            }
+        }
+
+        public sealed class Event
+        {
+            public string Body { get; set; }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Benchmarks/RedisReceiveBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/RedisReceiveBenchmarks.cs
@@ -128,7 +128,7 @@ namespace DotNetWorkQueue.Benchmarks
 
             _multiplexer = ConnectionMultiplexer.Connect(_connectionString);
             _database = _multiplexer.GetDatabase();
-            _server = _multiplexer.GetServer(_multiplexer.GetEndPoints().First());
+            _server = RedisPathBenchmarks.SingleServer(_multiplexer);
 
             var suffix = Guid.NewGuid().ToString("N");
             _rawPrefix = "{bench_" + suffix + "}";

--- a/Source/DotNetWorkQueue.Benchmarks/RedisReceiveBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/RedisReceiveBenchmarks.cs
@@ -1,0 +1,303 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IoC;
+using DotNetWorkQueue.Transport.Redis.Basic;
+using DotNetWorkQueue.Transport.Redis.Basic.Query;
+using DotNetWorkQueue.Transport.Shared;
+using StackExchange.Redis;
+
+namespace DotNetWorkQueue.Benchmarks
+{
+    /// <summary>
+    /// Decomposes a single Redis de-queue, the other half of #233.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The empty-queue rungs are the ones that matter most. An idle consumer polls continuously,
+    /// so whatever a de-queue costs when there is nothing to collect is paid forever by every
+    /// queue that is not busy. That is where the SQLite pass found its largest win - generating
+    /// the de-queue SQL was 91% of everything an empty de-queue allocated.
+    /// </para>
+    /// <para>
+    /// Redis cannot have that particular problem: the de-queue is one fixed Lua script, loaded
+    /// once and invoked by hash. These rungs are here to find out what it has instead, and to
+    /// separate the part that is the client and the network from the part that is the library.
+    /// </para>
+    /// <para>
+    /// The transport rungs resolve the real de-queue handler out of the consumer's own container,
+    /// so they run with the decorators the library actually wires up rather than a hand-built
+    /// approximation. See <see cref="ConsumerInternals"/>.
+    /// </para>
+    /// <para>
+    /// <b>Requires a Redis instance</b> via <c>DNWQ_REDIS_CONNECTION</c>.
+    /// </para>
+    /// </remarks>
+    [MemoryDiagnoser]
+    [InvocationCount(16)]
+    public class RedisReceiveBenchmarks
+    {
+        /// <summary>One more than the invocation count, so a populated rung never runs dry.</summary>
+        private const int MessagesPerIteration = 24;
+        private const int PayloadBytes = 256;
+
+        private string _connectionString;
+        private ConnectionMultiplexer _multiplexer;
+        private IDatabase _database;
+        private IServer _server;
+
+        private string _rawPrefix;
+        private RedisKey _rawValues;
+        private RedisKey _rawHeaders;
+        private RedisKey _rawPending;
+        private RedisKey _rawWorking;
+        private RedisKey _rawExpire;
+        private RedisKey _rawStatus;
+        private byte[] _scriptHash;
+        private byte[] _body;
+
+        private string _queueName;
+        private QueueConnection _queueConnection;
+        private QueueCreationContainer<RedisQueueInit> _creation;
+        private QueueContainer<RedisQueueInit> _producerContainer;
+        private IProducerQueue<Event> _producer;
+        private QueueContainer<RedisQueueInit> _consumerContainer;
+        private IConsumerQueue _consumer;
+        private IQueryHandler<ReceiveMessageQuery, RedisMessage> _receive;
+        private IMessageContextFactory _contextFactory;
+
+        //an idle consumer polls a queue that stays empty. Sharing one queue with the populated
+        //rung would have had the "empty" rung collecting the messages the setup just wrote.
+        private string _idleQueueName;
+        private QueueConnection _idleQueueConnection;
+        private QueueContainer<RedisQueueInit> _idleConsumerContainer;
+        private IConsumerQueue _idleConsumer;
+        private IQueryHandler<ReceiveMessageQuery, RedisMessage> _receiveIdle;
+        private IMessageContextFactory _idleContextFactory;
+        private string _payload;
+
+        /// <summary>
+        /// The transport's de-queue script, written for <c>EVALSHA</c> with positional keys. Same
+        /// work, called the cheapest way the client offers - the gap to the transport rung is the
+        /// library rather than Redis.
+        /// </summary>
+        private const string DequeueScriptPositional = @"local uuid = redis.call('rpop', KEYS[1])
+                    if (uuid==false) then
+                        return nil;
+                    end
+                    local expireScore = redis.call('zscore', KEYS[5], uuid)
+                    local message = redis.call('hget', KEYS[2], uuid)
+                    local headers = redis.call('hget', KEYS[3], uuid)
+                    if(message) then
+                        redis.call('zadd', KEYS[4], ARGV[1], uuid)
+                        redis.call('hset', KEYS[6], uuid, '1')
+                        return {uuid, message, headers, expireScore}
+                    else
+                        return {uuid, '', '', ''}
+                    end";
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _connectionString = Environment.GetEnvironmentVariable("DNWQ_REDIS_CONNECTION");
+            if (string.IsNullOrWhiteSpace(_connectionString))
+                throw new InvalidOperationException(
+                    "Set DNWQ_REDIS_CONNECTION to a Redis connection string. See the class remarks.");
+
+            _body = new byte[PayloadBytes];
+            _payload = new string('x', PayloadBytes);
+
+            _multiplexer = ConnectionMultiplexer.Connect(_connectionString);
+            _database = _multiplexer.GetDatabase();
+            _server = _multiplexer.GetServer(_multiplexer.GetEndPoints().First());
+
+            var suffix = Guid.NewGuid().ToString("N");
+            _rawPrefix = "{bench_" + suffix + "}";
+            _rawPending = _rawPrefix + "pending";
+            _rawValues = _rawPrefix + "values";
+            _rawHeaders = _rawPrefix + "headers";
+            _rawWorking = _rawPrefix + "working";
+            _rawExpire = _rawPrefix + "expire";
+            _rawStatus = _rawPrefix + "status";
+            _scriptHash = _server.ScriptLoad(DequeueScriptPositional);
+
+            _queueName = "bench" + suffix;
+            _queueConnection = new QueueConnection(_queueName, _connectionString);
+            _creation = new QueueCreationContainer<RedisQueueInit>();
+            using (var creator = _creation.GetQueueCreation<RedisQueueCreation>(_queueConnection))
+            {
+                var created = creator.CreateQueue();
+                if (!created.Success)
+                    throw new InvalidOperationException(created.ErrorMessage);
+            }
+
+            _producerContainer = new QueueContainer<RedisQueueInit>();
+            _producer = _producerContainer.CreateProducer<Event>(_queueConnection);
+
+            _consumerContainer = new QueueContainer<RedisQueueInit>();
+            _consumer = _consumerContainer.CreateConsumer(_queueConnection);
+            var container = ConsumerInternals.ContainerOf(_consumerContainer);
+            _receive = container.GetInstance<IQueryHandler<ReceiveMessageQuery, RedisMessage>>();
+            _contextFactory = container.GetInstance<IMessageContextFactory>();
+
+            _idleQueueName = "benchidle" + suffix;
+            _idleQueueConnection = new QueueConnection(_idleQueueName, _connectionString);
+            using (var creator = _creation.GetQueueCreation<RedisQueueCreation>(_idleQueueConnection))
+            {
+                var created = creator.CreateQueue();
+                if (!created.Success)
+                    throw new InvalidOperationException(created.ErrorMessage);
+            }
+
+            _idleConsumerContainer = new QueueContainer<RedisQueueInit>();
+            _idleConsumer = _idleConsumerContainer.CreateConsumer(_idleQueueConnection);
+            var idleContainer = ConsumerInternals.ContainerOf(_idleConsumerContainer);
+            _receiveIdle = idleContainer.GetInstance<IQueryHandler<ReceiveMessageQuery, RedisMessage>>();
+            _idleContextFactory = idleContainer.GetInstance<IMessageContextFactory>();
+        }
+
+        /// <summary>
+        /// The populated rungs consume what they read, so each iteration has to start from a known
+        /// depth - otherwise a rung measures how many messages the one before it left behind.
+        /// </summary>
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            DeleteKeys(_rawPrefix + "*");
+            DeleteKeys("*" + _queueName + "*");
+
+            for (var i = 0; i < MessagesPerIteration; i++)
+            {
+                _database.ListLeftPush(_rawPending, i);
+                _database.HashSet(_rawValues, i, _body);
+                _database.HashSet(_rawHeaders, i, _body);
+
+                var result = _producer.Send(new Event { Body = _payload });
+                if (result.HasError) throw result.SendingException ?? new InvalidOperationException("send failed");
+            }
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _idleConsumer?.Dispose();
+            _idleConsumerContainer?.Dispose();
+            _consumer?.Dispose();
+            _consumerContainer?.Dispose();
+            _producer?.Dispose();
+            _producerContainer?.Dispose();
+
+            foreach (var connection in new[] { _queueConnection, _idleQueueConnection })
+            {
+                if (connection == null) continue;
+                try
+                {
+                    using var creator = _creation.GetQueueCreation<RedisQueueCreation>(connection);
+                    creator.RemoveQueue();
+                }
+                catch (RedisException)
+                {
+                    //a queue left behind is not worth failing a run over
+                }
+            }
+            _creation?.Dispose();
+
+            try
+            {
+                DeleteKeys(_rawPrefix + "*");
+            }
+            catch (RedisException)
+            {
+                //same
+            }
+
+            _multiplexer?.Dispose();
+        }
+
+        /// <summary>The floor: one round trip that does no work.</summary>
+        [Benchmark(Description = "round trip only: PING")]
+        public TimeSpan Roundtrip_Ping()
+        {
+            return _database.Ping();
+        }
+
+        /// <summary>
+        /// The de-queue script against an empty pending list - the poll an idle consumer repeats
+        /// forever, with the client cost and nothing else.
+        /// </summary>
+        [Benchmark(Baseline = true, Description = "raw: de-queue script, empty queue")]
+        public object RawDequeue_Empty()
+        {
+            return _database.ScriptEvaluate(_scriptHash, EmptyKeys(), new RedisValue[] { 0 });
+        }
+
+        /// <summary>The same script when there is a message to collect.</summary>
+        [Benchmark(Description = "raw: de-queue script, message waiting")]
+        public object RawDequeue_Populated()
+        {
+            return _database.ScriptEvaluate(_scriptHash, RawKeys(), new RedisValue[] { 0 });
+        }
+
+        /// <summary>
+        /// The library's de-queue against an empty queue, decorators included. Against the raw
+        /// empty rung, what is left is what the library adds to a poll that collects nothing.
+        /// </summary>
+        [Benchmark(Description = "DotNetWorkQueue Redis de-queue, empty queue")]
+        public object Transport_Dequeue_Empty()
+        {
+            using var context = _idleContextFactory.Create();
+            return _receiveIdle.Handle(new ReceiveMessageQuery(context));
+        }
+
+        /// <summary>The library's de-queue when there is a message to collect.</summary>
+        [Benchmark(Description = "DotNetWorkQueue Redis de-queue, message waiting")]
+        public object Transport_Dequeue_Populated()
+        {
+            using var context = _contextFactory.Create();
+            return _receive.Handle(new ReceiveMessageQuery(context));
+        }
+
+        /// <summary>Keys that exist but hold nothing, so the script takes its empty branch.</summary>
+        private RedisKey[] EmptyKeys()
+        {
+            return new[] { (RedisKey)(_rawPrefix + "nothing"), _rawValues, _rawHeaders, _rawWorking, _rawExpire, _rawStatus };
+        }
+
+        private RedisKey[] RawKeys()
+        {
+            return new[] { _rawPending, _rawValues, _rawHeaders, _rawWorking, _rawExpire, _rawStatus };
+        }
+
+        private void DeleteKeys(string pattern)
+        {
+            foreach (var key in _server.Keys(_database.Database, pattern).ToArray())
+            {
+                _database.KeyDelete(key);
+            }
+        }
+
+        public sealed class Event
+        {
+            public string Body { get; set; }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis/InternalsVisibleForTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/InternalsVisibleForTests.cs
@@ -22,3 +22,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("DotNetWorkQueue.Transport.Redis.Integration.Tests")]
 [assembly: InternalsVisibleTo("DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests")]
+//the benchmark harness measures the dequeue query handler directly; reaching it by
+//reflection instead would measure the reflection - the same reason SqlServer grants this.
+[assembly: InternalsVisibleTo("DotNetWorkQueue.Benchmarks")]


### PR DESCRIPTION
Closes #233.

Two benchmark ladders for Redis — send and de-queue — and the conclusion that the transport has no lever left. **No production code changes.**

## What the ladders found

Measured against Redis over the LAN from WSL2, 256-byte payload, default job, `--inProcess` from `/tmp`. Full tables and reasoning are in `Source/DotNetWorkQueue.Benchmarks/README.md`.

| | mean | allocated |
|---|---|---|
| raw: DNWQ shape, separate commands (6 round trips) | 2,384.1 us | 1,489 B |
| raw: DNWQ shape, one script (object parameters, as the transport calls it) | 341.1 us | 1,161 B |
| DotNetWorkQueue Redis send (end to end) | 562.6 us | 18,232 B |
| DotNetWorkQueue Redis de-queue, empty queue | 367.9 us | 1,329 B |
| raw: de-queue script, empty queue | 343.3 us | 897 B |

- **Round trips are already collapsed** — 6.6x, and the transport has always done it.
- **The opening hypothesis is dead.** `BaseLua` passes an anonymous object to `ScriptEvaluate`, so the client maps `@name` placeholders through its own extractor — the obvious suspect. Against the same script invoked by hash with explicit key/value arrays it is *not slower* and costs 280 B more, 1.5% of a send.
- **The idle poll is at the floor** — the library adds ~25 us and 432 B to an empty de-queue. This was SQLite's largest win; Redis has no equivalent because there is no SQL to generate.
- **What is left is core, not transport** — 18,232 B for a send against 1,161 B of Redis work.

Two more hypotheses died by reading rather than measurement, and both are recorded: scripts are loaded once and invoked by hash, and `RedisServerUnixTime` caches its offset rather than round-tripping per de-queue.

## What to look at

**The round-trip time dominates every rung** — a PING to this host is ~335-380 us, so each single-round-trip form lands on top of it and the latency column mostly measures the network. The allocation column is the one that transfers to a different deployment. That caveat is stated at the top of the README section rather than buried, because quoting these latencies as per-operation library costs would be wrong.

**The sync and async rungs are single-threaded and deliberately prove nothing about concurrency.** The known SE.Redis 3.x problem is contention at concurrency, not per-operation cost (#161). A single-threaded number cannot show it.

**`InternalsVisibleTo("DotNetWorkQueue.Benchmarks")` added to the Redis transport**, matching what SqlServer already grants, so the de-queue rungs resolve the real handler out of the consumer's own container with its decorators.

## Why there is no changelog entry

Nothing here is visible to a consumer — no behaviour, no API, no performance change. Under the rule added in #254 that makes it a commit-message matter, not a changelog one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Redis enqueue and dequeue performance benchmarks covering raw Redis operations and transport-level workflows.
  - Added benchmark documentation summarizing performance findings and investigation results.

- **Chores**
  - Enabled the benchmark project to reference the Redis transport for performance testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->