### PR TITLE
Gate on the compile, run unit tests beside the integration stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,76 +27,99 @@ pipeline {
     }
 
     stages {
-        stage('Build & Unit Tests') {
+        // Compile gate. The integration stages build only their own test project
+        // (#269), so this full-solution build is the only thing that compiles
+        // Dashboard.Ui, the benchmarks and the examples - a compile error in an
+        // untested project would otherwise reach master. It is also fast: 6s to
+        // restore and 12s to build on a warm agent.
+        //
+        // Unit tests used to live here and gated everything behind them. They are
+        // now a parallel branch below: nothing downstream consumes their output,
+        // and at ~7 minutes they hide entirely under the 10-minute critical path,
+        // which took the whole build from ~17m40s to ~11m.
+        stage('Build') {
             agent { label 'docker' }
             steps {
                 sh 'dotnet restore "Source/DotNetWorkQueue.sln"'
                 sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug --no-restore'
-
-                sh '''
-                    dotnet test "Source/DotNetWorkQueue.Tests/DotNetWorkQueue.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-core/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/DotNetWorkQueue.Transport.RelationalDatabase.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-relational/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Transport.SqlServer.Tests/DotNetWorkQueue.Transport.SqlServer.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-sqlserver/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/DotNetWorkQueue.Transport.PostgreSQL.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-postgresql/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Transport.Redis.Tests/DotNetWorkQueue.Transport.Redis.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-redis/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Transport.SQLite.Tests/DotNetWorkQueue.Transport.SQLite.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-sqlite/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Transport.LiteDb.Tests/DotNetWorkQueue.Transport.LiteDb.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-litedb/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Transport.Memory.Tests/DotNetWorkQueue.Transport.Memory.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-memory/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Dashboard.Api.Tests/DotNetWorkQueue.Dashboard.Api.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-dashboard-api/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Dashboard.Client.Tests/DotNetWorkQueue.Dashboard.Client.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-dashboard-client/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-
-                    dotnet test "Source/DotNetWorkQueue.Dashboard.Ui.Tests/DotNetWorkQueue.Dashboard.Ui.Tests.csproj" \
-                        -f net10.0 -c Debug \
-                        /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-dashboard-ui/ \
-                        --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
-                '''
-
-                stash includes: 'coverage/**/*.xml', name: 'unit-coverage'
-                stash includes: 'junit-results/**/*.xml', name: 'junit-unit', allowEmpty: true
             }
         }
 
-        stage('Integration Tests') {
+        stage('Tests') {
             parallel {
+                // Last in the clone stagger: this branch is ~7 minutes against a
+                // 10-minute critical path, so a late start costs nothing.
+                stage('Unit Tests') {
+                    agent { label 'docker' }
+                    steps {
+                        sleep(time: 75, unit: 'SECONDS')
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'dotnet restore "Source/DotNetWorkQueue.sln"'
+                            sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug --no-restore'
+
+                            sh '''
+                                dotnet test "Source/DotNetWorkQueue.Tests/DotNetWorkQueue.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-core/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/DotNetWorkQueue.Transport.RelationalDatabase.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-relational/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Transport.SqlServer.Tests/DotNetWorkQueue.Transport.SqlServer.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-sqlserver/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/DotNetWorkQueue.Transport.PostgreSQL.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-postgresql/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Transport.Redis.Tests/DotNetWorkQueue.Transport.Redis.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-redis/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Transport.SQLite.Tests/DotNetWorkQueue.Transport.SQLite.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-sqlite/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Transport.LiteDb.Tests/DotNetWorkQueue.Transport.LiteDb.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-litedb/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Transport.Memory.Tests/DotNetWorkQueue.Transport.Memory.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-memory/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Dashboard.Api.Tests/DotNetWorkQueue.Dashboard.Api.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-dashboard-api/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Dashboard.Client.Tests/DotNetWorkQueue.Dashboard.Client.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-dashboard-client/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+
+                                dotnet test "Source/DotNetWorkQueue.Dashboard.Ui.Tests/DotNetWorkQueue.Dashboard.Ui.Tests.csproj" \
+                                    -f net10.0 -c Debug \
+                                    /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/unit-dashboard-ui/ \
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
+                            '''
+                        }
+
+                        stash includes: 'coverage/**/*.xml', name: 'unit-coverage', allowEmpty: true
+                        stash includes: 'junit-results/**/*.xml', name: 'junit-unit', allowEmpty: true
+                    }
+                }
+
                 stage('SqlServer') {
                     agent { label 'docker' }
                     steps {


### PR DESCRIPTION
Follows #270. `Build & Unit Tests` is 7 of a 17m40s build and everything waits on it — this takes the build to **~11m**.

## The build was never the problem

From the stage view of a green master run:

| step | time |
|---|---|
| checkout | 4s |
| `dotnet restore` | 6s |
| `dotnet build` — whole solution, 42 projects | **12s** |
| the eleven `dotnet test` runs | **6m 33s** |
| stashes | 0.7s |

**93% of the stage is eleven test invocations running one after another.** The solution build is twelve seconds on a warm agent.

And nothing downstream needs them. The only `unstash` calls in the file are in `Coverage Report` and `Codecov Upload` at the end; no integration stage consumes unit output. The stage is a gate and nothing more.

## So keep the gate and move the tests

```
stage('Build')          // restore + build solution, ~22s
stage('Tests') {
  parallel {
    stage('Unit Tests')   // the eleven dotnet test runs
    stage('SqlServer') … stage('Dashboard UI E2E')   // unchanged
  }
}
```

| | now | after |
|---|---|---|
| gate | 7m 00s | **~22s** |
| parallel block | 10m 00s | 10m 00s |
| tail | 43s | 43s |
| **whole build** | **17m 40s** | **~11m** |

**The unit tests are not made faster — they are made free.** At ~7 minutes they fit under the 10-minute critical path, so they stop costing wall clock without anyone parallelising 28 unit projects or taking on that flakiness risk.

Capacity is unaffected: ~107 min of agent time against 13 slots is 8.2 min, still under the 10 min longest stage, so nothing becomes capacity-bound by the extra branch.

## What to look at

**The full-solution build stays in the gate for a reason beyond fail-fast.** Since #269 the integration stages build only their own test project, so this is now the only thing compiling `Dashboard.Ui`, the benchmarks and the examples. Remove it and a compile error in an untested project reaches master.

**Unit Tests uses the same `catchError` as the integration stages**, so a unit failure marks the build red without stopping coverage being collected and reported. The deliberate trade-off: **a failing unit test no longer stops the integration stages.** That spends agent time on an already-failing build, not wall clock.

**`unit-coverage` gains `allowEmpty`**, matching every other coverage stash. A stage that can now fail without aborting the build should not also fail on stashing coverage it never got to write.

**Unit Tests takes the last clone-stagger slot at 75s** — a ~7 minute branch against a 10 minute critical path, so a late start costs nothing.

## Verification

There is no Groovy or Jenkins linter available locally, so **the syntax is validated by the run this PR triggers** — which is the right shape for a Jenkinsfile change anyway (#260). What I could check statically: brace balance 163/163 (was 159/159), 16 parallel branches (was 15), 4 top-level stages, no BOM and LF endings preserved — the Jenkinsfile has been broken by a stray BOM before.

The eleven `dotnet test` invocations are moved verbatim, re-indented only; no flags, paths, coverage outputs or stash names changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved CI test-stage organization by separating compilation from unit testing.
  - Unit tests now run in parallel with other checks while preserving test and coverage results.
  - Test result collection is more resilient when coverage output is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->