### PR TITLE
Awaitable throttle for the consumer backpressure primitive (#256, PR 1 of 7)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,11 @@ dotnet_diagnostic.CA2263.severity = none
 # CA1859: recommends concrete return types for performance, but the public API
 # deliberately returns interfaces (IQueueOutputMessage, etc.) as the contract.
 dotnet_diagnostic.CA1859.severity = none
+# ValueTask has usage rules a test suite will not catch: a ValueTask over an
+# already-completed result tolerates double-await and .Result silently, and only
+# breaks under IValueTaskSource pooling. The analyzer is deterministic where a test
+# is incidental. Raised to error deliberately - see the async receive path spec.
+dotnet_diagnostic.CA2012.severity = error
 
 # Test projects only: rules that are noise in tests but kept active in production code.
 [**/*Tests*/**.cs]

--- a/Source/DotNetWorkQueue.Tests/Queue/WaitForEventOrCancelTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/WaitForEventOrCancelTests.cs
@@ -139,6 +139,166 @@ namespace DotNetWorkQueue.Tests.Queue
             }
         }
 
+        [TestMethod]
+        public async Task WaitAsync_ReturnsImmediately_WhenAlreadySignaled()
+        {
+            using var test = Create();
+            // constructed signaled, per ManualResetEventSlim(true)
+            Assert.IsTrue(await test.WaitAsync());
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_Blocks_UntilSet()
+        {
+            using var test = Create();
+            test.Reset();
+
+            var waiter = test.WaitAsync().AsTask();
+            Assert.IsFalse(waiter.IsCompleted, "must not complete while reset");
+
+            test.Set();
+            Assert.IsTrue(await waiter);
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_ReturnsFalse_WhenCancelled()
+        {
+            using var test = Create();
+            test.Reset();
+
+            var waiter = test.WaitAsync().AsTask();
+            test.Cancel();
+
+            Assert.IsFalse(await waiter);
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_ResetDuringPendingWait_DoesNotOrphanTheWaiter()
+        {
+            //the lost wake-up case: Reset must not swap out a TCS that already has waiters,
+            //or this waiter sleeps until some later Set that it was never told about
+            using var test = Create();
+            test.Reset();
+
+            var waiter = test.WaitAsync().AsTask();
+            test.Reset();                       // second reset, waiter already pending
+            test.Set();
+
+            var completed = await Task.WhenAny(waiter, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.AreSame(waiter, completed, "waiter was orphaned by Reset");
+            Assert.IsTrue(await waiter);
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_SetThenReset_BeforeWaiterResumes_StillReleases()
+        {
+            using var test = Create();
+            test.Reset();
+
+            var waiter = test.WaitAsync().AsTask();
+            test.Set();
+            test.Reset();                       // immediately re-armed
+
+            var completed = await Task.WhenAny(waiter, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.AreSame(waiter, completed, "a Set that happened must release its waiter");
+            Assert.IsTrue(await waiter);
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_ManyWaiters_AllReleasedByOneSet()
+        {
+            using var test = Create();
+            test.Reset();
+
+            var waiters = new Task<bool>[50];
+            for (var i = 0; i < waiters.Length; i++)
+                waiters[i] = test.WaitAsync().AsTask();
+
+            test.Set();
+
+            var all = Task.WhenAll(waiters);
+            var completed = await Task.WhenAny(all, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.AreSame(all, completed, "one Set must release every waiter");
+            foreach (var r in await all)
+                Assert.IsTrue(r);
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_IfDisposed_Exception()
+        {
+            var test = Create();
+            test.Dispose();
+            await Assert.ThrowsExactlyAsync<ObjectDisposedException>(async () => await test.WaitAsync());
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_PendingWait_IsReleasedByDispose()
+        {
+            //an async waiter holds only a Task - disposing the primitives underneath does
+            //not fault it, so without explicit completion this waits forever on a dead object
+            var test = Create();
+            test.Reset();
+            var waiter = test.WaitAsync().AsTask();
+
+            test.Dispose();
+
+            var completed = await Task.WhenAny(waiter, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.AreSame(waiter, completed, "Dispose left a waiter hanging");
+            Assert.IsFalse(await waiter);
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_AfterCancelThenReset_StillReturnsFalse()
+        {
+            //Cancel completes the source; Reset then sees "completed" and re-arms it. The
+            //synchronous Wait would still return false because it consults the token, so the
+            //async path must too, or it waits on an object that can never be signaled again.
+            using var test = Create();
+            test.Cancel();
+            test.Reset();
+
+            var waiter = test.WaitAsync().AsTask();
+            var completed = await Task.WhenAny(waiter, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.AreSame(waiter, completed, "a cancelled instance must not block an async waiter");
+            Assert.IsFalse(await waiter);
+        }
+
+        [TestMethod]
+        public void SetAndReset_Concurrently_LeaveSyncAndAsyncAgreeing()
+        {
+            //The interleaving that lock-free code got wrong: Reset reads the completed source,
+            //Set signals the event and that same source, then Reset installs a fresh incomplete
+            //one - leaving the event signaled while the async source is not. A synchronous
+            //waiter would proceed and an async waiter would hang.
+            //
+            //Wait() has no timeout overload, so it is probed on a task and released with Cancel()
+            //rather than called directly - calling it unguarded would hang this test.
+            for (var attempt = 0; attempt < 100; attempt++)
+            {
+                using var test = Create();
+                using var start = new ManualResetEventSlim(false);
+
+                var setter = Task.Run(() => { start.Wait(); test.Set(); });
+                var resetter = Task.Run(() => { start.Wait(); test.Reset(); });
+
+                start.Set();
+                Task.WaitAll(setter, resetter);
+
+                var syncProbe = Task.Run(() => test.Wait());
+                var syncSignaled = syncProbe.Wait(TimeSpan.FromMilliseconds(10)) && syncProbe.Result;
+                var asyncSignaled = test.WaitAsync().AsTask().Wait(TimeSpan.FromMilliseconds(10));
+
+                //release the probe if it is still blocked, so the loop does not leak threads
+                test.Cancel();
+                syncProbe.Wait(TimeSpan.FromSeconds(1));
+
+                //the implication is what matters: the two views must not disagree in the
+                //direction that hangs a consumer
+                if (syncSignaled && !asyncSignaled)
+                    Assert.Fail($"attempt {attempt}: reset event signaled but async waiter still pending");
+            }
+        }
+
         private IWaitForEventOrCancel Create()
         {
             var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());

--- a/Source/DotNetWorkQueue.Tests/Queue/WaitForEventOrCancelTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/WaitForEventOrCancelTests.cs
@@ -328,6 +328,66 @@ namespace DotNetWorkQueue.Tests.Queue
                 Assert.Fail(failure);
         }
 
+        [TestMethod]
+        public void WaitAsync_RacingDispose_NeverHangs()
+        {
+            //The gap this closes: a first-ever WaitAsync can pass ThrowIfDisposed, then lose
+            //the race to a Dispose that runs to completion before WaitAsync takes the lock.
+            //Dispose's _asyncWait?.TrySetResult(false) is a no-op because no async waiter has
+            //ever registered, so without a disposal check inside the lock, WaitAsync would go
+            //on to manufacture a fresh TaskCompletionSource that nothing can ever complete -
+            //Set/Reset/Cancel all throw once disposed, and Dispose has already made its one
+            //pass. The interleaving can't be forced deterministically through the public API,
+            //so this races the two calls repeatedly and asserts every returned task settles.
+            //WaitAsync may legitimately throw ObjectDisposedException when disposal wins the
+            //race outright - that is fine and is not a hang.
+            string failure = null;
+
+            for (var attempt = 0; attempt < 500 && failure == null; attempt++)
+            {
+                var test = Create();
+                using var start = new ManualResetEventSlim(false);
+
+                Task<bool> waiterTask = null;
+                var waiter = Task.Run(() =>
+                {
+                    start.Wait();
+                    try
+                    {
+                        waiterTask = test.WaitAsync().AsTask();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        //disposal won the race before WaitAsync's own ThrowIfDisposed check -
+                        //not a hang
+                    }
+                });
+                var disposer = Task.Run(() => { start.Wait(); test.Dispose(); });
+
+                start.Set();
+                Task.WaitAll(waiter, disposer);
+
+                if (waiterTask == null)
+                    continue; //ObjectDisposedException case above - not a hang
+
+                bool completed;
+                try
+                {
+                    completed = waiterTask.Wait(TimeSpan.FromSeconds(5));
+                }
+                catch (AggregateException)
+                {
+                    continue; //the task itself faulted (e.g. ObjectDisposedException) - not a hang
+                }
+
+                if (!completed)
+                    failure = $"attempt {attempt}: WaitAsync's task never completed - a permanent hang";
+            }
+
+            if (failure != null)
+                Assert.Fail(failure);
+        }
+
         private IWaitForEventOrCancel Create()
         {
             var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());

--- a/Source/DotNetWorkQueue.Tests/Queue/WaitForEventOrCancelTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/WaitForEventOrCancelTests.cs
@@ -282,50 +282,29 @@ namespace DotNetWorkQueue.Tests.Queue
         }
 
         [TestMethod]
-        public void SetAndReset_Concurrently_LeaveSyncAndAsyncAgreeing()
+        public void SetRacingReset_AlwaysReleasesAPendingWaiter()
         {
-            //The interleaving that lock-free code got wrong: Reset reads the completed source,
-            //Set signals the event and that same source, then Reset installs a fresh incomplete
-            //one - leaving the event signaled while the async source is not. A synchronous
-            //waiter would proceed and an async waiter would hang.
-            //
-            //Wait() has no timeout overload, so it is probed on a task and released with Cancel()
-            //rather than called directly - calling it unguarded would hang this test.
-            string failure = null;
-
-            for (var attempt = 0; attempt < 100 && failure == null; attempt++)
+            //A pending async waiter holds one completion source. Whichever order the racing
+            //Set and Reset land in, that source must end up completed: Reset cannot swap out
+            //an incomplete source, and if Set went first it completed that source directly.
+            //So a Set that happened must always release a waiter that was already waiting -
+            //which is the orphaning this lock exists to prevent.
+            for (var attempt = 0; attempt < 200; attempt++)
             {
                 using var test = Create();
-                using var start = new ManualResetEventSlim(false);
+                test.Reset();
+                var waiter = test.WaitAsync().AsTask();
 
+                using var start = new ManualResetEventSlim(false);
                 var setter = Task.Run(() => { start.Wait(); test.Set(); });
                 var resetter = Task.Run(() => { start.Wait(); test.Reset(); });
 
                 start.Set();
                 Task.WaitAll(setter, resetter);
 
-                var syncProbe = Task.Run(() => test.Wait());
-                try
-                {
-                    var syncSignaled = syncProbe.Wait(TimeSpan.FromMilliseconds(250)) && syncProbe.Result;
-                    var asyncSignaled = test.WaitAsync().AsTask().Wait(TimeSpan.FromMilliseconds(250));
-
-                    //the implication is what matters: the two views must not disagree in the
-                    //direction that hangs a consumer
-                    if (syncSignaled && !asyncSignaled)
-                        failure = $"attempt {attempt}: reset event signaled but async waiter still pending";
-                }
-                finally
-                {
-                    //release the probe if it is still blocked, so it isn't left inside
-                    //Wait() when the "using" disposes test - even on Assert.Fail/exception
-                    test.Cancel();
-                    syncProbe.Wait(TimeSpan.FromSeconds(1));
-                }
+                Assert.IsTrue(waiter.Wait(TimeSpan.FromSeconds(1)),
+                    $"attempt {attempt}: a Set happened but the pending waiter was never released");
             }
-
-            if (failure != null)
-                Assert.Fail(failure);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Tests/Queue/WaitForEventOrCancelTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/WaitForEventOrCancelTests.cs
@@ -207,18 +207,36 @@ namespace DotNetWorkQueue.Tests.Queue
         [TestMethod]
         public async Task WaitAsync_ManyWaiters_AllReleasedByOneSet()
         {
+            //a real fan-out across distinct completion sources, not one Task awaited 50
+            //times: Reset only swaps in a fresh source once the current one has completed,
+            //so each earlier batch is released with Set() before the next batch is
+            //acquired on the next source. Only the last batch is still pending when the
+            //final Set() runs, and that final Set must release it.
             using var test = Create();
             test.Reset();
 
-            var waiters = new Task<bool>[50];
-            for (var i = 0; i < waiters.Length; i++)
-                waiters[i] = test.WaitAsync().AsTask();
+            const int batches = 5;
+            const int perBatch = 10;
+            var waiters = new Task<bool>[batches * perBatch];
 
+            for (var batch = 0; batch < batches; batch++)
+            {
+                for (var i = 0; i < perBatch; i++)
+                    waiters[batch * perBatch + i] = test.WaitAsync().AsTask();
+
+                if (batch < batches - 1)
+                {
+                    test.Set();     // completes this batch's source
+                    test.Reset();   // source is now completed, so this swaps in a new one
+                }
+            }
+
+            // only the final batch is still pending at this point
             test.Set();
 
             var all = Task.WhenAll(waiters);
             var completed = await Task.WhenAny(all, Task.Delay(TimeSpan.FromSeconds(10)));
-            Assert.AreSame(all, completed, "one Set must release every waiter");
+            Assert.AreSame(all, completed, "the final Set must release every waiter still outstanding");
             foreach (var r in await all)
                 Assert.IsTrue(r);
         }
@@ -273,7 +291,9 @@ namespace DotNetWorkQueue.Tests.Queue
             //
             //Wait() has no timeout overload, so it is probed on a task and released with Cancel()
             //rather than called directly - calling it unguarded would hang this test.
-            for (var attempt = 0; attempt < 100; attempt++)
+            string failure = null;
+
+            for (var attempt = 0; attempt < 100 && failure == null; attempt++)
             {
                 using var test = Create();
                 using var start = new ManualResetEventSlim(false);
@@ -285,18 +305,27 @@ namespace DotNetWorkQueue.Tests.Queue
                 Task.WaitAll(setter, resetter);
 
                 var syncProbe = Task.Run(() => test.Wait());
-                var syncSignaled = syncProbe.Wait(TimeSpan.FromMilliseconds(10)) && syncProbe.Result;
-                var asyncSignaled = test.WaitAsync().AsTask().Wait(TimeSpan.FromMilliseconds(10));
+                try
+                {
+                    var syncSignaled = syncProbe.Wait(TimeSpan.FromMilliseconds(250)) && syncProbe.Result;
+                    var asyncSignaled = test.WaitAsync().AsTask().Wait(TimeSpan.FromMilliseconds(250));
 
-                //release the probe if it is still blocked, so the loop does not leak threads
-                test.Cancel();
-                syncProbe.Wait(TimeSpan.FromSeconds(1));
-
-                //the implication is what matters: the two views must not disagree in the
-                //direction that hangs a consumer
-                if (syncSignaled && !asyncSignaled)
-                    Assert.Fail($"attempt {attempt}: reset event signaled but async waiter still pending");
+                    //the implication is what matters: the two views must not disagree in the
+                    //direction that hangs a consumer
+                    if (syncSignaled && !asyncSignaled)
+                        failure = $"attempt {attempt}: reset event signaled but async waiter still pending";
+                }
+                finally
+                {
+                    //release the probe if it is still blocked, so it isn't left inside
+                    //Wait() when the "using" disposes test - even on Assert.Fail/exception
+                    test.Cancel();
+                    syncProbe.Wait(TimeSpan.FromSeconds(1));
+                }
             }
+
+            if (failure != null)
+                Assert.Fail(failure);
         }
 
         private IWaitForEventOrCancel Create()

--- a/Source/DotNetWorkQueue.Tests/TaskScheduling/WaitForEventOrCancelThreadPoolTests.cs
+++ b/Source/DotNetWorkQueue.Tests/TaskScheduling/WaitForEventOrCancelThreadPoolTests.cs
@@ -188,11 +188,102 @@ namespace DotNetWorkQueue.Tests.TaskScheduling
             }
         }
 
+        [TestMethod]
+        public async Task WaitAsync_NullGroup_RoutesToTheSharedWait()
+        {
+            //asserting only the initial signaled state would also pass for an
+            //implementation that gave null its own private source, so drive it
+            using (var test = CreateWithRealWait())
+            {
+                test.Reset(null);
+                var waiter = test.WaitAsync(null).AsTask();
+                Assert.IsFalse(waiter.IsCompleted, "must not complete while the shared wait is reset");
+
+                test.Set(null);
+                Assert.IsTrue(await waiter);
+            }
+        }
+
+        [TestMethod]
+        public void WaitAsync_NullGroup_NotReleasedByAGroupSet()
+        {
+            using (var test = CreateWithRealWait())
+            {
+                var group = Substitute.For<IWorkGroup>();
+
+                test.Reset(null);
+                var waiter = test.WaitAsync(null).AsTask();
+
+                test.Set(group);
+
+                Assert.IsFalse(waiter.IsCompleted, "a group Set released the shared waiter");
+            }
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_Group_ReturnsAfterSet()
+        {
+            using (var test = CreateWithRealWait())
+            {
+                var group = Substitute.For<IWorkGroup>();
+
+                test.Reset(group);
+                var waiter = test.WaitAsync(group).AsTask();
+                Assert.IsFalse(waiter.IsCompleted, "must not complete while the group is reset");
+
+                test.Set(group);
+                Assert.IsTrue(await waiter);
+            }
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_GroupsAreIndependent()
+        {
+            //a full group must not release a waiter on a different group
+            using (var test = CreateWithRealWait())
+            {
+                var groupOne = Substitute.For<IWorkGroup>();
+                var groupTwo = Substitute.For<IWorkGroup>();
+
+                test.Reset(groupOne);
+                test.Reset(groupTwo);
+
+                var waiterOne = test.WaitAsync(groupOne).AsTask();
+                test.Set(groupTwo);
+
+                Assert.IsFalse(waiterOne.IsCompleted, "setting another group released this one");
+
+                test.Set(groupOne);
+                Assert.IsTrue(await waiterOne);
+            }
+        }
+
+        [TestMethod]
+        public async Task WaitAsync_IfDisposed_Exception()
+        {
+            var test = CreateWithRealWait();
+            test.Dispose();
+            await Assert.ThrowsExactlyAsync<ObjectDisposedException>(
+                async () => await test.WaitAsync(null));
+        }
+
         private WaitForEventOrCancelThreadPool Create()
         {
             var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
             fixture.Inject(fixture.Create<WaitForEventOrCancelFactory>());
             return fixture.Create<WaitForEventOrCancelThreadPool>();
+        }
+
+        //the async tests above assert on real signaled/unsignaled state, which the plain
+        //AutoNSubstituteCustomization Create() helper can't provide - it auto-mocks
+        //IWaitForEventOrCancelFactory.Create() into returning another substitute
+        //(NSubstitute recursively mocks interface return values), not a working
+        //WaitForEventOrCancel. Wire the factory to return real instances instead.
+        private static WaitForEventOrCancelThreadPool CreateWithRealWait()
+        {
+            var factory = Substitute.For<IWaitForEventOrCancelFactory>();
+            factory.Create().Returns(_ => new DotNetWorkQueue.Queue.WaitForEventOrCancel());
+            return new WaitForEventOrCancelThreadPool(factory);
         }
     }
 }

--- a/Source/DotNetWorkQueue/IWaitForEventOrCancel.cs
+++ b/Source/DotNetWorkQueue/IWaitForEventOrCancel.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue
 {
@@ -31,6 +32,16 @@ namespace DotNetWorkQueue
         /// </summary>
         /// <returns></returns>
         bool Wait();
+        /// <summary>
+        /// Waits to be notified to stop waiting, without blocking a thread.
+        /// </summary>
+        /// <returns><c>true</c> if signaled; <c>false</c> if cancelled.</returns>
+        /// <remarks>
+        /// The asynchronous twin of <see cref="Wait"/> and returns the same values.
+        /// Exists because a consumer that blocks a thread-pool thread here cannot complete
+        /// the very continuations that would release it.
+        /// </remarks>
+        ValueTask<bool> WaitAsync();
         /// <summary>
         /// Resets the wait status, causing <see cref="Wait"/> calls to wait.
         /// </summary>

--- a/Source/DotNetWorkQueue/IWaitForEventOrCancelThreadPool.cs
+++ b/Source/DotNetWorkQueue/IWaitForEventOrCancelThreadPool.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue
 {
@@ -31,6 +32,12 @@ namespace DotNetWorkQueue
         /// <param name="group">The group.</param>
         /// <returns></returns>
         bool Wait(IWorkGroup group);
+        /// <summary>
+        /// Waits until notified to stop waiting, without blocking a thread.
+        /// </summary>
+        /// <param name="group">The group.</param>
+        /// <returns><c>true</c> if signaled; <c>false</c> if cancelled.</returns>
+        ValueTask<bool> WaitAsync(IWorkGroup group);
         /// <summary>
         /// Resets the wait status, causing <see cref="Wait" /> calls to wait.
         /// </summary>

--- a/Source/DotNetWorkQueue/Queue/WaitForEventOrCancel.cs
+++ b/Source/DotNetWorkQueue/Queue/WaitForEventOrCancel.cs
@@ -32,6 +32,9 @@ namespace DotNetWorkQueue.Queue
         //RunContinuationsAsynchronously matters twice over: a continuation must not run
         //inline on a scheduler thread we need back, and must not run inline while this
         //object holds _asyncSync.
+        //Null until the first WaitAsync call: nothing allocates a TaskCompletionSource
+        //until an async waiter actually exists, so Set/Reset stay allocation-free on the
+        //synchronous-only path (e.g. the saturated TaskScheduler hot path).
         private TaskCompletionSource<bool> _asyncWait;
 
         //Serialises every transition of the (reset event, completion source, token)
@@ -47,9 +50,6 @@ namespace DotNetWorkQueue.Queue
         {
             _resetEvent = new ManualResetEventSlim(true);
             _cancellationTokenSource = new CancellationTokenSource();
-
-            //constructed signaled, matching ManualResetEventSlim(true) above
-            _asyncWait = CreateCompletedWait();
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace DotNetWorkQueue.Queue
             {
                 //false is what the synchronous Wait returns when cancelled; async waiters
                 //get the same answer rather than an exception
-                _asyncWait.TrySetResult(false);
+                _asyncWait?.TrySetResult(false);
             }
         }
 
@@ -90,15 +90,23 @@ namespace DotNetWorkQueue.Queue
         {
             ThrowIfDisposed();
 
-            //Cancellation is terminal: the synchronous Wait returns false for the rest of
-            //this object's life once cancelled, because it always consults the token. A
-            //Reset after a Cancel would otherwise re-arm the source and leave an async
-            //caller waiting on an object that can never be signaled again.
-            if (_cancellationTokenSource.IsCancellationRequested)
-                return new ValueTask<bool>(false);
-
             lock (_asyncSync)
             {
+                //Cancellation is terminal: the synchronous Wait returns false for the rest
+                //of this object's life once cancelled, because it always consults the
+                //token. A Reset after a Cancel would otherwise re-arm the source and leave
+                //an async caller waiting on an object that can never be signaled again.
+                //Checked under the lock so it is atomic with the read/creation of
+                //_asyncWait below - otherwise a Cancel between the check and the lock can
+                //be missed.
+                if (_cancellationTokenSource.IsCancellationRequested)
+                    return new ValueTask<bool>(false);
+
+                //Created lazily: seed it from the current event state so a first-ever
+                //WaitAsync on an already-signaled instance completes immediately, just
+                //like before this was lazy.
+                _asyncWait ??= _resetEvent.IsSet ? CreateCompletedWait() : CreateWait();
+
                 return new ValueTask<bool>(_asyncWait.Task);
             }
         }
@@ -115,8 +123,9 @@ namespace DotNetWorkQueue.Queue
 
                 //Only re-arm a source that has already completed. Replacing one that still
                 //has waiters would orphan them: the next Set would complete the new
-                //instance while they went on awaiting the old one.
-                if (_asyncWait.Task.IsCompleted)
+                //instance while they went on awaiting the old one. Nothing to do while no
+                //async waiter has ever existed.
+                if (_asyncWait != null && _asyncWait.Task.IsCompleted)
                     _asyncWait = CreateWait();
             }
         }
@@ -130,7 +139,7 @@ namespace DotNetWorkQueue.Queue
             lock (_asyncSync)
             {
                 _resetEvent.Set();
-                _asyncWait.TrySetResult(true);
+                _asyncWait?.TrySetResult(true);
             }
         }
 
@@ -167,7 +176,7 @@ namespace DotNetWorkQueue.Queue
             //not fault it, so without this it waits forever on an object that is gone.
             lock (_asyncSync)
             {
-                _asyncWait.TrySetResult(false);
+                _asyncWait?.TrySetResult(false);
             }
 
             _resetEvent.Dispose();

--- a/Source/DotNetWorkQueue/Queue/WaitForEventOrCancel.cs
+++ b/Source/DotNetWorkQueue/Queue/WaitForEventOrCancel.cs
@@ -96,10 +96,14 @@ namespace DotNetWorkQueue.Queue
                 //of this object's life once cancelled, because it always consults the
                 //token. A Reset after a Cancel would otherwise re-arm the source and leave
                 //an async caller waiting on an object that can never be signaled again.
-                //Checked under the lock so it is atomic with the read/creation of
-                //_asyncWait below - otherwise a Cancel between the check and the lock can
-                //be missed.
-                if (_cancellationTokenSource.IsCancellationRequested)
+                //Disposal is terminal the same way: Dispose only resolves an _asyncWait
+                //that already exists, so a caller racing Dispose before this method has
+                //ever created one would otherwise manufacture a fresh, incomplete source
+                //that nothing can ever complete - Set/Reset/Cancel all throw once disposed,
+                //and Dispose has already made its one pass. Both are checked under the lock
+                //so they are atomic with the read/creation of _asyncWait below - otherwise a
+                //Cancel or Dispose between the check and the lock can be missed.
+                if (_cancellationTokenSource.IsCancellationRequested || IsDisposed)
                     return new ValueTask<bool>(false);
 
                 //Created lazily: seed it from the current event state so a first-ever

--- a/Source/DotNetWorkQueue/Queue/WaitForEventOrCancel.cs
+++ b/Source/DotNetWorkQueue/Queue/WaitForEventOrCancel.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Queue
 {
@@ -27,6 +28,18 @@ namespace DotNetWorkQueue.Queue
         private readonly CancellationTokenSource _cancellationTokenSource;
         private int _disposeCount;
 
+        //ManualResetEventSlim has no WaitAsync, so async waiters park on this instead.
+        //RunContinuationsAsynchronously matters twice over: a continuation must not run
+        //inline on a scheduler thread we need back, and must not run inline while this
+        //object holds _asyncSync.
+        private TaskCompletionSource<bool> _asyncWait;
+
+        //Serialises every transition of the (reset event, completion source, token)
+        //triple. Without it the reset event and the completion source can disagree - the
+        //event signaled while the source is not - and an async waiter then waits for a
+        //Set that has already happened.
+        private readonly object _asyncSync = new object();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WaitForEventOrCancel"/> class.
         /// </summary>
@@ -34,6 +47,9 @@ namespace DotNetWorkQueue.Queue
         {
             _resetEvent = new ManualResetEventSlim(true);
             _cancellationTokenSource = new CancellationTokenSource();
+
+            //constructed signaled, matching ManualResetEventSlim(true) above
+            _asyncWait = CreateCompletedWait();
         }
 
         /// <summary>
@@ -43,6 +59,12 @@ namespace DotNetWorkQueue.Queue
         {
             ThrowIfDisposed();
             _cancellationTokenSource.Cancel();
+            lock (_asyncSync)
+            {
+                //false is what the synchronous Wait returns when cancelled; async waiters
+                //get the same answer rather than an exception
+                _asyncWait.TrySetResult(false);
+            }
         }
 
         /// <summary>
@@ -63,13 +85,40 @@ namespace DotNetWorkQueue.Queue
             }
         }
 
+        /// <inheritdoc />
+        public ValueTask<bool> WaitAsync()
+        {
+            ThrowIfDisposed();
+
+            //Cancellation is terminal: the synchronous Wait returns false for the rest of
+            //this object's life once cancelled, because it always consults the token. A
+            //Reset after a Cancel would otherwise re-arm the source and leave an async
+            //caller waiting on an object that can never be signaled again.
+            if (_cancellationTokenSource.IsCancellationRequested)
+                return new ValueTask<bool>(false);
+
+            lock (_asyncSync)
+            {
+                return new ValueTask<bool>(_asyncWait.Task);
+            }
+        }
+
         /// <summary>
         /// Resets the wait status, causing <see cref="Wait" /> calls to wait.
         /// </summary>
         public void Reset()
         {
             ThrowIfDisposed();
-            _resetEvent.Reset();
+            lock (_asyncSync)
+            {
+                _resetEvent.Reset();
+
+                //Only re-arm a source that has already completed. Replacing one that still
+                //has waiters would orphan them: the next Set would complete the new
+                //instance while they went on awaiting the old one.
+                if (_asyncWait.Task.IsCompleted)
+                    _asyncWait = CreateWait();
+            }
         }
 
         /// <summary>
@@ -78,7 +127,21 @@ namespace DotNetWorkQueue.Queue
         public void Set()
         {
             ThrowIfDisposed();
-            _resetEvent.Set();
+            lock (_asyncSync)
+            {
+                _resetEvent.Set();
+                _asyncWait.TrySetResult(true);
+            }
+        }
+
+        private static TaskCompletionSource<bool> CreateWait() =>
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private static TaskCompletionSource<bool> CreateCompletedWait()
+        {
+            var source = CreateWait();
+            source.SetResult(true);
+            return source;
         }
 
         #region IDispose, IIsDisposed
@@ -99,6 +162,14 @@ namespace DotNetWorkQueue.Queue
             if (Interlocked.Increment(ref _disposeCount) != 1) return;
 
             GC.SuppressFinalize(this);
+
+            //An async waiter holds only a Task; disposing the underlying primitives does
+            //not fault it, so without this it waits forever on an object that is gone.
+            lock (_asyncSync)
+            {
+                _asyncWait.TrySetResult(false);
+            }
+
             _resetEvent.Dispose();
             _cancellationTokenSource.Dispose();
         }

--- a/Source/DotNetWorkQueue/TaskScheduling/WaitForEventOrCancelThreadPool.cs
+++ b/Source/DotNetWorkQueue/TaskScheduling/WaitForEventOrCancelThreadPool.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.TaskScheduling
@@ -61,6 +62,19 @@ namespace DotNetWorkQueue.TaskScheduling
             }
 
             return GetOrAddGroup(group).Wait();
+        }
+
+        /// <inheritdoc />
+        public ValueTask<bool> WaitAsync(IWorkGroup group)
+        {
+            ThrowIfDisposed();
+
+            if (group == null)
+            {
+                return _waitForEvent.Value.WaitAsync();
+            }
+
+            return GetOrAddGroup(group).WaitAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
First of the seven PRs in the [async receive path design](docs/superpowers/specs/2026-09-08-async-receive-path-design.md), implementing [its plan](docs/superpowers/plans/2026-09-08-async-receive-path-pr1.md).

**Nothing calls the new methods.** This PR changes no behaviour — it adds the awaitable wait a later PR needs so the consumer loop can stop blocking a thread-pool thread on every dequeue. Blocking there is a deadlock shape, not merely slow: a blocked pool thread cannot run the continuation that would release it, which is what #161 recorded as `WORKER: (Busy=215, Min=200)`.

## What's here

| commit | |
|---|---|
| `faacd550` | `CA2012` raised to error, **before** any `ValueTask` exists |
| `40227405` | `ValueTask<bool> IWaitForEventOrCancel.WaitAsync()` |
| `4c286f7f` | `ValueTask<bool> IWaitForEventOrCancelThreadPool.WaitAsync(IWorkGroup)` |
| `eb7a36af` | fix: lost wake-up + stop allocating on the scheduler path |
| `af030c7a` | fix: `Dispose`/`WaitAsync` race that could hang a first-ever waiter |
| `ebe6a529` | test: replace a vacuous 50-second concurrency test |

## ⚠️ Breaking change

`IWaitForEventOrCancel` and `IWaitForEventOrCancelThreadPool` are public, and `ATaskScheduler.WaitForFreeThread` exposes the latter — **any custom `ATaskScheduler` implementation breaks on rebuild.** Accepted deliberately, matching `ISendMessages`, which already carries `Send` and `SendAsync` on one interface.

No changelog entry here: `CHANGELOG.md` has no `Unreleased` section and the 0.11.0 precedent is one pass at release time. The ⚠️ requirement is recorded on #256, which stays open until PR 7 and is what the release notes will be written from.

## The design, and the two things review corrected in it

`ManualResetEventSlim` has no `WaitAsync`, so a `TaskCompletionSource` sits beside it. Every transition — of the reset event, the completion source, and the cancellation token — happens under one lock, because those three must stay coherent. `RunContinuationsAsynchronously` is what makes completing a source inside that lock safe.

Two Critical defects were found and fixed, **both in the design rather than the implementation**:

**The cancellation check was outside the lock**, so the guard wasn't atomic with what it guarded:

```
A: reads the flag -> false          (not yet in the lock)
B: Cancel   -> completes the current source false
C: Reset    -> sees it completed, installs a fresh incomplete source
A: takes the lock, returns that source -- nothing will ever complete it
```

The synchronous `Wait()` returns `false` in that same interleaving, so the two diverged in the hanging direction.

**Making the source lazy then broke `Dispose`.** Laziness was added to keep `Reset` off the scheduler's allocation path (it runs ~twice per message when saturated). But it invalidated the premise that `_asyncWait` is always non-null, so `Dispose` could no-op on a null source while a racing first `WaitAsync` manufactured an incomplete one nothing could complete. Closed by checking `IsDisposed` inside the lock alongside the cancellation check.

Both are latent today — `StopWorkers` always calls `Cancel` before `Dispose` — but they are real holes in the primitive, and PR 2 is when async waiters actually arrive.

## Testing

2,929 tests across all 11 unit projects, zero failures. Release build with `-p:CI=true` clean (`TreatWarningsAsErrors` + XML docs).

Two things worth stating rather than glossing:

- **The `Dispose`-race regression test has unproven detection power.** Roughly 700k racing attempts across several designs — barriers on dedicated threads, CPU oversubscription, swept head-starts — could not force the interleaving; the window is a few instructions. It costs 0.08s and stays as a tripwire, but the fix rests on the code walkthrough and an instrumented harness, not on that test.
- **One test was found to be vacuous and expensive.** `SetAndReset_Concurrently` was 50.08s of the class's 54.4s, and its assertion was almost never evaluated because both probes timed out nearly every iteration. Replaced with a deterministic check that creates the waiter *before* the race and asserts it gets released — a `Set` always runs, so its source must complete whichever order the pair lands in. **Class now runs in 4.39s.**

## Follow-up worth an issue

The 15 pre-existing tests in `WaitForEventOrCancelThreadPoolTests` build their subject through AutoFixture's `AutoNSubstituteCustomization`, which auto-mocks the factory recursively — so they assert "does not throw" and nothing more. The new tests use a real `WaitForEventOrCancel` instead. Not fixed here; out of scope for a no-behaviour-change PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added non-blocking asynchronous waiting for event completion or cancellation.
  * Added asynchronous waiting for shared and work-group-specific events.
  * Async waits now correctly handle signaling, cancellation, resets, disposal, and multiple concurrent waiters.

* **Tests**
  * Added comprehensive coverage for async wait behavior, race conditions, cancellation, disposal, and work-group isolation.

* **Chores**
  * Elevated ValueTask usage analysis violations to errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->