### PR TITLE
Run the Dashboard E2E tests as a non-root agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -377,23 +377,25 @@ pipeline {
                 }
 
                 stage('Dashboard UI E2E') {
-                    // Uses the repo's standard docker-labeled agent (same as other stages)
-                    // and installs Chromium + its system dependencies at stage time via
-                    // Microsoft.Playwright.dll's embedded install command. The earlier
-                    // approach of pulling mcr.microsoft.com/playwright/dotnet failed
-                    // because the agent lacks a Docker CLI for docker-in-docker.
+                    // Uses the repo's standard docker-labeled agent (same as other stages).
+                    // Chromium and its system dependencies are baked into that image at
+                    // build time and found via PLAYWRIGHT_BROWSERS_PATH, so there is
+                    // nothing to install here.
+                    //
+                    // This stage used to install them per build with `--with-deps`, which
+                    // shells out to apt and so needs root. That broke when the agents
+                    // stopped running as root. Installing in the image fixes it where the
+                    // cause is and drops a ~150 MB download plus an apt run from every
+                    // build - see blehnen/dotnetworkqueue-ci#1.
+                    //
+                    // Bumping Microsoft.Playwright means rebuilding that image: the .NET
+                    // package and its browser builds ship as a pair.
                     agent { label 'docker' }
                     steps {
                         sleep(time: 70, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh '''
                                 dotnet build "Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.csproj" -c Debug
-
-                                # Install Playwright browsers (Chromium only) + apt system deps.
-                                dotnet exec \
-                                    --runtimeconfig Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/bin/Debug/net10.0/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.runtimeconfig.json \
-                                    Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/bin/Debug/net10.0/Microsoft.Playwright.dll \
-                                    install --with-deps chromium
 
                                 dotnet test "Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.csproj" \
                                     --no-build -c Debug \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,14 @@ pipeline {
         DOTNET_CLI_TELEMETRY_OPTOUT = '1'
         DOTNET_NOLOGO = '1'
         NUGET_XMLDOC_MODE = 'skip'
+
+        // Where the CI image keeps the Playwright browsers. The image sets this
+        // itself, but it is repeated here so the pipeline does not depend on
+        // image ENV surviving the agent launcher - and so a stale image fails
+        // with "Executable doesn't exist at /ms-playwright/..." which names the
+        // cause, rather than falling back to ~/.cache and looking like a
+        // missing install step. See blehnen/dotnetworkqueue-ci#1.
+        PLAYWRIGHT_BROWSERS_PATH = '/ms-playwright'
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -403,6 +403,12 @@ pipeline {
                         sleep(time: 70, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh '''
+                                # One line that says whether the image carries the browsers,
+                                # so a failure here is not ambiguous between a stale image and
+                                # the browsers not being found. Never fails the stage itself.
+                                echo "PLAYWRIGHT_BROWSERS_PATH=${PLAYWRIGHT_BROWSERS_PATH:-<unset>}"
+                                ls -d "${PLAYWRIGHT_BROWSERS_PATH:-/ms-playwright}"/* 2>&1 | head -5 || true
+
                                 dotnet build "Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.csproj" -c Debug
 
                                 dotnet test "Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/DotNetWorkQueue.Dashboard.Ui.E2E.Tests.csproj" \

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -56,6 +56,10 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="2.2.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.2.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.2.3" />
+    <!-- Bumping these means rebuilding blehnen74/dotnetworkqueue-ci. The browser
+         builds live in that image and ship as a pair with this package, so a
+         mismatch fails the E2E tests with "Executable doesn't exist at
+         /ms-playwright/chromium-XXXX". See blehnen/dotnetworkqueue-ci#1. -->
     <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
     <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.60.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/AssemblyFixture.cs
+++ b/Source/DotNetWorkQueue.Dashboard.Ui.E2E.Tests/AssemblyFixture.cs
@@ -39,7 +39,18 @@ namespace DotNetWorkQueue.Dashboard.Ui.E2E.Tests
             Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
             Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
             {
-                Headless = true
+                Headless = true,
+
+                //Chromium's sandbox needs unprivileged user namespaces, which the CI
+                //container does not have - it aborts with "No usable sandbox!" as soon
+                //as it tries to start a renderer. Dropping the sandbox is what the
+                //Playwright container documentation recommends for exactly this case,
+                //and these tests only ever load the dashboard this repository builds.
+                //
+                //--disable-dev-shm-usage because a container gets a 64 MB /dev/shm by
+                //default, which Chromium will exhaust and crash on for anything larger
+                //than the pages here.
+                Args = ["--no-sandbox", "--disable-dev-shm-usage"]
             });
         }
 

--- a/docs/jenkins-setup.md
+++ b/docs/jenkins-setup.md
@@ -56,8 +56,15 @@ For each Docker host, create a cloud entry:
 - **Container Cap**: number of concurrent containers this host can run (depends on CPU/RAM)
 - **Docker Agent Template**:
   - **Labels**: `docker`
-  - **Docker Image**: `blehnen74/dotnetworkqueue-ci:latest`
-  - **Pull strategy**: **Pull once** (or periodically, to pick up the weekly rebuild)
+  - **Docker Image**: `blehnen74/dotnetworkqueue-ci:weekly`
+  - **Pull strategy**: **Pull all images every time**
+
+> ⚠️ The pull strategy and the tag have to be chosen together. *Pull once and update
+> latest* re-pulls only when the tag is literally `latest`; with any other tag —
+> including `weekly` — it behaves as *pull once*, and the agents keep whatever they
+> cached the first time. Because `weekly` is a rolling tag, that combination looks
+> configured for freshness while never actually refreshing, and a rebuilt image
+> silently never reaches the agents. It cost two builds to find once already.
   - **Remote Filing System Root**: `/home/jenkins`
   - **Connect method**: Attach Docker container
 


### PR DESCRIPTION
Fixes the E2E stage, which has been failing since the Jenkins node runners stopped running as root:

```
Installing dependencies...
Switching to root user to install dependencies...
Password: su: Authentication failure
Failed to install browsers
```

This blocks more than the PR check — `publish.yml`'s verify-gate requires `continuous-integration/jenkins/branch` to be `success` on the tagged commit, and this stage sets `buildResult: 'FAILURE'`, so `v0.11.0` could not be tagged until it is fixed.

Companion to blehnen/dotnetworkqueue-ci#1, which must be published first (it is).

## Two problems, not one

**The install needed root.** `install --with-deps chromium` shells out to apt. Chromium and its system libraries are now baked into the CI image and found through `PLAYWRIGHT_BROWSERS_PATH`, so the step is gone — which also takes a ~150 MB download and an apt run out of every build.

**The browser then still would not start.** This is the part worth knowing about: Chromium's sandbox needs unprivileged user namespaces, which the container does not have, so it aborts with `No usable sandbox!` as soon as it starts a renderer. `--version` succeeds, so the install looks healthy right up until a test tries to open a page. The fixture now passes `--no-sandbox`, which is what the Playwright container documentation recommends for exactly this case, and `--disable-dev-shm-usage` because a container gets a 64 MB `/dev/shm`.

## Verified in the image, not reasoned about

I pulled the published image and ran the suite inside it rather than trusting the change and spending a Jenkins cycle:

- runs as `uid=1000(ubuntu)`, `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`
- `/ms-playwright` holds `chromium-1223`, `chromium_headless_shell-1223`, `ffmpeg-1011`, world-readable
- with no install step and the new launch args: **6/6 E2E tests pass**
- the raw headless shell reproduces the sandbox abort without the flag, and renders a page with it

## What to look at

**`--no-sandbox` is a real security relaxation**, so it is worth agreeing to rather than skimming. The trade is: these tests load only the dashboard this repository builds, in a throwaway CI container, and the alternative is granting the container `SYS_ADMIN` or a custom seccomp profile — more privilege than dropping the sandbox, and it would have to be configured on every agent host. Playwright's own container guidance takes the same route.

It is applied unconditionally rather than only under CI. Conditioning it would mean the tests run one way locally and another way in the pipeline, which is how a container-only failure gets missed until it reaches Jenkins.

**The version coupling now has a note in `Directory.Packages.props`.** Bumping `Microsoft.Playwright` requires rebuilding the CI image, because the package and its browser builds ship as a pair. Without that note the next bump fails with `Executable doesn't exist at /ms-playwright/chromium-XXXX` and nothing points at the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved dashboard end-to-end test reliability by using the preconfigured Chromium environment provided by the test agent.
  * Updated browser launch settings to improve compatibility in containerized environments.
  * Added guidance for keeping browser and Playwright versions aligned when updating test dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->