### PR TITLE
Stagger longest stage first, and drop the retry flag that never ran

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,8 +47,24 @@ pipeline {
 
         stage('Tests') {
             parallel {
-                // Last in the clone stagger: this branch is ~7 minutes against a
-                // 10-minute critical path, so a late start costs nothing.
+                // About the sleeps below. They pace nuget.org, not git.
+                //
+                // A stage-level agent does an implicit checkout before its steps run, and
+                // nothing here sets skipDefaultCheckout, so every sleep lands *after* that
+                // stage has already cloned and *before* its `dotnet build`, which is where
+                // the restore happens. Sixteen restores arriving together is what
+                // nuget.org rate-limits, and that is what the spacing prevents.
+                //
+                // So the clones do all go out at once, and always have. That has never
+                // been the thing that fails, which is why this is left as it is. If clone
+                // pacing is ever wanted, it needs options { skipDefaultCheckout() } plus
+                // an explicit checkout scm after the sleep, in all sixteen stages.
+                //
+                // Slots run longest-work-first so the critical-path stage starts at zero.
+                // Only the slot the longest stage occupies affects wall clock.
+                //
+                // This branch is ~3 minutes of work against a 9m25s critical path, so its
+                // late slot costs nothing.
                 stage('Unit Tests') {
                     agent { label 'docker' }
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                 stage('Unit Tests') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 75, unit: 'SECONDS')
+                        sleep(time: 65, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet restore "Source/DotNetWorkQueue.sln"'
                             sh 'dotnet build "Source/DotNetWorkQueue.sln" -c Debug --no-restore'
@@ -123,7 +123,7 @@ pipeline {
                 stage('SqlServer') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 0, unit: 'SECONDS')
+                        sleep(time: 25, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/DotNetWorkQueue.Transport.SqlServer.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN')]) {
@@ -133,8 +133,7 @@ pipeline {
                                 dotnet test "Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/DotNetWorkQueue.Transport.SqlServer.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \
                                     /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/int-sqlserver/ \
-                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
-                                    -- --retry-failed-tests 1
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
                             '''
                         }
                         stash includes: 'coverage/**/*.xml', name: 'cov-sqlserver', allowEmpty: true
@@ -145,7 +144,7 @@ pipeline {
                 stage('SqlServer Linq') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 5, unit: 'SECONDS')
+                        sleep(time: 15, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'sqlserver-connstring', variable: 'SQLSERVER_CONN')]) {
@@ -155,8 +154,7 @@ pipeline {
                                 dotnet test "Source/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests/DotNetWorkQueue.Transport.SqlServer.Linq.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \
                                     /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/int-sqlserver-linq/ \
-                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
-                                    -- --retry-failed-tests 1
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
                             '''
                         }
                         stash includes: 'coverage/**/*.xml', name: 'cov-sqlserver-linq', allowEmpty: true
@@ -167,7 +165,7 @@ pipeline {
                 stage('PostgreSQL') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 10, unit: 'SECONDS')
+                        sleep(time: 5, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN')]) {
@@ -177,8 +175,7 @@ pipeline {
                                 dotnet test "Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \
                                     /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/int-postgresql/ \
-                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
-                                    -- --retry-failed-tests 1
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
                             '''
                         }
                         stash includes: 'coverage/**/*.xml', name: 'cov-postgresql', allowEmpty: true
@@ -189,7 +186,7 @@ pipeline {
                 stage('PostgreSQL Linq') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 15, unit: 'SECONDS')
+                        sleep(time: 20, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'postgresql-connstring', variable: 'POSTGRESQL_CONN')]) {
@@ -199,8 +196,7 @@ pipeline {
                                 dotnet test "Source/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests/DotNetWorkQueue.Transport.PostgreSQL.Linq.Integration.Tests.csproj" \
                                     -f net10.0 -c Debug \
                                     /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/int-postgresql-linq/ \
-                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
-                                    -- --retry-failed-tests 1
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
                             '''
                         }
                         stash includes: 'coverage/**/*.xml', name: 'cov-postgresql-linq', allowEmpty: true
@@ -211,7 +207,7 @@ pipeline {
                 stage('Redis') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 20, unit: 'SECONDS')
+                        sleep(time: 50, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/DotNetWorkQueue.Transport.Redis.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')]) {
@@ -222,8 +218,7 @@ pipeline {
                                     -f net10.0 -c Debug \
                                     --filter "TestCategory!=StarvationBaseline" \
                                     /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/int-redis/ \
-                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
-                                    -- --retry-failed-tests 1
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
                             '''
                         }
                         stash includes: 'coverage/**/*.xml', name: 'cov-redis', allowEmpty: true
@@ -234,7 +229,7 @@ pipeline {
                 stage('Redis Linq') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 25, unit: 'SECONDS')
+                        sleep(time: 30, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests/DotNetWorkQueue.Transport.Redis.Linq.Integration.Tests.csproj" -c Debug'
                             withCredentials([string(credentialsId: 'redis-connstring', variable: 'REDIS_CONN')]) {
@@ -245,8 +240,7 @@ pipeline {
                                     -f net10.0 -c Debug \
                                     --filter "TestCategory!=StarvationBaseline" \
                                     /p:CollectCoverage=true /p:CoverletOutput=$WORKSPACE/coverage/int-redis-linq/ \
-                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml" \
-                                    -- --retry-failed-tests 1
+                                    --logger "junit;LogFilePath=$WORKSPACE/junit-results/{assembly}.{framework}.xml"
                             '''
                         }
                         stash includes: 'coverage/**/*.xml', name: 'cov-redis-linq', allowEmpty: true
@@ -257,7 +251,7 @@ pipeline {
                 stage('SQLite') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 30, unit: 'SECONDS')
+                        sleep(time: 10, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Integration.Tests.csproj" -c Debug'
                             sh '''
@@ -275,7 +269,7 @@ pipeline {
                 stage('SQLite Linq') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 35, unit: 'SECONDS')
+                        sleep(time: 0, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests/DotNetWorkQueue.Transport.SQLite.Linq.Integration.Tests.csproj" -c Debug'
                             sh '''
@@ -293,7 +287,7 @@ pipeline {
                 stage('LiteDB') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 40, unit: 'SECONDS')
+                        sleep(time: 55, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/DotNetWorkQueue.Transport.LiteDb.IntegrationTests.csproj" -c Debug'
                             sh '''
@@ -311,7 +305,7 @@ pipeline {
                 stage('LiteDB Linq') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 45, unit: 'SECONDS')
+                        sleep(time: 40, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.LiteDB.Linq.Integration.Tests/DotNetWorkQueue.Transport.LiteDb.Linq.Integration.Tests.csproj" -c Debug'
                             sh '''
@@ -329,7 +323,7 @@ pipeline {
                 stage('Memory') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 50, unit: 'SECONDS')
+                        sleep(time: 60, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/DotNetWorkQueue.Transport.Memory.Integration.Tests.csproj" -c Debug'
                             sh '''
@@ -347,7 +341,7 @@ pipeline {
                 stage('Memory Linq') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 55, unit: 'SECONDS')
+                        sleep(time: 45, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests/DotNetWorkQueue.Transport.Memory.Linq.Integration.Tests.csproj" -c Debug'
                             sh '''
@@ -365,7 +359,7 @@ pipeline {
                 stage('Dashboard') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 60, unit: 'SECONDS')
+                        sleep(time: 35, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.Dashboard.Api.Integration.Tests/DotNetWorkQueue.Dashboard.Api.Integration.Tests.csproj" -c Debug'
                             withCredentials([
@@ -394,7 +388,7 @@ pipeline {
                 stage('TaskScheduler Distributed') {
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 65, unit: 'SECONDS')
+                        sleep(time: 70, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh 'dotnet build "Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Integration.Tests.csproj" -c Debug'
                             sh '''
@@ -423,7 +417,7 @@ pipeline {
                     // package and its browser builds ship as a pair.
                     agent { label 'docker' }
                     steps {
-                        sleep(time: 70, unit: 'SECONDS')
+                        sleep(time: 75, unit: 'SECONDS')
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             sh '''
                                 # One line that says whether the image carries the browsers,


### PR DESCRIPTION
Two small Jenkinsfile changes. Neither alters what runs.

## 1. Stagger the longest stage first — 35s, free

Slots were assigned in source order, so the critical-path stage sat in a late one:

| | was | now |
|---|---|---|
| SQLite Linq (9m25s of work — the critical path) | 35s | **0s** |
| SqlServer (7m20s) | 0s | 25s |
| Dashboard UI E2E (59s of work) | 70s | 75s |

Only the slot occupied by the *longest* stage affects wall clock. Sorting by measured work:

| | now | after |
|---|---|---|
| parallel block | 600s (10m00s) | **565s (9m25s)** |
| whole build | 668s | **633s (10m33s)** |

**The spacing and spread are unchanged** — still 5s apart, still 0–75s. The request pacing to nuget.org is byte-for-byte identical, so nothing about the rate-limit protection the stagger exists for is weakened.

Ordering is by measured work from the last green master build; if stage times shift materially it is worth re-sorting, but only the top three or four slots matter.

## 2. Remove `-- --retry-failed-tests 1` — it has never run

Six stages passed it. It does nothing.

`--retry-failed-tests` belongs to **Microsoft.Testing.Platform**. These projects run under **VSTest** — no `EnableMSTestRunner` anywhere in the tree, and every run banners `VSTest version 18.0.2`. VSTest reads what follows `--` as RunSettings `Key=Value` pairs, so it is discarded with no error and no warning.

Demonstrated rather than assumed, with a one-test project pinned to the same MSTest 4.2.3 and Test.Sdk 18.7.0, whose only test always fails and appends a line each time its body runs:

```
without the flag:  Failed: 1  ->  test body executed 1 time
with the flag:     Failed: 1  ->  test body executed 1 time
```

**How it got here:** PR #89, *"ci: enable MSTest runner for test retry support"*, was reverted — `EnableMSTestRunner` is all-or-nothing across what is now 28 projects. The flag was added afterwards in `eb84367c` and was inert from its first commit. Right intent, missing prerequisite, no error to reveal it.

Removing it does not remove protection. It removes the *appearance* of protection, which is worse than none — two of the four #270 validation builds failed on transient faults a working retry would have absorbed. #271 tracks getting real retries; the fix there is the MSTest runner migration, which is its own project.

## Verification

No Groovy or Jenkins linter is available locally, so syntax is validated by the run this triggers. Statically: brace balance 163/163 unchanged, all 16 stages re-staggered exactly once, 26 `dotnet test` invocations intact, zero `sh` blocks left with a dangling line-continuation backslash, no BOM, LF preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated CI timing for unit, integration, dashboard, task-scheduler, and end-to-end test stages.
  - Unit and integration tests now run without automatically retrying failed tests.
- **Chores**
  - Preserved existing build, reporting, artifact-stashing, and credential-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->