### PR TITLE
Scope the GITHUB_TOKEN in ci.yml and sonarcloud.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    # Checks out, builds and tests. It writes nothing back to the repository,
+    # so it needs no more than read access to the contents. Declared on the job
+    # rather than the workflow to match publish.yml and to satisfy S8264, which
+    # objects to a workflow-level grant covering jobs that do not need it.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 
@@ -73,4 +79,10 @@ jobs:
 
   build-release:
     name: build-release
+    # build-pack.yml declares contents: read for itself, so the effective grant is
+    # already read-only. Stated here as well because a caller's permissions are the
+    # ceiling: without this, a later change to the reusable workflow would silently
+    # inherit the repository default again.
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-pack.yml

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,6 +12,12 @@ jobs:
   build:
     name: Build and analyze
     runs-on: windows-latest
+    # The scanner reads the working tree and uploads to SonarCloud with SONAR_TOKEN.
+    # It does not use GITHUB_TOKEN to reach the GitHub API - PR decoration is done
+    # by SonarCloud's own GitHub App - so contents: read is the whole requirement.
+    # The checkout already sets persist-credentials: false for the same reason.
+    permissions:
+      contents: read
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0


### PR DESCRIPTION
Closes the file half of #268.

Neither workflow declared `permissions` at any level, so every job took the repository default:

```console
$ gh api repos/blehnen/DotNetWorkQueue/actions/permissions/workflow
{"default_workflow_permissions":"write", ...}
```

A **write-scoped token** — contents, issues, packages, pull-requests — available to every step and every third-party action, for jobs that check out, build, test and scan. `ci.yml` runs on `pull_request`, so it executes on branch contributions.

## Three jobs, not two

The issue names two workflows; there are three jobs. `ci.yml` also has `build-release`, which calls the reusable `build-pack.yml`.

`build-pack.yml` already declares `contents: read` for itself, so that grant was **already** effectively read-only. It is declared on the caller anyway because a caller's permissions are the *ceiling* — without it, a later change to the reusable workflow would silently inherit the repository default again.

## Verified by parsing, not by reading the diff

| workflow | job | permissions |
|---|---|---|
| ci.yml | build-and-test | `contents: read` |
| ci.yml | build-release | `contents: read` |
| sonarcloud.yml | build | `contents: read` |
| publish.yml | verify-gate | `contents: read`, `statuses: read` |
| publish.yml | build-pack | `contents: read` |
| publish.yml | **publish** | **`contents: write`** |
| publish.yml | docker-publish | `contents: read` |

Every job across all four workflow files is explicitly scoped, and the release job is the only holder of write.

## What to watch

**This PR exercises its own change** — `sonarcloud.yml` runs on `pull_request`, so the `Build and analyze` check on this PR is the test. The issue warns not to assume the scanner's needs, and it's right to: getting it wrong makes Sonar fail in a way that looks unrelated to permissions.

`contents: read` should be the whole requirement. The scanner reads the working tree and uploads with `SONAR_TOKEN`; PR decoration is done by SonarCloud's own GitHub App, not by `GITHUB_TOKEN`. The existing `persist-credentials: false` on the checkout is consistent with that. If the check goes red, the fix is `pull-requests: read`, and we'll know rather than have guessed.

## Not in this PR

The durable half of #268: flipping the repository default to read-only (Settings → Actions → General → Workflow permissions), so an omitted block fails safe instead of open and every workflow added later inherits the safe default. That is a repository setting, not a file.

The issue also flags `can_approve_pull_request_reviews: true` — that token can approve pull requests — as worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflows to explicitly limit repository content access to read-only permissions.
  - Clarified workflow permission settings for build, release, and code quality analysis processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->