### PR TITLE
Stop the SQLite retry policy tests sitting through the whole retry ladder

### DIFF
--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/RetryTransactionPolicyCreationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/RetryTransactionPolicyCreationTests.cs
@@ -151,12 +151,19 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
                 pipeline.Execute(() =>
                 {
                     callCount++;
-                    throw new SQLiteException((SQLiteErrorCode)errorCode, "test");
+
+                    //Fail once, then succeed. What this test decides is whether the code is
+                    //classified as retryable, and the first retry settles that. Throwing every
+                    //time instead makes the test sit through the whole production ladder -
+                    //eight attempts from a 500ms base, exponential - which measured 50-83
+                    //seconds per case and 99% of this project's test time.
+                    if (callCount == 1)
+                        throw new SQLiteException((SQLiteErrorCode)errorCode, "test");
                 });
             }
             catch (SQLiteException)
             {
-                // expected after retries exhausted or no retry
+                // a non-retryable code surfaces that first failure
             }
 
             if (shouldRetry)


### PR DESCRIPTION
`DotNetWorkQueue.Transport.SQLite.Tests` takes **272 seconds — 69% of the entire unit suite** — at 1.23s per test. Its sibling transport unit projects run at 21–33ms per test with comparable test counts:

| project | time | tests | ms/test |
|---|---|---|---|
| **Transport.SQLite.Tests** | **272s** | 221 | **1,230** |
| Transport.SqlServer.Tests | 20s | 194 | 103 |
| Transport.PostgreSQL.Tests | 6s | 179 | 33 |
| Transport.LiteDb.Tests | 5s | 179 | 27 |
| Transport.Redis.Tests | 4s | 187 | 21 |

## Where it went

Profiling with `--logger junit` put **252.4 of 253.8 seconds in one class**, and four of its nineteen tests:

| test | time |
|---|---|
| Extended code 262 (SQLITE_LOCKED_SHAREDCACHE) should retry | 82.56s |
| Base code 6 (SQLITE_LOCKED) should retry | 65.79s |
| Base code 5 (SQLITE_BUSY) should retry | 53.58s |
| Extended code 517 (SQLITE_BUSY_RECOVERY) should retry | 50.44s |
| *the other fifteen, combined* | **0.03s** |

They were sleeping. The test builds the real pipeline and the delegate threw unconditionally, so Polly exhausted the production ladder every time — `RetryCount = 8` from a `FirstWaitInMs = 500` base, exponential with jitter.

**Nothing needed that.** The assertion is `callCount > 1`, and the case names read "should retry", not "should retry eight times". What is under test is SQLite error-code classification — base 5 and 6 against extended 262 and 517 — and the first retry settles it.

## The change

Fail once, then succeed. One backoff instead of eight.

| | before | after |
|---|---|---|
| Extended code 262 | 82.56s | **0.34s** |
| Base code 6 | 65.79s | **0.68s** |
| Base code 5 | 53.58s | **0.19s** |
| Extended code 517 | 50.44s | **0.30s** |
| **project total** | **272s** | **4s** |

## What to check

**That the tests still test something.** They do, and by the same mechanism as before: `callCount` reaches 2 only if the pipeline actually retried, so a code wrongly classified as non-retryable still fails the assertion. Verified by running it — **221 of 221 pass**, zero `<failure>` elements in the junit.

The non-retryable case (code 1) is untouched: it throws once, that failure surfaces, and the assertion is still `callCount == 1`.

What is no longer covered is the retry *count* and the backoff *shape* — but neither was asserted before, so nothing that was verified has been given up.

## Context

Found while measuring what makes the unit stage seven minutes (#264). It is **not** on the critical path once #272 lands, since unit tests hide under the 10-minute integration block either way. Two reasons to do it regardless: it is four and a half minutes every time a developer runs this project locally, and it is the headroom worth having when the integration stages come down further.

SQL Server and PostgreSQL use identical constants (`RetryCount = 8`, `FirstWaitInMs = 500`) and are fast because neither has an equivalent test — so this is not a SQLite configuration difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated SQLite retry policy tests to simulate a failure on the first attempt followed by success.
  - Clarified validation of how retryable and non-retryable SQLite errors are surfaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->