### PR TITLE
Build each stage's own test project instead of the whole solution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
                     steps {
                         sleep(time: 0, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/DotNetWorkQueue.Transport.SqlServer.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN')]) {
                                 sh 'echo "$SQLSERVER_CONN" > "Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/bin/Debug/net10.0/connectionstring.txt"'
                             }
@@ -124,7 +124,7 @@ pipeline {
                     steps {
                         sleep(time: 5, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN')]) {
                                 sh 'echo "$SQLSERVER_CONN" > "Source/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
                             }
@@ -146,7 +146,7 @@ pipeline {
                     steps {
                         sleep(time: 10, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN')]) {
                                 sh 'echo "$POSTGRESQL_CONN" > "Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
                             }
@@ -168,7 +168,7 @@ pipeline {
                     steps {
                         sleep(time: 15, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN')]) {
                                 sh 'echo "$POSTGRESQL_CONN" > "Source/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
                             }
@@ -190,7 +190,7 @@ pipeline {
                     steps {
                         sleep(time: 20, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/DotNetWorkQueue.Transport.Redis.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')]) {
                                 sh 'echo "$REDIS_CONN" > "Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/bin/Debug/net10.0/connectionstring.txt"'
                             }
@@ -213,7 +213,7 @@ pipeline {
                     steps {
                         sleep(time: 25, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')]) {
                                 sh 'echo "$REDIS_CONN" > "Source/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests/bin/Debug/net10.0/connectionstring.txt"'
                             }
@@ -236,7 +236,7 @@ pipeline {
                     steps {
                         sleep(time: 30, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Integration.Tests.csproj" -c Debug'
                             sh '''
                                 dotnet test "Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \
@@ -254,7 +254,7 @@ pipeline {
                     steps {
                         sleep(time: 35, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests.csproj" -c Debug'
                             sh '''
                                 dotnet test "Source/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \
@@ -272,7 +272,7 @@ pipeline {
                     steps {
                         sleep(time: 40, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/DotNetWorkQueue.Transport.LiteDb.IntegrationTests.csproj" -c Debug'
                             sh '''
                                 dotnet test "Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/DotNetWorkQueue.Transport.LiteDb.IntegrationTests.csproj" \
                                     -f net10.0 -c Debug \
@@ -290,7 +290,7 @@ pipeline {
                     steps {
                         sleep(time: 45, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.LiteDB.Linq.Integration.Tests/DotNetWorkQueue.Transport.LiteDb.Linq.Integration.Tests.csproj" -c Debug'
                             sh '''
                                 dotnet test "Source/DotNetWorkQueue.Transport.LiteDB.Linq.Integration.Tests/DotNetWorkQueue.Transport.LiteDb.Linq.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \
@@ -308,7 +308,7 @@ pipeline {
                     steps {
                         sleep(time: 50, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/DotNetWorkQueue.Transport.Memory.Integration.Tests.csproj" -c Debug'
                             sh '''
                                 dotnet test "Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/DotNetWorkQueue.Transport.Memory.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \
@@ -326,7 +326,7 @@ pipeline {
                     steps {
                         sleep(time: 55, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests.csproj" -c Debug'
                             sh '''
                                 dotnet test "Source/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \
@@ -344,7 +344,7 @@ pipeline {
                     steps {
                         sleep(time: 60, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/DotNetWorkQueue.Dashboard.Api.Integration.Tests.csproj" -c Debug'
                             withCredentials([
                                 string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN'),
                                 string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN'),
@@ -373,7 +373,7 @@ pipeline {
                     steps {
                         sleep(time: 65, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug'
+                            sh 'dotnet build "Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests.csproj" -c Debug'
                             sh '''
                                 dotnet test "Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \


### PR DESCRIPTION
Addresses the build half of #260.

All fourteen parallel stages ran `dotnet build Source/DotNetWorkQueue.sln`, compiling **42 projects when the mean stage needs about 6**. Every stage compiled `Dashboard.Ui` — Blazor, the most CPU-hungry compilation in the tree — for nobody.

## Measured, not estimated

Clean solution build against a clean single-project build, same machine, same state:

| | time |
|---|---|
| full solution | 19.64 s |
| one integration project | **3.49 s** |
| | **5.6x, 82% less** |

Jenkins measures its solution build at 1m40s per stage, so this is roughly **1m22s saved per stage** — about **19 minutes of agent time** across fourteen stages, and **~1.4 minutes off the critical path** (set by the three stages at 32–34 min).

**That wall-clock number is deliberately unexciting, and worth being straight about.** The issue's framing implied the compile was the dominant cost; the #264 measurement showed it is about 5% of a stage. The reason to do this anyway is that #264 also found the real lever — a few clock-bound consumer tests, `ConsumerHeartbeat` alone being 25% of a critical-path stage — and shortening their timers safely needs margin against a loaded agent. This buys that margin.

## What to look at

**The risk in this change is runtime, not compile.** Building only the test project changes what lands in the output directory, so anything loaded by reflection rather than referenced would compile fine and fail at *run* time — a worse failure than the one being fixed.

`Dashboard.Api` does exactly that: `Assembly.LoadFrom` in `DashboardExtensions`, and a two-stage `Type.GetType` → `Assembly.LoadFrom` resolver in `DashboardService`. It probes `AppContext.BaseDirectory` and configured plugin paths, **not** sibling project outputs — and `Dashboard.Api.Integration.Tests` references all six transports explicitly, so they land in its own bin.

Verified rather than reasoned: all fifteen projects build standalone, and the Dashboard API integration tests pass **219/219 on both net10.0 and net8.0** from a standalone build. The one test that configures a plugin path uses an empty temp directory, so it does not depend on a sibling build either.

**Stage 1 is untouched** — it runs eleven test projects and genuinely needs the solution.

## Not done here

The MSBuild parallelism cap (`-m:`) the issue also proposes. Landing both at once would make the effect of either unattributable, and with 42 projects down to 6 the cap may no longer be needed — better to measure this first.

The memory half of #260 — container cap sizing on the 32 GiB host and a `--memory` limit in the agent template — is Jenkins configuration rather than repository content, so it stays with the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration-test pipeline stages to build only their respective test projects.
  * Improved build targeting across database, in-memory, dashboard, and distributed task-scheduler integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->