### PR TITLE
Sonar cleanup after the performance sweep

### DIFF
--- a/Source/DotNetWorkQueue.Benchmarks/LiteDbReceiveConcurrencyBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/LiteDbReceiveConcurrencyBenchmarks.cs
@@ -76,7 +76,6 @@ namespace DotNetWorkQueue.Benchmarks
         private const int MaxThreads = 8;
 
         private string _dir;
-        private string _payload;
         private List<LiteDbPathBenchmarks.Event> _seed;
 
         private Fixture _a, _b;
@@ -102,10 +101,10 @@ namespace DotNetWorkQueue.Benchmarks
         [GlobalSetup]
         public void GlobalSetup()
         {
-            _payload = new string('x', PayloadBytes);
+            var payload = new string('x', PayloadBytes);
             _seed = new List<LiteDbPathBenchmarks.Event>(TotalMessages);
             for (var i = 0; i < TotalMessages; i++)
-                _seed.Add(new LiteDbPathBenchmarks.Event { Body = _payload });
+                _seed.Add(new LiteDbPathBenchmarks.Event { Body = payload });
 
             _dir = Path.Combine(Path.GetTempPath(), "dnwq-litedb-recv-conc", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(_dir);

--- a/Source/DotNetWorkQueue.Benchmarks/MemoryReceiveBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/MemoryReceiveBenchmarks.cs
@@ -68,7 +68,6 @@ namespace DotNetWorkQueue.Benchmarks
         private const int PayloadBytes = 256;
 
         private string _payload;
-        private QueueConnection _queueConnection;
 
         private QueueCreationContainer<MemoryBasic.MemoryMessageQueueInit> _creation;
         private QueueContainer<MemoryBasic.MemoryMessageQueueInit> _producerContainer;
@@ -116,10 +115,10 @@ namespace DotNetWorkQueue.Benchmarks
         [IterationSetup]
         public void IterationSetup()
         {
-            _queueConnection = new QueueConnection("benchMemoryReceive" + Guid.NewGuid().ToString("N"), "memory");
+            var queueConnection = new QueueConnection("benchMemoryReceive" + Guid.NewGuid().ToString("N"), "memory");
 
             _creation = new QueueCreationContainer<MemoryBasic.MemoryMessageQueueInit>();
-            using (var creator = _creation.GetQueueCreation<MemoryBasic.MessageQueueCreation>(_queueConnection))
+            using (var creator = _creation.GetQueueCreation<MemoryBasic.MessageQueueCreation>(queueConnection))
             {
                 var result = creator.CreateQueue();
                 if (!result.Success)
@@ -127,7 +126,7 @@ namespace DotNetWorkQueue.Benchmarks
             }
 
             _producerContainer = new QueueContainer<MemoryBasic.MemoryMessageQueueInit>();
-            _producer = _producerContainer.CreateProducer<Event>(_queueConnection);
+            _producer = _producerContainer.CreateProducer<Event>(queueConnection);
             for (var i = 0; i < Messages; i++)
             {
                 var result = _producer.Send(new Event { Body = _payload });
@@ -139,7 +138,7 @@ namespace DotNetWorkQueue.Benchmarks
             //queue this benchmark is draining. It exists so the container builds the receive chain
             //exactly as a running consumer would, and the pieces are then driven directly.
             _consumerContainer = new QueueContainer<MemoryBasic.MemoryMessageQueueInit>();
-            _consumer = _consumerContainer.CreateConsumer(_queueConnection);
+            _consumer = _consumerContainer.CreateConsumer(queueConnection);
 
             var container = ConsumerInternals.ContainerOf(_consumerContainer);
             _storage = container.GetInstance<IDataStorage>();
@@ -199,7 +198,7 @@ namespace DotNetWorkQueue.Benchmarks
         public void IterationCleanup()
         {
             _sharedLinked?.Dispose();
-            (_storage as IDataStorage)?.Clear();
+            _storage?.Clear();
             _consumer?.Dispose();
             _consumerContainer?.Dispose();
             _producer?.Dispose();

--- a/Source/DotNetWorkQueue.Benchmarks/PostgreSqlAutoPrepareBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/PostgreSqlAutoPrepareBenchmarks.cs
@@ -76,7 +76,7 @@ namespace DotNetWorkQueue.Benchmarks
             //mean a caller whose string already set Max Auto Prepare got a baseline that was not
             //off, and a comparison of a thing against itself - which would look like "no effect"
             //and be indistinguishable from a real result.
-            var separator = baseConnection.TrimEnd().EndsWith(";", StringComparison.Ordinal) ? "" : ";";
+            var separator = baseConnection.TrimEnd().EndsWith(';') ? "" : ";";
             _off = Fixture.Create(baseConnection + separator + AutoPrepareDisabled, _payload);
             _on = Fixture.Create(baseConnection + separator + AutoPrepareSettings, _payload);
         }

--- a/Source/DotNetWorkQueue.Benchmarks/PostgreSqlReceiveBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/PostgreSqlReceiveBenchmarks.cs
@@ -54,7 +54,6 @@ namespace DotNetWorkQueue.Benchmarks
     [MemoryDiagnoser]
     public class PostgreSqlReceiveBenchmarks
     {
-        private string _connectionString;
         private QueueConnection _queueConnection;
         private QueueCreationContainer<PostgreSqlMessageQueueInit> _creation;
         private QueueContainer<PostgreSqlMessageQueueInit> _container;
@@ -70,15 +69,15 @@ namespace DotNetWorkQueue.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            _connectionString = Environment.GetEnvironmentVariable("DNWQ_POSTGRES_CONNECTION");
-            if (string.IsNullOrWhiteSpace(_connectionString))
+            var connectionString = Environment.GetEnvironmentVariable("DNWQ_POSTGRES_CONNECTION");
+            if (string.IsNullOrWhiteSpace(connectionString))
                 throw new InvalidOperationException(
                     "Set DNWQ_POSTGRES_CONNECTION to a PostgreSQL connection string.");
 
             _routes = new List<string> { "a-route" };
 
             _queueConnection = new QueueConnection(
-                "benchpgrecv" + Guid.NewGuid().ToString("N"), _connectionString);
+                "benchpgrecv" + Guid.NewGuid().ToString("N"), connectionString);
 
             _creation = new QueueCreationContainer<PostgreSqlMessageQueueInit>();
             using (var creator = _creation.GetQueueCreation<PostgreSqlMessageQueueCreation>(_queueConnection))

--- a/Source/DotNetWorkQueue.Benchmarks/RedisPathBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/RedisPathBenchmarks.cs
@@ -80,7 +80,6 @@ namespace DotNetWorkQueue.Benchmarks
     {
         private const int PayloadBytes = 256;
 
-        private string _connectionString;
         private ConnectionMultiplexer _multiplexer;
         private IDatabase _database;
         private IServer _server;
@@ -142,8 +141,8 @@ namespace DotNetWorkQueue.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            _connectionString = Environment.GetEnvironmentVariable("DNWQ_REDIS_CONNECTION");
-            if (string.IsNullOrWhiteSpace(_connectionString))
+            var connectionString = Environment.GetEnvironmentVariable("DNWQ_REDIS_CONNECTION");
+            if (string.IsNullOrWhiteSpace(connectionString))
                 throw new InvalidOperationException(
                     "Set DNWQ_REDIS_CONNECTION to a Redis connection string. See the class remarks.");
 
@@ -152,7 +151,7 @@ namespace DotNetWorkQueue.Benchmarks
             _meta = new byte[64];
             _payload = new string('x', PayloadBytes);
 
-            _multiplexer = ConnectionMultiplexer.Connect(_connectionString);
+            _multiplexer = ConnectionMultiplexer.Connect(connectionString);
             _database = _multiplexer.GetDatabase();
             _server = SingleServer(_multiplexer);
 
@@ -171,7 +170,7 @@ namespace DotNetWorkQueue.Benchmarks
 
             //the transport's own queue, for the end-to-end rungs
             _queueName = "bench" + suffix;
-            _queueConnection = new QueueConnection(_queueName, _connectionString);
+            _queueConnection = new QueueConnection(_queueName, connectionString);
             _creation = new QueueCreationContainer<RedisQueueInit>();
             using (var creator = _creation.GetQueueCreation<RedisQueueCreation>(_queueConnection))
             {
@@ -275,7 +274,7 @@ namespace DotNetWorkQueue.Benchmarks
         {
             return _database.ScriptEvaluate(_loadedScript, new
             {
-                field = (RedisValue)RedisValue.EmptyString,
+                field = RedisValue.EmptyString,
                 key = _rawValues,
                 value = (RedisValue)_body,
                 headerskey = _rawHeaders,

--- a/Source/DotNetWorkQueue.Benchmarks/RedisReceiveBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/RedisReceiveBenchmarks.cs
@@ -60,7 +60,6 @@ namespace DotNetWorkQueue.Benchmarks
         private const int MessagesPerIteration = 24;
         private const int PayloadBytes = 256;
 
-        private string _connectionString;
         private ConnectionMultiplexer _multiplexer;
         private IDatabase _database;
         private IServer _server;
@@ -87,7 +86,6 @@ namespace DotNetWorkQueue.Benchmarks
 
         //an idle consumer polls a queue that stays empty. Sharing one queue with the populated
         //rung would have had the "empty" rung collecting the messages the setup just wrote.
-        private string _idleQueueName;
         private QueueConnection _idleQueueConnection;
         private QueueContainer<RedisQueueInit> _idleConsumerContainer;
         private IConsumerQueue _idleConsumer;
@@ -118,15 +116,15 @@ namespace DotNetWorkQueue.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            _connectionString = Environment.GetEnvironmentVariable("DNWQ_REDIS_CONNECTION");
-            if (string.IsNullOrWhiteSpace(_connectionString))
+            var connectionString = Environment.GetEnvironmentVariable("DNWQ_REDIS_CONNECTION");
+            if (string.IsNullOrWhiteSpace(connectionString))
                 throw new InvalidOperationException(
                     "Set DNWQ_REDIS_CONNECTION to a Redis connection string. See the class remarks.");
 
             _body = new byte[PayloadBytes];
             _payload = new string('x', PayloadBytes);
 
-            _multiplexer = ConnectionMultiplexer.Connect(_connectionString);
+            _multiplexer = ConnectionMultiplexer.Connect(connectionString);
             _database = _multiplexer.GetDatabase();
             _server = RedisPathBenchmarks.SingleServer(_multiplexer);
 
@@ -141,7 +139,7 @@ namespace DotNetWorkQueue.Benchmarks
             _scriptHash = _server.ScriptLoad(DequeueScriptPositional);
 
             _queueName = "bench" + suffix;
-            _queueConnection = new QueueConnection(_queueName, _connectionString);
+            _queueConnection = new QueueConnection(_queueName, connectionString);
             _creation = new QueueCreationContainer<RedisQueueInit>();
             using (var creator = _creation.GetQueueCreation<RedisQueueCreation>(_queueConnection))
             {
@@ -159,8 +157,8 @@ namespace DotNetWorkQueue.Benchmarks
             _receive = container.GetInstance<IQueryHandler<ReceiveMessageQuery, RedisMessage>>();
             _contextFactory = container.GetInstance<IMessageContextFactory>();
 
-            _idleQueueName = "benchidle" + suffix;
-            _idleQueueConnection = new QueueConnection(_idleQueueName, _connectionString);
+            var idleQueueName = "benchidle" + suffix;
+            _idleQueueConnection = new QueueConnection(idleQueueName, connectionString);
             using (var creator = _creation.GetQueueCreation<RedisQueueCreation>(_idleQueueConnection))
             {
                 var created = creator.CreateQueue();

--- a/Source/DotNetWorkQueue.Benchmarks/SqlServerReceiveBenchmarks.cs
+++ b/Source/DotNetWorkQueue.Benchmarks/SqlServerReceiveBenchmarks.cs
@@ -56,7 +56,6 @@ namespace DotNetWorkQueue.Benchmarks
     [MemoryDiagnoser]
     public class SqlServerReceiveBenchmarks
     {
-        private string _connectionString;
         private QueueConnection _queueConnection;
         private QueueCreationContainer<SqlServerMessageQueueInit> _creation;
         private QueueContainer<SqlServerMessageQueueInit> _container;
@@ -71,15 +70,15 @@ namespace DotNetWorkQueue.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            _connectionString = Environment.GetEnvironmentVariable("DNWQ_SQLSERVER_CONNECTION");
-            if (string.IsNullOrWhiteSpace(_connectionString))
+            var connectionString = Environment.GetEnvironmentVariable("DNWQ_SQLSERVER_CONNECTION");
+            if (string.IsNullOrWhiteSpace(connectionString))
                 throw new InvalidOperationException(
                     "Set DNWQ_SQLSERVER_CONNECTION to a SQL Server connection string.");
 
             _routes = new List<string> { "a-route" };
 
             _queueConnection = new QueueConnection(
-                "benchSqlServerRecv" + Guid.NewGuid().ToString("N"), _connectionString);
+                "benchSqlServerRecv" + Guid.NewGuid().ToString("N"), connectionString);
 
             _creation = new QueueCreationContainer<SqlServerMessageQueueInit>();
             using (var creator = _creation.GetQueueCreation<SqlServerMessageQueueCreation>(_queueConnection))

--- a/Source/DotNetWorkQueue.Tests/Metrics/Net/TimerNetTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Metrics/Net/TimerNetTests.cs
@@ -73,12 +73,12 @@ namespace DotNetWorkQueue.Tests.Metrics.Net
             using (var context = test.NewContext())
             {
                 System.Threading.Thread.Sleep(5);
-                Assert.IsTrue(context.Elapsed > TimeSpan.Zero, "the scope should be timing");
+                Assert.IsGreaterThan(TimeSpan.Zero, context.Elapsed, "the scope should be timing");
             }
 
             listener.Dispose();
             Assert.HasCount(1, recorded);
-            Assert.IsTrue(recorded[0] > 0, "the recorded duration should be greater than zero");
+            Assert.IsGreaterThan(0, recorded[0], "the recorded duration should be greater than zero");
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/Consumer/DateKindIsPreserved.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/Consumer/DateKindIsPreserved.cs
@@ -72,7 +72,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.IntegrationTests.Consumer
                 "delayed messages early");
 
             //and the comparison the de-queue makes gives the right answer
-            Assert.IsTrue(row.QueueProcessTime.Value >= DateTime.UtcNow,
+            Assert.IsGreaterThanOrEqualTo(DateTime.UtcNow, row.QueueProcessTime.Value,
                 "a message deferred an hour ahead should compare as not yet due");
         }
     }

--- a/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/Producer/BatchSendResults.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/Producer/BatchSendResults.cs
@@ -64,12 +64,12 @@ namespace DotNetWorkQueue.Transport.LiteDb.IntegrationTests.Producer
             var results = producer.Send(batch).ToList();
 
             Assert.HasCount(messageCount, results);
-            Assert.IsFalse(results.Any(r => r.HasError),
+            Assert.DoesNotContain(r => r.HasError, results,
                 results.FirstOrDefault(r => r.HasError)?.SendingException?.ToString() ?? "no error");
 
             var ids = results.Select(r => (int)r.SentMessage.MessageId.Id.Value).ToList();
-            Assert.IsFalse(ids.Any(id => id <= 0), "every message should come back with a real id");
-            Assert.AreEqual(messageCount, ids.Distinct().Count(), "ids should be unique");
+            Assert.DoesNotContain(id => id <= 0, ids, "every message should come back with a real id");
+            Assert.HasCount(messageCount, ids.Distinct().ToList(), "ids should be unique");
 
             //inserted sequentially in one transaction, so the caller's order is the id order
             CollectionAssert.AreEqual(ids.OrderBy(id => id).ToList(), ids,
@@ -157,7 +157,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.IntegrationTests.Producer
             var results = producer.Send(batch).ToList();
 
             Assert.HasCount(batch.Count, results);
-            Assert.IsFalse(results.Any(r => r.HasError),
+            Assert.DoesNotContain(r => r.HasError, results,
                 results.FirstOrDefault(r => r.HasError)?.SendingException?.ToString() ?? "no error");
         }
 

--- a/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Producer/BatchSendOrder.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/Producer/BatchSendOrder.cs
@@ -92,17 +92,17 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.Producer
             var results = send(producer, batch);
 
             Assert.HasCount(messageCount, results);
-            Assert.IsFalse(results.Any(r => r.HasError),
+            Assert.DoesNotContain(r => r.HasError, results,
                 results.FirstOrDefault(r => r.HasError)?.SendingException?.ToString() ?? "no error");
 
             var returned = results.Select(r => (Guid)r.SentMessage.CorrelationId.Id.Value).ToList();
             CollectionAssert.AreEqual(sent, returned,
                 "results came back in a different order than the messages were sent");
 
-            Assert.IsFalse(results.Any(r => (Guid)r.SentMessage.MessageId.Id.Value == Guid.Empty),
+            Assert.DoesNotContain(r => (Guid)r.SentMessage.MessageId.Id.Value == Guid.Empty, results,
                 "every message should come back with a real id");
-            Assert.AreEqual(messageCount,
-                results.Select(r => (Guid)r.SentMessage.MessageId.Id.Value).Distinct().Count(),
+            Assert.HasCount(messageCount,
+                results.Select(r => (Guid)r.SentMessage.MessageId.Id.Value).Distinct().ToList(),
                 "ids should be unique");
         }
     }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Producer/AutoPrepareSurvivesDdl.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Producer/AutoPrepareSurvivesDdl.cs
@@ -81,7 +81,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Producer
 
         private static string WithAutoPrepare(string connectionString)
         {
-            var separator = connectionString.TrimEnd().EndsWith(";", StringComparison.Ordinal) ? "" : ";";
+            var separator = connectionString.TrimEnd().EndsWith(';') ? "" : ";";
             return connectionString + separator + AutoPrepare;
         }
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandHandler/SendMessage.cs
@@ -113,20 +113,18 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
         /// Whether this message's statement is the invariant shape and may be cached.
         /// </summary>
         /// <remarks>
-        /// A delay or an expiration is written into the meta insert as a literal tick count, so
-        /// those texts differ per message. <see cref="PostgreSqlMessageQueueTransportOptions.EnableDelayedProcessing"/>
-        /// is stricter than it looks: with it on, the current time is inlined even when the message
-        /// carries <b>no</b> delay, so every send produces a different statement. SQL Server writes
-        /// an invariant <c>GetUTCDate()</c> in that position instead. Parameterising the two would
-        /// let this cover every message and is worth doing separately - it is why a delayed-processing
-        /// queue re-plans on every send.
+        /// The delay and the expiration used to be written into the meta insert as literal tick
+        /// counts, which kept a delayed-processing queue out of this cache entirely and made it
+        /// re-plan on every send. They ride as parameters since #255, so neither excludes a
+        /// message any more.
         /// <para>
-        /// User columns on the status table are written into that insert by name, so those are
-        /// excluded too.
+        /// What remains are the two shapes whose <em>text</em> still varies per message: user
+        /// columns on the meta insert, and user columns on the status insert, both written in by
+        /// name.
         /// </para>
         /// </remarks>
         private static bool CanCacheSingleRoundTripSql(IAdditionalMessageData data,
-            PostgreSqlMessageQueueTransportOptions options, TimeSpan expiration)
+            PostgreSqlMessageQueueTransportOptions options)
         {
             if (options.AdditionalColumnsOnMetaData) return false;
             if (options.EnableStatusTable && data.AdditionalMetaData.Count > 0) return false;
@@ -187,7 +185,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandHandler
             }
 
             string cacheKey = null;
-            if (CanCacheSingleRoundTripSql(data, options, expiration))
+            if (CanCacheSingleRoundTripSql(data, options))
             {
                 //every table the statement writes to is named in the key. Both shipped helpers
                 //derive StatusName from QueueName, but ITableNameHelper exposes the two

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessage.cs
@@ -101,15 +101,16 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
         private static readonly ConcurrentDictionary<string, string> MetaSqlCache = new();
 
         /// <summary>
-        /// Whether this message's meta SQL is the invariant shape. Anything that writes a literal
-        /// into the text - a delay, an expiration - or that varies with the message's own columns
-        /// is built fresh.
+        /// Whether this message's meta SQL is the invariant shape.
         /// </summary>
-        private static bool CanCacheMetaSql(IAdditionalMessageData data,
-            SqlServerMessageQueueTransportOptions options, TimeSpan? delay, TimeSpan expiration)
+        /// <remarks>
+        /// The delay and the expiration used to be literals in the text, so any message carrying
+        /// one was built fresh. They ride as parameters since #255, which leaves the user's own
+        /// columns as the only thing that still varies the text per message.
+        /// </remarks>
+        private static bool CanCacheMetaSql(SqlServerMessageQueueTransportOptions options)
         {
-            if (options.AdditionalColumnsOnMetaData) return false;
-            return true;
+            return !options.AdditionalColumnsOnMetaData;
         }
 
         /// <summary>
@@ -206,10 +207,12 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
             //StatusName from QueueName, but ITableNameHelper exposes the two independently -
             //keying on the derivation rather than the name would serve one helper's SQL to
             //another whose status table is somewhere else.
-            var cacheKey = CanCacheMetaSql(data, options, delay, expiration) && !statusEmbedsUserColumns
+            var statusPart = options.EnableStatusTable
+                ? "|" + tableNameHelper.StatusName
+                : string.Empty;
+            var cacheKey = CanCacheMetaSql(options) && !statusEmbedsUserColumns
                 ? tableNameHelper.QueueName + "|" + tableNameHelper.MetaDataName + "|" +
-                  options.GetMetaSqlShape() +
-                  (options.EnableStatusTable ? "|" + tableNameHelper.StatusName : string.Empty)
+                  options.GetMetaSqlShape() + statusPart
                 : null;
 
             if (cacheKey != null && SingleRoundTripSqlCache.TryGetValue(cacheKey, out var cached))
@@ -268,7 +271,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
             //no longer varies per message and this covers every send rather than only the
             //invariant shape - which also stops SQL Server compiling a fresh plan per distinct
             //delay value.
-            var cacheKey = CanCacheMetaSql(data, options, delay, expiration)
+            var cacheKey = CanCacheMetaSql(options)
                 ? tableNameHelper.MetaDataName + "|" + options.GetMetaSqlShape()
                 : null;
 

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandler.cs
@@ -111,17 +111,13 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                 return HandleExternalTransaction(commandSend);
 
             var jobName = _jobSchedulerMetaData.GetJobName(commandSend.MessageData);
-            var scheduledTime = DateTimeOffset.MinValue;
-            var eventTime = DateTimeOffset.MinValue;
-            if (!string.IsNullOrWhiteSpace(jobName))
-            {
-                scheduledTime = _jobSchedulerMetaData.GetScheduledTime(commandSend.MessageData);
-                eventTime = _jobSchedulerMetaData.GetEventTime(commandSend.MessageData);
-            }
-            else
+            if (string.IsNullOrWhiteSpace(jobName))
             {
                 return HandleSingleRoundTrip(commandSend);
             }
+
+            var scheduledTime = _jobSchedulerMetaData.GetScheduledTime(commandSend.MessageData);
+            var eventTime = _jobSchedulerMetaData.GetEventTime(commandSend.MessageData);
 
             using (var connection = new SqlConnection(_configurationSend.ConnectionInfo.ConnectionString))
             {

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -111,17 +111,13 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.CommandHandler
                 return await HandleExternalTransactionAsync(commandSend).ConfigureAwait(false);
 
             var jobName = _jobSchedulerMetaData.GetJobName(commandSend.MessageData);
-            var scheduledTime = DateTimeOffset.MinValue;
-            var eventTime = DateTimeOffset.MinValue;
-            if (!string.IsNullOrWhiteSpace(jobName))
-            {
-                scheduledTime = _jobSchedulerMetaData.GetScheduledTime(commandSend.MessageData);
-                eventTime = _jobSchedulerMetaData.GetEventTime(commandSend.MessageData);
-            }
-            else
+            if (string.IsNullOrWhiteSpace(jobName))
             {
                 return await HandleSingleRoundTripAsync(commandSend).ConfigureAwait(false);
             }
+
+            var scheduledTime = _jobSchedulerMetaData.GetScheduledTime(commandSend.MessageData);
+            var eventTime = _jobSchedulerMetaData.GetEventTime(commandSend.MessageData);
 
             using (var connection = new SqlConnection(_configurationSend.ConnectionInfo.ConnectionString))
             {

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/QueryHandler/CreateDequeueStatement.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/QueryHandler/CreateDequeueStatement.cs
@@ -260,7 +260,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.QueryHandler
         /// the behaviour it had before any of this: the statement is rebuilt per poll.
         /// </para>
         /// </remarks>
-        private string BuildCacheKey(List<string> routes, string userQuery)
+        private static string BuildCacheKey(List<string> routes, string userQuery)
         {
             if (!string.IsNullOrEmpty(userQuery))
             {


### PR DESCRIPTION
Closes #243.

59 open issues in the new-code period at the start of this: **32 fixed here, 27 marked accepted on SonarCloud** with a per-rule explanation. The split is the point — most of the remainder are rules misreading a deliberate choice.

## The findings that mattered

**`S1172` unused parameter was pointing at stale documentation, not dead code.** #255 stopped writing the delay and expiration into the statement text, which left `CanCacheSingleRoundTripSql` holding an `expiration` it no longer reads and `CanCacheMetaSql` holding both a `delay` and an `expiration` — and left both doc comments describing behaviour that no longer exists:

> A delay or an expiration is written into the meta insert as a literal tick count […] Parameterising the two would let this cover every message and is worth doing separately - it is why a delayed-processing queue re-plans on every send.

All of that was fixed in #255. A comment that confidently describes the opposite of what the code does is worse than a dead parameter, and it would have sent the next reader looking for work that is already done. Both are rewritten.

Two more from the same change: the cache key was a ternary nested inside a ternary (`S3358`), now split; and the SQL Server handlers seeded `scheduledTime`/`eventTime` with `MinValue` ahead of an if/else whose `else` returns (`S1854` ×4), so the seeds were dead. Reordered to return early on the ordinary send — which is how the PostgreSQL handler already reads, so the two transports now match.

## The mechanical remainder

`BuildCacheKey` touches no instance state; ten assertions become the specific MSTest 4 form, which reports better on failure; two `EndsWith(string)` become `EndsWith(char)`; two redundant casts go; seven benchmark fields only ever used inside `GlobalSetup` become locals.

## What to look at

**The assertion swaps changed argument order in a way that is easy to get wrong.** `Assert.DoesNotContain` takes the *predicate first* and the collection second — I had it backwards initially and the compiler caught it. Worth a look that each swap still asserts what it did before.

`Assert.IsGreaterThan(lowerBound, value)` and `IsGreaterThanOrEqualTo(lowerBound, value)` likewise put the bound first, matching the existing 36 and 75 uses elsewhere in the tree.

## Accepted rather than fixed

Each carries its reasoning as a SonarCloud comment. The pattern is that the rule is right in general and wrong here: `[Obsolete]` `Guard` overloads deprecated on purpose in #230; `GC.Collect` in benchmark rungs that measure allocation; the reflection in `ConsumerInternals`, which is what makes the receive rungs run the real decorated chain; benchmark loops and literals that are themselves what is being measured; `Thread.Sleep` in tests of time-dependent behaviour; 8-parameter send-path builders where a parameter object would allocate per send; and `GenerateMessageHeaders` returning null to avoid allocating an empty dictionary on every message.

## Verification

Release gate clean (`NoTests.sln -c Release -p:CI=true`, 0 warnings). 1,088 core + 194 SQL Server + 179 PostgreSQL + 31 Memory unit tests, plus the Memory and LiteDb integration tests whose assertions changed.

No changelog entry: nothing here is visible to a consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved SQL command caching for PostgreSQL and SQL Server by allowing delayed and expiring messages to reuse cached command structures.
  - Streamlined message-send processing, including more efficient handling of messages without job names.

- **Tests**
  - Updated benchmark and integration-test coverage to use clearer, modern assertion methods while preserving existing validation.

- **Maintenance**
  - Simplified internal setup and connection-handling logic without changing externally visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->