### PR TITLE
Async receive path: core plumbing plus a genuinely async Redis de-queue (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ﻿### Unreleased
 - Redis consumers no longer hold a thread through the de-queue. Under thread-pool pressure, where a consumer previously timed out waiting on Redis, it now keeps working (GitHub #256)
 - ⚠️ Custom transports and consumers must add async members: `IReceiveMessages.ReceiveMessageAsync`, `IQueueWait.WaitAsync`, and `IRedisQueueWorkSub.WaitAsync` for Redis. Built-in transports are unaffected (GitHub #256)
-- ⚠️ `IMessageProcessing.Handle()` is now `HandleAsync()`, returning a task the worker loop waits on. Only affects code implementing that interface directly (GitHub #256)
+- ⚠️ `IMessageProcessing.Handle()` is now `HandleAsync()` and returns a task. Only affects code implementing that interface directly (GitHub #256)
 - Tracing: the async consumer emits its receive span as `ReceiveMessageAsync` rather than `ReceiveMessage`. Dashboards filtering on the old name will not match it. Metric names are unchanged (GitHub #256)
 
 ### 0.11.0 — 2026-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-﻿### 0.11.0 — 2026-09-06
+﻿### Unreleased
+- Redis consumers no longer hold a thread through the de-queue. Under thread-pool pressure, where a consumer previously timed out waiting on Redis, it now keeps working (GitHub #256)
+- ⚠️ Custom transports and consumers must add async members: `IReceiveMessages.ReceiveMessageAsync`, `IQueueWait.WaitAsync`, and `IRedisQueueWorkSub.WaitAsync` for Redis. Built-in transports are unaffected (GitHub #256)
+- ⚠️ `IMessageProcessing.Handle()` is now `HandleAsync()`, returning a task the worker loop waits on. Only affects code implementing that interface directly (GitHub #256)
+- Tracing: the async consumer emits its receive span as `ReceiveMessageAsync` rather than `ReceiveMessage`. Dashboards filtering on the old name will not match it. Metric names are unchanged (GitHub #256)
+
+### 0.11.0 — 2026-09-06
 - SQL Server and PostgreSQL: an ordinary send is one round trip instead of four, on `Send` and `SendAsync`. A SQL Server send allocates 16% less — 29,298 B down to 24,648 B — and the time saved grows with distance to the server (GitHub #231, #232)
 - SQL Server and PostgreSQL: queues using `EnableDelayedProcessing` or `EnableMessageExpiration` no longer pay a per-send penalty, and SQL Server no longer fills its plan cache with one plan per delay value (GitHub #255)
 - SQL Server and PostgreSQL: a routed consumer no longer rebuilds its de-queue statement on every poll — 5,368 B down to 80 B a poll on SQL Server, 2,648 B down to 80 B on PostgreSQL (GitHub #231, #232)

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/VerifyMetrics.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/VerifyMetrics.cs
@@ -54,11 +54,19 @@ namespace DotNetWorkQueue.IntegrationTests.Shared
             long count = 0;
             foreach (var name in names)
             {
+                //Sum every matching counter, which is what this method has always claimed to do.
+                //It used to stop after the first, which was invisible while exactly one counter ended
+                //in each suffix. The Redis transport now has two ending in ".HandleAsync.Expired" -
+                //one for the synchronous receive handler and one for the asynchronous twin - and only
+                //the path the consumer actually used is non-zero. Taking whichever enumerated first
+                //returned 0 for a run that had expired every message.
+                //
+                //Summing cannot double count: a consumer uses the sync receive path or the async one,
+                //never both, so at most one of the pair is ever incremented.
                 foreach (var metric in data.Counters.Where(
                     c => c.Key.EndsWith(name, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     count = count + metric.Value;
-                    break;
                 }
             }
             return count;

--- a/Source/DotNetWorkQueue.Tests/History/Decorator/ReceiveMessagesHistoryDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/History/Decorator/ReceiveMessagesHistoryDecoratorTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using DotNetWorkQueue.History.Decorator;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -78,6 +80,72 @@ namespace DotNetWorkQueue.Tests.History.Decorator
         }
 
         [TestMethod]
+        public async Task ReceiveMessageAsync_Calls_Inner_Handler_And_Returns_Result()
+        {
+            var (decorator, inner, _, _, _) = CreateDecorator(enabled: false);
+            var context = CreateContext();
+            var expectedResult = Substitute.For<IReceivedMessageInternal>();
+            SetupAsyncReceive(inner, context, expectedResult);
+
+            var result = await decorator.ReceiveMessageAsync(context, CancellationToken.None);
+
+            Assert.AreSame(expectedResult, result);
+        }
+
+        [TestMethod]
+        public async Task ReceiveMessageAsync_When_Enabled_Records_Processing_Start()
+        {
+            var (decorator, inner, history, _, _) = CreateDecorator(enabled: true, trackProcessing: true);
+            var context = CreateContext();
+            var receivedMessage = Substitute.For<IReceivedMessageInternal>();
+            SetupAsyncReceive(inner, context, receivedMessage);
+
+            await decorator.ReceiveMessageAsync(context, CancellationToken.None);
+
+            history.Received(1).RecordProcessingStart(Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public async Task ReceiveMessageAsync_When_Disabled_Does_Not_Record()
+        {
+            var (decorator, inner, history, _, _) = CreateDecorator(enabled: false);
+            var context = CreateContext();
+            var receivedMessage = Substitute.For<IReceivedMessageInternal>();
+            SetupAsyncReceive(inner, context, receivedMessage);
+
+            await decorator.ReceiveMessageAsync(context, CancellationToken.None);
+
+            history.DidNotReceive().RecordProcessingStart(Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public async Task ReceiveMessageAsync_When_Null_Result_Does_Not_Record()
+        {
+            var (decorator, inner, history, _, _) = CreateDecorator(enabled: true, trackProcessing: true);
+            var context = CreateContext();
+            SetupAsyncReceive(inner, context, null);
+
+            await decorator.ReceiveMessageAsync(context, CancellationToken.None);
+
+            history.DidNotReceive().RecordProcessingStart(Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public async Task ReceiveMessageAsync_When_History_Throws_Exception_Is_Swallowed()
+        {
+            var (decorator, inner, history, _, _) = CreateDecorator(enabled: true, trackProcessing: true);
+            var context = CreateContext();
+            var receivedMessage = Substitute.For<IReceivedMessageInternal>();
+            SetupAsyncReceive(inner, context, receivedMessage);
+            history.When(h => h.RecordProcessingStart(Arg.Any<string>()))
+                .Do(_ => throw new InvalidOperationException("history write failed"));
+
+            var result = await decorator.ReceiveMessageAsync(context, CancellationToken.None);
+
+            Assert.AreSame(receivedMessage, result);
+        }
+
+        [TestMethod]
         public void IsBlockingOperation_Delegates_To_Inner()
         {
             var (decorator, inner, _, _, _) = CreateDecorator(enabled: false);
@@ -88,6 +156,18 @@ namespace DotNetWorkQueue.Tests.History.Decorator
             inner.IsBlockingOperation.Returns(false);
 
             Assert.IsFalse(decorator.IsBlockingOperation);
+        }
+
+        private static void SetupAsyncReceive(IReceiveMessages inner, IMessageContext context,
+            IReceivedMessageInternal result)
+        {
+            //Configuring a substitute is the one case where the returned ValueTask is not meant to be
+            //consumed at all - NSubstitute intercepts the call to record the setup. Kept in this single
+            //helper so the suppression does not spread across the tests.
+#pragma warning disable CA2012
+            inner.ReceiveMessageAsync(context, Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IReceivedMessageInternal>(result));
+#pragma warning restore CA2012
         }
 
         private static IMessageContext CreateContext()

--- a/Source/DotNetWorkQueue.Tests/Policies/Decorator/ReceiveMessagesPolicyDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Policies/Decorator/ReceiveMessagesPolicyDecoratorTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Policies;
+using DotNetWorkQueue.Policies.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Tests.Policies.Decorator
+{
+    /// <summary>
+    /// Covers both branches of the receive policy decorator, on both the synchronous and the
+    /// asynchronous path: a pipeline registered for the key, and no pipeline registered.
+    ///
+    /// Neither path had tests before. The asynchronous one is the reason these exist — its
+    /// cancellation token used to be dropped on the floor, so a retry or timeout strategy kept
+    /// waiting out its delay after the queue had been told to stop.
+    /// </summary>
+    [TestClass]
+    public class ReceiveMessagesPolicyDecoratorTests
+    {
+        private const string Key = "ReceiveMessageFromTransport";
+
+        [TestMethod]
+        public void ReceiveMessage_WithNoPipelineRegistered_CallsTheHandler()
+        {
+            var (decorator, handler, context) = Create(registerPipeline: false);
+            var expected = Substitute.For<IReceivedMessageInternal>();
+            handler.ReceiveMessage(context).Returns(expected);
+
+            Assert.AreSame(expected, decorator.ReceiveMessage(context));
+        }
+
+        [TestMethod]
+        public void ReceiveMessage_WithPipelineRegistered_CallsTheHandler()
+        {
+            var (decorator, handler, context) = Create(registerPipeline: true);
+            var expected = Substitute.For<IReceivedMessageInternal>();
+            handler.ReceiveMessage(context).Returns(expected);
+
+            Assert.AreSame(expected, decorator.ReceiveMessage(context));
+        }
+
+        [TestMethod]
+        public async Task ReceiveMessageAsync_WithNoPipelineRegistered_CallsTheHandler()
+        {
+            var (decorator, handler, context) = Create(registerPipeline: false);
+            var expected = Substitute.For<IReceivedMessageInternal>();
+            SetupAsync(handler, context, expected);
+
+            Assert.AreSame(expected, await decorator.ReceiveMessageAsync(context, CancellationToken.None));
+        }
+
+        [TestMethod]
+        public async Task ReceiveMessageAsync_WithPipelineRegistered_CallsTheHandler()
+        {
+            var (decorator, handler, context) = Create(registerPipeline: true);
+            var expected = Substitute.For<IReceivedMessageInternal>();
+            SetupAsync(handler, context, expected);
+
+            Assert.AreSame(expected, await decorator.ReceiveMessageAsync(context, CancellationToken.None));
+        }
+
+        [TestMethod]
+        public async Task ReceiveMessageAsync_GivesTheCancellationTokenToThePipeline()
+        {
+            var (decorator, handler, context) = Create(registerPipeline: true);
+            SetupAsync(handler, context, Substitute.For<IReceivedMessageInternal>());
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            //An already-cancelled token must stop the pipeline before it reaches the handler. If the
+            //token is not forwarded, the pipeline runs against CancellationToken.None, the handler is
+            //called, and nothing throws - which is precisely the defect: a retry or timeout strategy
+            //would go on waiting out its delay after the queue had been told to stop.
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await decorator.ReceiveMessageAsync(context, cts.Token));
+
+            await handler.DidNotReceive().ReceiveMessageAsync(context, Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public void IsBlockingOperation_DelegatesToInner()
+        {
+            var (decorator, handler, _) = Create(registerPipeline: false);
+            handler.IsBlockingOperation.Returns(true);
+            Assert.IsTrue(decorator.IsBlockingOperation);
+        }
+
+        private static void SetupAsync(IReceiveMessages handler, IMessageContext context,
+            IReceivedMessageInternal result)
+        {
+            //Configuring a substitute never consumes the ValueTask, which is the one case CA2012's
+            //rule does not fit.
+#pragma warning disable CA2012
+            handler.ReceiveMessageAsync(context, Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<IReceivedMessageInternal>(result));
+#pragma warning restore CA2012
+        }
+
+        private static (IReceiveMessages decorator, IReceiveMessages handler, IMessageContext context)
+            Create(bool registerPipeline)
+        {
+            var handler = Substitute.For<IReceiveMessages>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+
+            if (registerPipeline)
+            {
+                registry.GetOrAddPipeline(Key,
+                    builder => builder.AddTimeout(TimeSpan.FromSeconds(30)));
+            }
+
+            policies.Registry.Returns(registry);
+            policies.Definition.Returns(new PolicyDefinitions());
+
+            return (new ReceiveMessagesPolicyDecorator(policies, handler), handler,
+                Substitute.For<IMessageContext>());
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Tests/Queue/MessageProcessingAsyncPacingTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/MessageProcessingAsyncPacingTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using DotNetWorkQueue.Queue;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Tests.Queue
+{
+    /// <summary>
+    /// Pins what paces the worker loop, which is the thing that bounds how many de-queues can be in
+    /// flight at once.
+    ///
+    /// <c>Worker.MainLoop</c> is <c>while (!ShouldExit) { ... MessageProcessing.HandleAsync() ... }</c>
+    /// and it waits on the returned task. So the invariant is simply: that task must not complete
+    /// while a de-queue is still running. Until #256 the cap was an accident of the receive being a
+    /// blocking call; awaiting the receive without moving the cap first was measured at 15,910,404
+    /// concurrent in-flight de-queues against a configured worker count of seven, which OOM-killed
+    /// the machine.
+    ///
+    /// These are deliberately unit tests over the pacing contract rather than a load test. A load
+    /// test for this has to be bounded very carefully or it reproduces the OOM instead of reporting
+    /// it; asserting the contract costs milliseconds and cannot run away.
+    ///
+    /// Every transport implementation added in the first half of #256 returns an already-completed
+    /// <c>ValueTask</c>, so nothing here would fail without a receive that genuinely suspends. That
+    /// is exactly why these tests supply one: the defect is invisible to every other test in the
+    /// repository until a real transport goes async.
+    /// </summary>
+    [TestClass]
+    public class MessageProcessingAsyncPacingTests
+    {
+        private static readonly TimeSpan SettleTime = TimeSpan.FromMilliseconds(250);
+
+        [TestMethod]
+        public async Task ReadyForNext_DoesNotComplete_WhileTheDeQueueIsStillRunning()
+        {
+            var harness = new Harness();
+            var readyForNext = harness.Processor.HandleAsync();
+
+            // The receive is pending, so the worker loop must still be parked here. If this task were
+            // complete, MainLoop would already be starting another de-queue - the runaway.
+            var completedEarly = await Task.WhenAny(readyForNext, Task.Delay(SettleTime))
+                .ConfigureAwait(false) == readyForNext;
+
+            Assert.IsFalse(completedEarly,
+                "HandleAsync signalled the worker loop while the de-queue was still in flight. " +
+                "MainLoop would immediately start another receive, and another, without bound.");
+
+            harness.CompleteReceiveWith(null);
+            await readyForNext.ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task ReadyForNext_Completes_OnceTheDeQueueFindsNothing()
+        {
+            var harness = new Harness();
+            var readyForNext = harness.Processor.HandleAsync();
+
+            harness.CompleteReceiveWith(null);
+
+            // The idle back-off is a substitute here, so it returns immediately; the point is that the
+            // loop is released rather than left parked for good.
+            var released = await Task.WhenAny(readyForNext, Task.Delay(SettleTime))
+                .ConfigureAwait(false) == readyForNext;
+
+            Assert.IsTrue(released,
+                "HandleAsync never signalled the worker loop after an empty de-queue. A lost signal " +
+                "here parks that worker permanently.");
+        }
+
+        [TestMethod]
+        public async Task ReadyForNext_Completes_AfterDispatch_WithoutWaitingForTheWorkToFinish()
+        {
+            var harness = new Harness();
+            var readyForNext = harness.Processor.HandleAsync();
+
+            harness.CompleteReceiveWith(Substitute.For<IReceivedMessageInternal>());
+
+            // Dispatched but still running: this is the old `async void Handle` hand-back point, and
+            // the loop resuming here is what lets the scheduler run more work than there are workers.
+            // Waiting for the work itself would quietly serialise each worker to one message at a time.
+            var released = await Task.WhenAny(readyForNext, Task.Delay(SettleTime))
+                .ConfigureAwait(false) == readyForNext;
+
+            Assert.IsTrue(released,
+                "HandleAsync waited for the message to finish processing before releasing the worker " +
+                "loop. That serialises each worker to one message at a time and throws away the " +
+                "point of the async consumer.");
+
+            Assert.IsTrue(harness.HandlerWasInvoked,
+                "The loop was released without the message having been dispatched.");
+
+            harness.CompleteTheWork();
+        }
+
+        private sealed class Harness
+        {
+            private readonly TaskCompletionSource<IReceivedMessageInternal> _receive =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private readonly TaskCompletionSource<bool> _work =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public MessageProcessingAsync Processor { get; }
+            public bool HandlerWasInvoked { get; private set; }
+
+            public Harness()
+            {
+                var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
+
+                var receiveMessages = Substitute.For<IReceiveMessages>();
+                SetupReceive(receiveMessages, _receive.Task);
+
+                var receiveFactory = Substitute.For<IReceiveMessagesFactory>();
+                receiveFactory.Create().Returns(receiveMessages);
+
+                var handler = Substitute.For<IHandleMessage>();
+                handler.HandleAsync(Arg.Any<IReceivedMessageInternal>(), Arg.Any<IWorkerNotification>())
+                    .Returns(_ =>
+                    {
+                        HandlerWasInvoked = true;
+                        return _work.Task;
+                    });
+
+                fixture.Inject(receiveFactory);
+                fixture.Inject(handler);
+
+                Processor = fixture.Create<MessageProcessingAsync>();
+            }
+
+            public void CompleteReceiveWith(IReceivedMessageInternal message) => _receive.TrySetResult(message);
+
+            public void CompleteTheWork() => _work.TrySetResult(true);
+
+            private static void SetupReceive(IReceiveMessages receiveMessages, Task<IReceivedMessageInternal> pending)
+            {
+                //Configuring a substitute is the one place the returned ValueTask is not meant to be
+                //consumed - NSubstitute intercepts the call to record the setup - and CA2012 is an
+                //error repo-wide, flagging it whether it is a receiver or an argument.
+#pragma warning disable CA2012
+                receiveMessages.ReceiveMessageAsync(Arg.Any<IMessageContext>(), Arg.Any<CancellationToken>())
+                    .Returns(new ValueTask<IReceivedMessageInternal>(pending));
+#pragma warning restore CA2012
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Tests/Queue/MessageProcessingAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/MessageProcessingAsyncTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoNSubstitute;
 using DotNetWorkQueue.Queue;
@@ -10,20 +11,20 @@ namespace DotNetWorkQueue.Tests.Queue
     public class MessageProcessingAsyncTests
     {
         [TestMethod]
-        public void Handle()
+        public async Task Handle()
         {
             var wrapper = new MessageProcessingAsyncWrapper();
             var test = wrapper.Create();
-            test.Handle();
+            await test.HandleAsync();
             wrapper.MessageContextFactory.Received(1).Create();
         }
 
         [TestMethod]
-        public void Handle_Receive_Message()
+        public async Task Handle_Receive_Message()
         {
             var wrapper = new MessageProcessingAsyncWrapper();
             var test = wrapper.Create();
-            test.Handle();
+            await test.HandleAsync();
             wrapper.ReceiveMessages.ReceivedWithAnyArgs(1).Create();
         }
 

--- a/Source/DotNetWorkQueue.Tests/Queue/MessageProcessingTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/MessageProcessingTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoNSubstitute;
 using DotNetWorkQueue.Queue;
@@ -12,20 +13,20 @@ namespace DotNetWorkQueue.Tests.Queue
     public class MessageProcessingTests
     {
         [TestMethod]
-        public void Handle()
+        public async Task Handle()
         {
             var wrapper = new MessageProcessingWrapper();
             var test = wrapper.Create();
-            test.Handle();
+            await test.HandleAsync();
             wrapper.MessageContextFactory.Received(1).Create();
         }
 
         [TestMethod]
-        public void Handle_Receive_Message()
+        public async Task Handle_Receive_Message()
         {
             var wrapper = new MessageProcessingWrapper();
             var test = wrapper.Create();
-            test.Handle();
+            await test.HandleAsync();
             wrapper.ReceiveMessages.ReceivedWithAnyArgs(1).ReceiveMessage(null);
         }
 

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
@@ -23,6 +23,8 @@ using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.LiteDb.Basic
 {
@@ -108,6 +110,17 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
                 throw new ReceiveMessageException("An error occurred while attempting to read messages from the queue",
                     exception);
             }
+        }
+
+        /// <inheritdoc />
+        public ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            //Correct as written, not unfinished. This is an embedded database with no real
+            //asynchronous I/O - the LiteDB driver has no *Async API at all, it is a purely
+            //synchronous file-based engine - and a de-queue is on the order of microseconds,
+            //so there is nothing to release the thread for. Deliberately NOT Task.Run, which
+            //would only move the work to another pool thread.
+            return new ValueTask<IReceivedMessageInternal>(ReceiveMessage(context));
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
@@ -119,7 +119,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
             //asynchronous I/O - the LiteDB driver has no *Async API at all, it is a purely
             //synchronous file-based engine - and a de-queue is on the order of microseconds,
             //so there is nothing to release the thread for. Deliberately NOT Task.Run, which
-            //would only move the work to another pool thread.
+            //would only move the work to another pool thread. The token is ignored for the same
+            //reason - the call returns in microseconds, so there is no wait to cancel.
             return new ValueTask<IReceivedMessageInternal>(ReceiveMessage(context));
         }
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueReceive.cs
@@ -24,6 +24,8 @@ using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
 using Npgsql;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
 {
@@ -136,6 +138,15 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
                 throw new ReceiveMessageException("An error occurred while attempting to read messages from the queue",
                     exception);
             }
+        }
+
+        /// <inheritdoc />
+        public ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            //TEMPORARY - replaced with a genuinely asynchronous implementation later in this
+            //PR. Deliberately NOT Task.Run: that would move the block to a different pool
+            //thread while looking like a fix.
+            return new ValueTask<IReceivedMessageInternal>(ReceiveMessage(context));
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationBaselineTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationBaselineTests.cs
@@ -58,12 +58,19 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
     /// Run in isolation via:          --filter "TestCategory=StarvationBaseline"
     /// </summary>
     [TestClass]
+    [DoNotParallelize]
     public class StarvationBaselineTests
     {
         // Cap worker threads to this value. Must be low enough that the concurrent EVALs
         // saturate all available workers, but high enough that the test harness itself
         // can acquire a thread (avoids deadlocking the test runner before Redis is even
         // reached). Tuned at 6: concurrent senders = 50, well above the cap.
+        //DoNotParallelize above is required, not tidiness. SetMinThreads/SetMaxThreads are
+        //process-global, this assembly runs Parallelize(Workers = 2, Scope = MethodLevel), and the
+        //restore only happens in this test's finally - so for however long this runs, every test
+        //running alongside it sees a pool of WorkerCap threads and times out. CI never hits this
+        //because the Jenkinsfile filters the category out, but "Run All" in an IDE does, and so
+        //does running this category deliberately now that it holds more than one test.
         private const int WorkerCap = 6;
 
         // Number of concurrent parallel sender tasks driving sync EVAL calls.

--- a/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationReceiveBaselineTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationReceiveBaselineTests.cs
@@ -1,0 +1,403 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.Queue;
+using DotNetWorkQueue.Transport.Redis.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StackExchange.Redis;
+
+namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
+{
+    /// <summary>
+    /// Thread-pool starvation on the RECEIVE path — the gate for #256, plus the control that
+    /// establishes what does and does not cause it.
+    ///
+    /// <see cref="StarvationBaselineTests"/> looks like it already covers this and does not. It
+    /// floods with fifty concurrent <c>producer.Send</c> calls and contains no consumer, so it
+    /// exercises <c>EnqueueLua</c> on the send path. Its doc comment names
+    /// "ReceiveMessageQueryHandler.Handle", which is how the belief that receive was covered got
+    /// started. The send path already has an async implementation
+    /// (<c>SendMessageCommandHandlerAsync</c>), so it measures the sync API of a path that already
+    /// has an alternative, and no change to the receive path can move its result.
+    ///
+    /// The mechanism is not "our thread is blocked". Consumers run <c>MainLoop</c> on dedicated
+    /// threads (<c>Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning)</c>) — measured
+    /// at zero of twenty-seven receives on a pool thread — so a blocking receive occupies no pool
+    /// thread. What starves is StackExchange.Redis: a synchronous <c>ScriptEvaluate</c> is
+    /// sync-over-async internally and needs a pool thread to run the completion satisfying its own
+    /// blocking wait. Starve it of that thread and the wait outlives syncTimeout.
+    ///
+    /// The two tests here separate the two ways that can happen, because they are not equivalent:
+    ///
+    /// - <see cref="StarvationReceive_CappedPoolAlone_DoesNotStarve_Control"/> caps the pool and
+    ///   changes nothing else. It PASSES. The send-side baseline reproduces because its senders run
+    ///   ON the capped pool; a dedicated-thread caller leaves those threads free for completions.
+    /// - <see cref="StarvationReceive_ExternallySaturatedPool_SyncDequeue_FailsWithTimeout"/> holds
+    ///   the pool with unrelated work once the consumer is already running. That is the condition
+    ///   #161 actually recorded
+    ///   (<c>WORKER: (Busy=215, Min=200)</c>) — pressure from elsewhere, which on this CI means
+    ///   thirteen parallel Jenkins stages.
+    ///
+    /// Messages are always produced BEFORE the pool is interfered with. That is what lets a later
+    /// timeout be attributed to the receive: with sends completed under a healthy pool, a timeout
+    /// afterwards is not a send timeout. The assertions look only at
+    /// <c>ErrorReceiveNotification</c>, which <c>MessageProcessingAsync</c> raises solely from its
+    /// <c>ReceiveMessageException</c> handler; commit and rollback failures arrive on different
+    /// notifications and are reported, not asserted on.
+    ///
+    /// Both carry two categories on purpose. StarvationBaseline is what the Jenkinsfile already
+    /// excludes (<c>--filter "TestCategory!=StarvationBaseline"</c>), so neither needs a CI change
+    /// while the gate is expected RED. StarvationReceive selects this file alone:
+    ///     dotnet test ... --filter "TestCategory=StarvationReceive"
+    ///
+    /// Thread-pool settings are process-global and are ALWAYS restored, max before min — see the
+    /// comment at the restore; the order is not cosmetic.
+    ///
+    /// <c>[DoNotParallelize]</c> is load-bearing, not tidiness. This assembly runs
+    /// <c>Parallelize(Workers = 2, Scope = MethodLevel)</c>, and the first run of these two let
+    /// the gate's saturation land on the control's warm-up: the control failed having processed
+    /// zero messages "under a healthy pool" that the other test had already taken. Two tests that
+    /// both rewrite ThreadPool min/max cannot share a process concurrently.
+    /// </summary>
+    [TestClass]
+    [DoNotParallelize]
+    public class StarvationReceiveBaselineTests
+    {
+        // Cap worker threads to this value. Low enough that concurrent de-queue completions cannot
+        // all get a thread, high enough that the consumer's start-up machinery and the test harness
+        // can still acquire one. Matches the send-side baseline's cap.
+        private const int WorkerCap = 6;
+
+        // Consumer workers. Each gets a DEDICATED thread (LongRunning), so this is deliberately not
+        // bounded by WorkerCap - that asymmetry is the subject of the control below.
+        private const int WorkerCount = 25;
+
+        // Messages pre-loaded before the pool is touched. Enough that every worker finds work and
+        // keeps issuing de-queue EVALs, rather than parking in the empty-queue subscription wait -
+        // the Redis receive is IsBlockingOperation, and a worker waiting on the work signal is not
+        // exercising EVAL at all.
+        private const int MessageCount = 2000;
+
+        // Messages the consumer must process under a HEALTHY pool before pressure is applied,
+        // proving the connection is up and the de-queue loop is turning.
+        private const int WarmUpMessages = 20;
+
+        // Hard bound on each observation window. Under starvation the interesting event is a
+        // timeout; if none arrives we want a clean verdict rather than a hung agent.
+        private static readonly TimeSpan ObservationWindow = TimeSpan.FromSeconds(45);
+
+        /// <summary>
+        /// CONTROL — and it PASSES. Measured 2026-09-08: 60s window, zero receive timeouts.
+        ///
+        /// Capping the pool is not by itself enough to starve the receive. The send-side baseline
+        /// reproduces because its fifty senders are <c>new Task(...)</c> running ON the capped pool:
+        /// six threads block inside <c>ScriptEvaluate</c> and the completion that would release them
+        /// needs a seventh. The caller occupying a pool thread IS the deadlock.
+        ///
+        /// Consumer workers occupy none of the six, so they stay free to run completions. The
+        /// receive path is structurally immune to the self-inflicted deadlock the send path suffers.
+        ///
+        /// Keep this. If it ever goes red, something has moved the de-queue onto a pool thread and
+        /// the reasoning behind the gate below no longer holds.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("StarvationBaseline")]
+        [TestCategory("StarvationReceive")]
+        public void StarvationReceive_CappedPoolAlone_DoesNotStarve_Control()
+        {
+            var outcome = RunConsumerUnderPressure(saturatePool: false);
+
+            Assert.AreEqual(0, outcome.EvalTimeouts.Count,
+                $"Control went RED: capping the pool alone starved the receive, which contradicts " +
+                $"the reasoning the gate is built on. Something has likely moved the de-queue onto " +
+                $"a pool thread.\n{outcome}");
+
+            Assert.AreEqual(0, outcome.OtherReceiveErrors.Count,
+                $"Control saw receive errors that are not EVAL timeouts, so this run is " +
+                $"inconclusive: {outcome.OtherReceiveErrors.First()}\n{outcome}");
+        }
+
+        /// <summary>
+        /// THE GATE. Expected RED while the de-queue is synchronous, GREEN once it awaits
+        /// <c>DequeueLua.ExecuteAsync</c> (#256).
+        ///
+        /// The consumer is warmed up under a healthy pool first, then unrelated work takes every
+        /// worker thread - modelling #161's <c>WORKER: (Busy=215, Min=200)</c>, pressure arriving
+        /// at a consumer that is already running. Saturating before start-up only reproduces a
+        /// connection failure, since SE.Redis needs pool threads to connect at all.
+        ///
+        /// The saturating items self-release on a timer, so the test cannot wedge the agent even if
+        /// an assertion path is skipped.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("StarvationBaseline")]
+        [TestCategory("StarvationReceive")]
+        public void StarvationReceive_ExternallySaturatedPool_SyncDequeue_FailsWithTimeout()
+        {
+            var outcome = RunConsumerUnderPressure(saturatePool: true);
+
+            // A drained queue means the workers spent the window parked on the work signal
+            // rather than issuing de-queue EVALs, so a clean result proves nothing. Say so
+            // instead of passing quietly - a green that means "we never tested it" is worse
+            // than a red.
+            if (outcome.EvalTimeouts.Count == 0 && outcome.Processed >= MessageCount)
+            {
+                Assert.Inconclusive(
+                    $"Queue drained before the window elapsed, so the de-queue was idle for " +
+                    $"most of it and no conclusion can be drawn. Raise MessageCount.\n{outcome}");
+            }
+
+            Assert.AreEqual(0, outcome.EvalTimeouts.Count,
+                $"Receive-side thread-pool starvation reproduced: {outcome.EvalTimeouts.Count} " +
+                $"de-queue timeout(s) out of the synchronous ScriptEvaluate path, with the pool " +
+                $"capped at {WorkerCap}, held by unrelated work, and {WorkerCount} consumer " +
+                $"workers. This is the expected RED until the de-queue awaits " +
+                $"DequeueLua.ExecuteAsync (#256).\n{outcome}\n" +
+                $"First timeout: {outcome.EvalTimeouts.First().Message}");
+
+            Assert.AreEqual(0, outcome.OtherReceiveErrors.Count,
+                $"Receive errors occurred that are not EVAL timeouts, so this run is inconclusive " +
+                $"rather than a clean reproduction: {outcome.OtherReceiveErrors.First()}\n{outcome}");
+        }
+
+        private sealed class Outcome
+        {
+            public System.Collections.Generic.List<Exception> EvalTimeouts { get; init; }
+            public System.Collections.Generic.List<Exception> OtherReceiveErrors { get; init; }
+            public int Processed { get; init; }
+            public int OtherErrors { get; init; }
+            public int Cancellations { get; init; }
+            public TimeSpan Elapsed { get; init; }
+
+            public override string ToString() =>
+                $"processed {Processed}/{MessageCount}, starvation symptoms {EvalTimeouts.Count}, " +
+                $"unrelated receive errors {OtherReceiveErrors.Count}, shutdown cancellations " +
+                $"{Cancellations}, non-receive errors {OtherErrors}, " +
+                $"elapsed {Elapsed.TotalSeconds:F1}s" +
+                $"\n  symptom types: {Describe(EvalTimeouts)}" +
+                $"\n  unrelated types: {Describe(OtherReceiveErrors)}";
+
+            private static string Describe(System.Collections.Generic.IEnumerable<Exception> errors)
+            {
+                var grouped = errors
+                    .GroupBy(e =>
+                    {
+                        var inner = e.InnerException?.GetType().Name ?? "none";
+                        return e.GetType().Name + " -> " + inner;
+                    })
+                    .Select(g => g.Key + " x" + g.Count())
+                    .ToList();
+
+                return grouped.Count == 0 ? "none" : string.Join(", ", grouped);
+            }
+        }
+
+        private static Outcome RunConsumerUnderPressure(bool saturatePool)
+        {
+            var queueConnection = new QueueConnection(GenerateQueueName.Create(), ConnectionInfo.ConnectionString);
+
+            using var queueCreator = new QueueCreationContainer<RedisQueueInit>();
+            using var creation = queueCreator.GetQueueCreation<RedisQueueCreation>(queueConnection);
+            var created = creation.CreateQueue();
+            Assert.IsTrue(created.Success, created.ErrorMessage);
+
+            try
+            {
+                // --- Pre-load under a HEALTHY pool -------------------------------------------
+                // These must succeed. A send failure here makes the run inconclusive rather than
+                // red, and would otherwise be mistaken for the receive starvation under test.
+                using (var producerContainer = new QueueContainer<RedisQueueInit>())
+                using (var producer = producerContainer.CreateProducer<FakeMessage>(queueConnection))
+                {
+                    for (var i = 0; i < MessageCount; i++)
+                    {
+                        var sent = producer.Send(new FakeMessage { Name = Guid.NewGuid().ToString() });
+                        Assert.IsFalse(sent.HasError,
+                            $"Pre-load send {i} failed under an uncapped pool, so this run cannot " +
+                            $"attribute anything to the receive path: {sent.SendingException}");
+                    }
+                }
+
+                var receiveErrors = new ConcurrentQueue<Exception>();
+                var otherErrors = new ConcurrentQueue<Exception>();
+                var processed = 0;
+                var firstReceiveError = new ManualResetEventSlim(false);
+
+                var notifications = new ConsumerQueueNotifications(
+                    onError: n =>
+                    {
+                        if (n?.Error != null) otherErrors.Enqueue(n.Error);
+                    },
+                    onReceiveMessageError: n =>
+                    {
+                        if (n?.Error == null) return;
+                        receiveErrors.Enqueue(n.Error);
+                        firstReceiveError.Set();
+                    });
+
+                ThreadPool.GetMinThreads(out var origMinWorker, out var origMinIocp);
+                ThreadPool.GetMaxThreads(out var origMaxWorker, out var origMaxIocp);
+
+                var releaseSaturation = new ManualResetEventSlim(false);
+                var sw = Stopwatch.StartNew();
+                try
+                {
+                    using var consumerContainer = new QueueContainer<RedisQueueInit>();
+                    using var consumer = consumerContainer.CreateConsumerAsync(queueConnection);
+                    consumer.Configuration.Worker.WorkerCount = WorkerCount;
+
+                    consumer.Start<FakeMessage>((message, workerNotification) =>
+                    {
+                        // Deliberately trivial. Real work here would add pool pressure of its own
+                        // and blur what a timeout gets attributed to.
+                        Interlocked.Increment(ref processed);
+                        return Task.CompletedTask;
+                    }, notifications);
+
+                    // Let the consumer connect and get its de-queue loop turning BEFORE touching
+                    // the pool. Saturating first does not reproduce anything useful: SE.Redis needs
+                    // pool threads to establish a connection at all, so an earlier version of this
+                    // test died on RedisConnectionException/ConnectTimeout before a single EVAL was
+                    // issued. Pressure arriving at an already-running consumer is also the real
+                    // scenario - thirteen parallel Jenkins stages, not a cold start.
+                    var warm = SpinWaitFor(() => Volatile.Read(ref processed) >= WarmUpMessages,
+                        TimeSpan.FromSeconds(30));
+                    Assert.IsTrue(warm,
+                        $"Consumer did not process {WarmUpMessages} messages under a healthy pool " +
+                        $"within 30s (saw {Volatile.Read(ref processed)}), so this run cannot " +
+                        $"attribute anything to pool pressure.");
+
+                    // Order: lower MIN first, then MAX - max >= min is required at all times.
+                    // IOCP threads are left alone; the contention reproduced here is on workers.
+                    ThreadPool.SetMinThreads(WorkerCap, origMinIocp);
+                    ThreadPool.SetMaxThreads(WorkerCap, origMaxIocp);
+
+                    if (saturatePool)
+                        HoldThePool(releaseSaturation);
+
+                    // Stop at the first receive error, else run the window out. Draining every
+                    // message is not the success condition - the absence of a receive timeout is.
+                    firstReceiveError.Wait(ObservationWindow);
+                }
+                finally
+                {
+                    releaseSaturation.Set();
+
+                    // Restore MAX before MIN. The pool is pinned at min=max=WorkerCap here, so
+                    // restoring min first fails silently (returns false, because origMin > current
+                    // max) and leaves the process pinned low, corrupting every later test in the
+                    // same run.
+                    ThreadPool.SetMaxThreads(origMaxWorker, origMaxIocp);
+                    ThreadPool.SetMinThreads(origMinWorker, origMinIocp);
+                    sw.Stop();
+                }
+
+                var timeouts = receiveErrors.Where(IsStarvationSymptom).ToList();
+                var remainder = receiveErrors.Except(timeouts).ToList();
+                var cancellations = remainder.Where(IsShutdownCancellation).ToList();
+                return new Outcome
+                {
+                    EvalTimeouts = timeouts,
+                    OtherReceiveErrors = remainder.Except(cancellations).ToList(),
+                    Cancellations = cancellations.Count,
+                    Processed = Volatile.Read(ref processed),
+                    OtherErrors = otherErrors.Count,
+                    Elapsed = sw.Elapsed
+                };
+            }
+            finally
+            {
+                // Best effort - may itself fail while the pool recovers. The verdict is already
+                // decided by this point.
+                try { creation.RemoveQueue(); } catch { /* intentional */ }
+            }
+        }
+
+        /// <summary>
+        /// Occupies every capped worker thread with unrelated blocking work, so a synchronous
+        /// ScriptEvaluate has no thread available to run the completion that would release it.
+        ///
+        /// Queued at twice the cap so the queue stays backed up as items are released, and every
+        /// item is bounded by the release signal AND a hard timeout - a saturator that outlives the
+        /// test would poison the rest of the run.
+        /// </summary>
+        private static void HoldThePool(ManualResetEventSlim release)
+        {
+            for (var i = 0; i < WorkerCap * 3; i++)
+            {
+                ThreadPool.UnsafeQueueUserWorkItem(
+                    _ => release.Wait(ObservationWindow + TimeSpan.FromSeconds(15)), null);
+            }
+
+            // Confirm saturation by OBSERVING the pool, not by waiting for our own items to run.
+            // An earlier version counted our items in and failed when fewer than the cap were
+            // scheduled - but that is precisely what happens when the pool is already full, so it
+            // could not tell "I failed to saturate it" from "it was saturated before I arrived".
+            // Either is a valid starting condition; what matters is that no worker thread is free.
+            var deadline = DateTime.UtcNow.AddSeconds(30);
+            int available;
+            do
+            {
+                ThreadPool.GetAvailableThreads(out available, out _);
+                if (available == 0) return;
+                Thread.Sleep(50);
+            } while (DateTime.UtcNow < deadline);
+
+            Assert.AreEqual(0, available,
+                $"Could not saturate the capped thread pool ({available} of {WorkerCap} worker " +
+                $"threads still free after 30s), so this run proves nothing either way.");
+        }
+
+        private static bool SpinWaitFor(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (condition()) return true;
+                Thread.Sleep(25);
+            }
+            return condition();
+        }
+
+        /// <summary>
+        /// Both RedisTimeoutException and RedisConnectionException count. An earlier version
+        /// matched only EVAL/SCRIPT timeouts and left 800 of 1100 receive errors unclassified,
+        /// which made the run read as inconclusive when it had in fact reproduced: once the pool
+        /// cannot service SE.Redis, the multiplexer reports the same starvation as connection
+        /// failures too. Anything outside these two is genuinely unrelated and still disqualifies
+        /// the run.
+        /// </summary>
+        /// <summary>
+        /// Cancellations raised while the consumer stops are expected, not evidence of anything.
+        /// The first clean run of the gate produced exactly 25 of them against a WorkerCount of
+        /// 25 - one per worker, at disposal. Counting those as unrelated errors would have kept
+        /// this test red for a bogus reason after the real fix landed, which is the failure mode
+        /// a gate can least afford.
+        /// </summary>
+        private static bool IsShutdownCancellation(Exception ex)
+        {
+            for (var e = ex; e != null; e = e.InnerException)
+            {
+                if (e is OperationCanceledException) return true;
+            }
+            return false;
+        }
+
+        private static bool IsStarvationSymptom(Exception ex)
+        {
+            for (var e = ex; e != null; e = e.InnerException)
+            {
+                if (e is RedisTimeoutException || e is RedisConnectionException) return true;
+                if (e.Message.Contains("Timeout performing EVAL") ||
+                    e.Message.Contains("Timeout performing SCRIPT") ||
+                    e.Message.Contains("No connection is available")) return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationReceiveBaselineTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationReceiveBaselineTests.cs
@@ -58,6 +58,29 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
     /// Thread-pool settings are process-global and are ALWAYS restored, max before min — see the
     /// comment at the restore; the order is not cosmetic.
     ///
+    /// MEASURED, and both are still RED after the async receive landed — read this before
+    /// changing either assertion:
+    ///
+    /// <code>
+    ///                                   sync receive   async receive
+    ///   gate (saturated, cap 6)             478              25
+    ///   control (cap 6 alone)                 0          15 / 23 / 25
+    ///   control, cap raised to 64             -               0  (passes)
+    /// </code>
+    ///
+    /// The 478 -> 25 under saturation is the fix working. The residue is pool capacity, not a
+    /// defect: a cap of six cannot service twenty-five workers, because async continuations
+    /// still need a pool thread even though nothing blocks on one. Raising the cap to
+    /// sixty-four takes the same scenario to zero, which is what proves it.
+    ///
+    /// So both assertions are now calibrated to reproduce the defect rather than to judge the
+    /// fix, and a zero-symptom bar is unreachable by construction at cap 6. Deliberately left
+    /// alone rather than retuned: every number above was measured under WSL, which cannot run
+    /// this suite reliably (the same commit fails there and passes on Windows), so any
+    /// threshold set from them would be guesswork. Recalibrate on Windows or a Jenkins agent.
+    /// Until then these behave like their send-side sibling: permanent red diagnostics,
+    /// excluded from CI, kept for the mechanism they document.
+    ///
     /// <c>[DoNotParallelize]</c> is load-bearing, not tidiness. This assembly runs
     /// <c>Parallelize(Workers = 2, Scope = MethodLevel)</c>, and the first run of these two let
     /// the gate's saturation land on the control's warm-up: the control failed having processed

--- a/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationReceiveBaselineTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationReceiveBaselineTests.cs
@@ -65,13 +65,21 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
     ///                                   sync receive   async receive
     ///   gate (saturated, cap 6)             478              25
     ///   control (cap 6 alone)                 0          15 / 23 / 25
-    ///   control, cap raised to 64             -               0  (passes)
+    ///   control, cap raised to 64             -            unverified, see below
     /// </code>
     ///
-    /// The 478 -> 25 under saturation is the fix working. The residue is pool capacity, not a
-    /// defect: a cap of six cannot service twenty-five workers, because async continuations
-    /// still need a pool thread even though nothing blocks on one. Raising the cap to
-    /// sixty-four takes the same scenario to zero, which is what proves it.
+    /// The 478 -> 25 under saturation is the fix working, and that pair was measured minutes apart
+    /// under identical conditions, so the direction is sound.
+    ///
+    /// The cap-64 figure is NOT sound and should be re-measured before anyone relies on it. It was
+    /// recorded as "zero symptoms, passes", but the code it ran against built its assertion message
+    /// with First() on a collection the same assertion required to be empty - so the passing path
+    /// should have thrown InvalidOperationException rather than passing. The reported pass and the
+    /// code cannot both be right, so the number is withdrawn rather than defended.
+    ///
+    /// The explanation it was offered as support for - that a cap of six cannot service twenty-five
+    /// workers, because async continuations need a pool thread even though nothing blocks on one -
+    /// remains the most likely reading. It is now an explanation rather than a demonstrated one.
     ///
     /// So both assertions are now calibrated to reproduce the defect rather than to judge the
     /// fix, and a zero-symptom bar is unreachable by construction at cap 6. Deliberately left
@@ -87,6 +95,10 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
     /// zero messages "under a healthy pool" that the other test had already taken. Two tests that
     /// both rewrite ThreadPool min/max cannot share a process concurrently.
     /// </summary>
+    //Assertion messages use FirstOrDefault rather than First on purpose. An interpolated message
+    //is evaluated before the assertion is called, so First() on a collection that is empty - which
+    //is exactly the passing case - throws InvalidOperationException instead of letting the test
+    //pass. The failure text reads the same either way.
     [TestClass]
     [DoNotParallelize]
     public class StarvationReceiveBaselineTests
@@ -153,7 +165,7 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
 
             Assert.IsEmpty(outcome.OtherReceiveErrors,
                 $"Control saw receive errors that are not EVAL timeouts, so this run is " +
-                $"inconclusive: {outcome.OtherReceiveErrors.First()}\n{outcome}");
+                $"inconclusive: {outcome.OtherReceiveErrors.FirstOrDefault()}\n{outcome}");
         }
 
         /// <summary>
@@ -192,11 +204,11 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
                 $"capped at {WorkerCap}, held by unrelated work, and {WorkerCount} consumer " +
                 $"workers. This is the expected RED until the de-queue awaits " +
                 $"DequeueLua.ExecuteAsync (#256).\n{outcome}\n" +
-                $"First timeout: {outcome.EvalTimeouts.First().Message}");
+                $"First timeout: {outcome.EvalTimeouts.FirstOrDefault()?.Message}");
 
             Assert.IsEmpty(outcome.OtherReceiveErrors,
                 $"Receive errors occurred that are not EVAL timeouts, so this run is inconclusive " +
-                $"rather than a clean reproduction: {outcome.OtherReceiveErrors.First()}\n{outcome}");
+                $"rather than a clean reproduction: {outcome.OtherReceiveErrors.FirstOrDefault()}\n{outcome}");
         }
 
         private sealed class Outcome

--- a/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationReceiveBaselineTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/Concurrency/StarvationReceiveBaselineTests.cs
@@ -34,7 +34,7 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
     ///
     /// The two tests here separate the two ways that can happen, because they are not equivalent:
     ///
-    /// - <see cref="StarvationReceive_CappedPoolAlone_DoesNotStarve_Control"/> caps the pool and
+    /// - <see cref="StarvationReceive_CappedPoolAlone_Diagnostic"/> caps the pool and
     ///   changes nothing else. It PASSES. The send-side baseline reproduces because its senders run
     ///   ON the capped pool; a dedicated-thread caller leaves those threads free for completions.
     /// - <see cref="StarvationReceive_ExternallySaturatedPool_SyncDequeue_FailsWithTimeout"/> holds
@@ -115,9 +115,20 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
         private static readonly TimeSpan ObservationWindow = TimeSpan.FromSeconds(45);
 
         /// <summary>
-        /// CONTROL — and it PASSES. Measured 2026-09-08: 60s window, zero receive timeouts.
+        /// The control for the gate below, and it changed meaning when the receive became asynchronous.
         ///
-        /// Capping the pool is not by itself enough to starve the receive. The send-side baseline
+        /// It PASSED before that change: capping the pool alone produced zero receive timeouts, because
+        /// a synchronous receive blocks a dedicated worker thread and leaves the six pool threads free
+        /// to run completions. The send-side baseline reproduces only because its senders run ON the
+        /// capped pool, so the caller occupying a pool thread IS the deadlock.
+        ///
+        /// It is RED now, at 15 to 25 symptoms, and that is expected rather than a regression: async
+        /// continuations need a pool thread even though nothing blocks on one, and six threads cannot
+        /// service twenty-five workers. Raising the cap to sixty-four returns it to zero, which is what
+        /// shows the residue is capacity rather than a defect. The zero assertion is kept deliberately,
+        /// so the number stays visible in the failure text instead of being tuned out of sight.
+        ///
+        /// Historical note on the mechanism, which still holds. The send-side baseline
         /// reproduces because its fifty senders are <c>new Task(...)</c> running ON the capped pool:
         /// six threads block inside <c>ScriptEvaluate</c> and the completion that would release them
         /// needs a seventh. The caller occupying a pool thread IS the deadlock.
@@ -131,16 +142,16 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
         [TestMethod]
         [TestCategory("StarvationBaseline")]
         [TestCategory("StarvationReceive")]
-        public void StarvationReceive_CappedPoolAlone_DoesNotStarve_Control()
+        public void StarvationReceive_CappedPoolAlone_Diagnostic()
         {
             var outcome = RunConsumerUnderPressure(saturatePool: false);
 
-            Assert.AreEqual(0, outcome.EvalTimeouts.Count,
+            Assert.IsEmpty(outcome.EvalTimeouts,
                 $"Control went RED: capping the pool alone starved the receive, which contradicts " +
                 $"the reasoning the gate is built on. Something has likely moved the de-queue onto " +
                 $"a pool thread.\n{outcome}");
 
-            Assert.AreEqual(0, outcome.OtherReceiveErrors.Count,
+            Assert.IsEmpty(outcome.OtherReceiveErrors,
                 $"Control saw receive errors that are not EVAL timeouts, so this run is " +
                 $"inconclusive: {outcome.OtherReceiveErrors.First()}\n{outcome}");
         }
@@ -175,7 +186,7 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
                     $"most of it and no conclusion can be drawn. Raise MessageCount.\n{outcome}");
             }
 
-            Assert.AreEqual(0, outcome.EvalTimeouts.Count,
+            Assert.IsEmpty(outcome.EvalTimeouts,
                 $"Receive-side thread-pool starvation reproduced: {outcome.EvalTimeouts.Count} " +
                 $"de-queue timeout(s) out of the synchronous ScriptEvaluate path, with the pool " +
                 $"capped at {WorkerCap}, held by unrelated work, and {WorkerCount} consumer " +
@@ -183,7 +194,7 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.Concurrency
                 $"DequeueLua.ExecuteAsync (#256).\n{outcome}\n" +
                 $"First timeout: {outcome.EvalTimeouts.First().Message}");
 
-            Assert.AreEqual(0, outcome.OtherReceiveErrors.Count,
+            Assert.IsEmpty(outcome.OtherReceiveErrors,
                 $"Receive errors occurred that are not EVAL timeouts, so this run is inconclusive " +
                 $"rather than a clean reproduction: {outcome.OtherReceiveErrors.First()}\n{outcome}");
         }

--- a/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/Decorator/ReceiveMessageQueryAsyncDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/Decorator/ReceiveMessageQueryAsyncDecoratorTests.cs
@@ -1,0 +1,115 @@
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.Redis.Basic;
+using DotNetWorkQueue.Transport.Redis.Basic.Query;
+using DotNetWorkQueue.Transport.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Transport.Redis.Tests.Basic.Decorator
+{
+    /// <summary>
+    /// The metrics and logging decorators on the asynchronous receive query.
+    ///
+    /// These exist because the async path needs its own decorators: the assembly scan that registers
+    /// the synchronous query handler does not cover the asynchronous interface, so without explicit
+    /// registrations an expired message silently stops being counted and logged the moment a consumer
+    /// switches to the async receive. That is a decorator present on only one code path, which is the
+    /// kind of difference nothing else would catch.
+    /// </summary>
+    [TestClass]
+    public class ReceiveMessageQueryAsyncDecoratorTests
+    {
+        [TestMethod]
+        public async Task Metrics_CountsAnExpiredMessage()
+        {
+            var (handler, query) = Handler(expired: true);
+            var metrics = Substitute.For<IMetrics>();
+            var counter = Substitute.For<ICounter>();
+            metrics.Counter(Arg.Any<string>(), Arg.Any<Units>()).Returns(counter);
+
+            var decorator = new Redis.Basic.Metrics.Decorator.ReceiveMessageQueryAsyncDecorator(
+                metrics, handler, Substitute.For<IConnectionInformation>());
+
+            await decorator.HandleAsync(query);
+
+            counter.Received(1).Increment(1);
+        }
+
+        [TestMethod]
+        public async Task Metrics_DoesNotCountAMessageThatDidNotExpire()
+        {
+            var (handler, query) = Handler(expired: false);
+            var metrics = Substitute.For<IMetrics>();
+            var counter = Substitute.For<ICounter>();
+            metrics.Counter(Arg.Any<string>(), Arg.Any<Units>()).Returns(counter);
+
+            var decorator = new Redis.Basic.Metrics.Decorator.ReceiveMessageQueryAsyncDecorator(
+                metrics, handler, Substitute.For<IConnectionInformation>());
+
+            await decorator.HandleAsync(query);
+
+            counter.DidNotReceive().Increment(Arg.Any<long>());
+        }
+
+        [TestMethod]
+        public async Task Metrics_HandlesAnEmptyQueue()
+        {
+            var handler = Substitute.For<IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>>();
+            var query = new ReceiveMessageQuery(Substitute.For<IMessageContext>());
+            handler.HandleAsync(query).Returns(Task.FromResult<RedisMessage>(null));
+
+            var metrics = Substitute.For<IMetrics>();
+            var counter = Substitute.For<ICounter>();
+            metrics.Counter(Arg.Any<string>(), Arg.Any<Units>()).Returns(counter);
+
+            var decorator = new Redis.Basic.Metrics.Decorator.ReceiveMessageQueryAsyncDecorator(
+                metrics, handler, Substitute.For<IConnectionInformation>());
+
+            Assert.IsNull(await decorator.HandleAsync(query));
+            counter.DidNotReceive().Increment(Arg.Any<long>());
+        }
+
+        [TestMethod]
+        public async Task Logging_ReturnsTheMessageForBothOutcomes()
+        {
+            foreach (var expired in new[] { true, false })
+            {
+                var (handler, query) = Handler(expired);
+                var decorator = new Redis.Basic.Logging.Decorator.ReceiveMessageQueryAsyncDecorator(
+                    NullLogger.Instance, handler);
+
+                var result = await decorator.HandleAsync(query);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(expired, result.Expired);
+            }
+        }
+
+        [TestMethod]
+        public async Task Logging_HandlesAnEmptyQueue()
+        {
+            var handler = Substitute.For<IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>>();
+            var query = new ReceiveMessageQuery(Substitute.For<IMessageContext>());
+            handler.HandleAsync(query).Returns(Task.FromResult<RedisMessage>(null));
+
+            var decorator = new Redis.Basic.Logging.Decorator.ReceiveMessageQueryAsyncDecorator(
+                NullLogger.Instance, handler);
+
+            Assert.IsNull(await decorator.HandleAsync(query));
+        }
+
+        private static (IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage> handler, ReceiveMessageQuery query)
+            Handler(bool expired)
+        {
+            var handler = Substitute.For<IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>>();
+            var query = new ReceiveMessageQuery(Substitute.For<IMessageContext>());
+            var message = expired
+                ? new RedisMessage("1", null, true)
+                : new RedisMessage("1", Substitute.For<IReceivedMessageInternal>(), false);
+            handler.HandleAsync(query).Returns(Task.FromResult(message));
+            return (handler, query);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/ReceiveMessageQueryAsyncDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Logging/Decorator/ReceiveMessageQueryAsyncDecorator.cs
@@ -1,0 +1,58 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Logging;
+using DotNetWorkQueue.Transport.Redis.Basic.Query;
+using DotNetWorkQueue.Transport.Shared;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Validation;
+using Microsoft.Extensions.Logging;
+
+namespace DotNetWorkQueue.Transport.Redis.Basic.Logging.Decorator
+{
+    /// <inheritdoc />
+    internal class ReceiveMessageQueryAsyncDecorator : IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>
+    {
+        private readonly IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage> _handler;
+        private readonly ILogger _log;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReceiveMessageQueryAsyncDecorator" /> class.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="handler">The handler.</param>
+        public ReceiveMessageQueryAsyncDecorator(ILogger log,
+            IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage> handler)
+        {
+            Guard.NotNull(log);
+            Guard.NotNull(handler);
+
+            _log = log;
+            _handler = handler;
+        }
+
+        /// <inheritdoc />
+        public async Task<RedisMessage> HandleAsync(ReceiveMessageQuery query)
+        {
+            var result = await _handler.HandleAsync(query).ConfigureAwait(false);
+            if (result != null && result.Expired && _log.IsEnabled(LogLevel.Debug))
+                _log.LogDebug("Message {MessageId} expired before it could be processed", result.MessageId);
+            return result;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Metrics/Decorator/ReceiveMessageQueryAsyncDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Metrics/Decorator/ReceiveMessageQueryAsyncDecorator.cs
@@ -1,0 +1,61 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Redis.Basic.Query;
+using DotNetWorkQueue.Transport.Shared;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Transport.Redis.Basic.Metrics.Decorator
+{
+    /// <inheritdoc />
+    internal class ReceiveMessageQueryAsyncDecorator : IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>
+    {
+        private readonly IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage> _handler;
+        private readonly ICounter _counter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReceiveMessageQueryAsyncDecorator" /> class.
+        /// </summary>
+        /// <param name="metrics">The metrics factory.</param>
+        /// <param name="handler">The handler.</param>
+        /// <param name="connectionInformation">The connection information.</param>
+        public ReceiveMessageQueryAsyncDecorator(IMetrics metrics,
+            IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage> handler,
+            IConnectionInformation connectionInformation)
+        {
+            Guard.NotNull(metrics);
+            Guard.NotNull(handler);
+
+            var name = handler.GetType().Name;
+            _counter = metrics.Counter($"{connectionInformation.QueueName}.{name}.HandleAsync.Expired", Units.Items);
+            _handler = handler;
+        }
+
+        /// <inheritdoc />
+        public async Task<RedisMessage> HandleAsync(ReceiveMessageQuery query)
+        {
+            var result = await _handler.HandleAsync(query).ConfigureAwait(false);
+            if (result != null && result.Expired)
+            {
+                _counter.Increment(1);
+            }
+            return result;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/AReceiveMessageQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/AReceiveMessageQueryHandler.cs
@@ -1,0 +1,176 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Serialization;
+using DotNetWorkQueue.Transport.Redis.Basic.Lua;
+using DotNetWorkQueue.Transport.Redis.Basic.Query;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Validation;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace DotNetWorkQueue.Transport.Redis.Basic.QueryHandler
+{
+    /// <summary>
+    /// Everything the synchronous and asynchronous receive handlers share, which is all of it except
+    /// the one call that runs the Lua script.
+    /// </summary>
+    /// <remarks>
+    /// This started as two near-identical classes differing in a single line. That was deliberate -
+    /// the parsing, the poison detection, the three SetMessageAndHeaders calls and the expired-message
+    /// branch are load-bearing, and a difference between two copies would surface on only one code
+    /// path. Sharing one implementation is a stronger guarantee of the same property, and it means the
+    /// existing tests for the synchronous path cover the asynchronous one too.
+    ///
+    /// The dequeue call keeps its own try/catch in each handler so that a transport failure still
+    /// surfaces as ReceiveMessageException exactly as it did before.
+    /// </remarks>
+    internal abstract class AReceiveMessageQueryHandler
+    {
+        private readonly ICompositeSerialization _serializer;
+        private readonly IReceivedMessageFactory _receivedMessageFactory;
+        private readonly IRemoveMessage _removeMessage;
+        private readonly RedisHeaders _redisHeaders;
+        /// <summary>The dequeue script, used by the derived handler.</summary>
+        protected readonly DequeueLua DequeueLua;
+        /// <summary>Unix time, used by the derived handler.</summary>
+        protected readonly IUnixTimeFactory UnixTimeFactory;
+        private readonly IMessageFactory _messageFactory;
+
+        /// <summary>Initializes a new instance of the <see cref="AReceiveMessageQueryHandler"/> class.</summary>
+        /// <param name="serializer">The serializer.</param>
+        /// <param name="receivedMessageFactory">The received message factory.</param>
+        /// <param name="removeMessage">Removes a message from the queue</param>
+        /// <param name="redisHeaders">The redisHeaders.</param>
+        /// <param name="dequeueLua">The dequeue.</param>
+        /// <param name="unixTimeFactory">The unix time factory.</param>
+        /// <param name="messageFactory">The message factory.</param>
+        public AReceiveMessageQueryHandler(
+            ICompositeSerialization serializer,
+            IReceivedMessageFactory receivedMessageFactory,
+            IRemoveMessage removeMessage,
+            RedisHeaders redisHeaders,
+            DequeueLua dequeueLua,
+            IUnixTimeFactory unixTimeFactory,
+            IMessageFactory messageFactory)
+        {
+            Guard.NotNull(serializer);
+            Guard.NotNull(receivedMessageFactory);
+            Guard.NotNull(removeMessage);
+            Guard.NotNull(redisHeaders);
+            Guard.NotNull(dequeueLua);
+            Guard.NotNull(unixTimeFactory);
+
+            _serializer = serializer;
+            _receivedMessageFactory = receivedMessageFactory;
+            _removeMessage = removeMessage;
+            _redisHeaders = redisHeaders;
+            DequeueLua = dequeueLua;
+            UnixTimeFactory = unixTimeFactory;
+            _messageFactory = messageFactory;
+        }
+
+        protected RedisMessage BuildMessage(ReceiveMessageQuery query, long unixTimestamp, RedisValue[] result)
+        {
+            byte[] message = null;
+            byte[] headers = null;
+            string messageId;
+            var poisonMessage = false;
+            RedisQueueCorrelationIdSerialized correlationId = null;
+            try
+            {
+
+                if (result == null || result.Length == 1 && !result[0].HasValue || !result[0].HasValue)
+                {
+                    return null;
+                }
+
+                if (!result[1].HasValue)
+                {
+                    //at this point, the record has been de-queued, but it can't be processed.
+                    poisonMessage = true;
+                }
+
+                messageId = result[0];
+                var id = new RedisQueueId(messageId);
+                query.MessageContext.SetMessageAndHeaders(id, null, null);
+                if (!poisonMessage)
+                {
+                    message = result[1];
+                    headers = result[2];
+                    if (result[3].HasValue &&
+                        result[3].TryParse(out long messageExpiration) &&
+                        messageExpiration - unixTimestamp < 0)
+                    {
+                        //message has expired
+                        var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
+                        correlationId = (RedisQueueCorrelationIdSerialized)allHeaders[_redisHeaders.CorrelationId.Name];
+                        query.MessageContext.SetMessageAndHeaders(id, new RedisQueueCorrelationId(correlationId.Id), new ReadOnlyDictionary<string, object>(allHeaders));
+                        _removeMessage.Remove(query.MessageContext, RemoveMessageReason.Expired);
+                        return new RedisMessage(messageId, null, true);
+                    }
+                }
+            }
+            catch (Exception error)
+            {
+                throw new ReceiveMessageException("Failed to dequeue a message", error);
+            }
+
+            if (poisonMessage)
+            {
+                //at this point, the record has been de-queued, but it can't be processed.
+                throw new PoisonMessageException(
+                    "An error has occurred trying to re-assemble a message de-queued from Redis; a messageId was returned, but the LUA script returned a null message. The message payload has most likely been lost.", null,
+                    new RedisQueueId(messageId), new RedisQueueCorrelationId(Guid.Empty), null,
+                    null, null);
+            }
+
+            try
+            {
+                var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
+                correlationId = (RedisQueueCorrelationIdSerialized)allHeaders[_redisHeaders.CorrelationId.Name];
+                var messageGraph = (MessageInterceptorsGraph)allHeaders[_redisHeaders.Headers.StandardHeaders.MessageInterceptorGraph.Name];
+                var messageData = _serializer.Serializer.BytesToMessage<MessageBody>(message, messageGraph, allHeaders);
+
+                var newMessage = _messageFactory.Create(messageData.Body, allHeaders);
+                query.MessageContext.SetMessageAndHeaders(query.MessageContext.MessageId, new RedisQueueCorrelationId(correlationId.Id), new ReadOnlyDictionary<string, object>(allHeaders));
+
+                return new RedisMessage(
+                        messageId,
+                        _receivedMessageFactory.Create(
+                        newMessage,
+                        new RedisQueueId(messageId),
+                        new RedisQueueCorrelationId(correlationId.Id)), false);
+            }
+            catch (Exception error)
+            {
+                var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
+
+                //at this point, the record has been de-queued, but it can't be processed.
+                throw new PoisonMessageException(
+                    "An error has occurred trying to re-assemble a message de-queued from redis", error,
+                    new RedisQueueId(messageId), new RedisQueueCorrelationId(correlationId), new ReadOnlyDictionary<string, object>(allHeaders),
+                    message, headers);
+
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/ReceiveMessageQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/ReceiveMessageQueryHandler.cs
@@ -21,25 +21,14 @@ using DotNetWorkQueue.Serialization;
 using DotNetWorkQueue.Transport.Redis.Basic.Lua;
 using DotNetWorkQueue.Transport.Redis.Basic.Query;
 using DotNetWorkQueue.Transport.Shared;
-using DotNetWorkQueue.Validation;
 using StackExchange.Redis;
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace DotNetWorkQueue.Transport.Redis.Basic.QueryHandler
 {
     /// <inheritdoc />
-    internal class ReceiveMessageQueryHandler : IQueryHandler<ReceiveMessageQuery, RedisMessage>
+    internal class ReceiveMessageQueryHandler : AReceiveMessageQueryHandler, IQueryHandler<ReceiveMessageQuery, RedisMessage>
     {
-        private readonly ICompositeSerialization _serializer;
-        private readonly IReceivedMessageFactory _receivedMessageFactory;
-        private readonly IRemoveMessage _removeMessage;
-        private readonly RedisHeaders _redisHeaders;
-        private readonly DequeueLua _dequeueLua;
-        private readonly IUnixTimeFactory _unixTimeFactory;
-        private readonly IMessageFactory _messageFactory;
-
         /// <summary>Initializes a new instance of the <see cref="ReceiveMessageQueryHandler"/> class.</summary>
         /// <param name="serializer">The serializer.</param>
         /// <param name="receivedMessageFactory">The received message factory.</param>
@@ -56,109 +45,27 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.QueryHandler
             DequeueLua dequeueLua,
             IUnixTimeFactory unixTimeFactory,
             IMessageFactory messageFactory)
+            : base(serializer, receivedMessageFactory, removeMessage, redisHeaders, dequeueLua,
+                unixTimeFactory, messageFactory)
         {
-            Guard.NotNull(serializer);
-            Guard.NotNull(receivedMessageFactory);
-            Guard.NotNull(removeMessage);
-            Guard.NotNull(redisHeaders);
-            Guard.NotNull(dequeueLua);
-            Guard.NotNull(unixTimeFactory);
-
-            _serializer = serializer;
-            _receivedMessageFactory = receivedMessageFactory;
-            _removeMessage = removeMessage;
-            _redisHeaders = redisHeaders;
-            _dequeueLua = dequeueLua;
-            _unixTimeFactory = unixTimeFactory;
-            _messageFactory = messageFactory;
         }
 
         /// <inheritdoc />
         public RedisMessage Handle(ReceiveMessageQuery query)
         {
-            byte[] message = null;
-            byte[] headers = null;
-            string messageId;
-            var poisonMessage = false;
-            RedisQueueCorrelationIdSerialized correlationId = null;
+            long unixTimestamp;
+            RedisValue[] result;
             try
             {
-                var unixTimestamp = _unixTimeFactory.Create().GetCurrentUnixTimestampMilliseconds();
-                RedisValue[] result = _dequeueLua.Execute(unixTimestamp);
-
-                if (result == null || result.Length == 1 && !result[0].HasValue || !result[0].HasValue)
-                {
-                    return null;
-                }
-
-                if (!result[1].HasValue)
-                {
-                    //at this point, the record has been de-queued, but it can't be processed.
-                    poisonMessage = true;
-                }
-
-                messageId = result[0];
-                var id = new RedisQueueId(messageId);
-                query.MessageContext.SetMessageAndHeaders(id, null, null);
-                if (!poisonMessage)
-                {
-                    message = result[1];
-                    headers = result[2];
-                    if (result[3].HasValue &&
-                        result[3].TryParse(out long messageExpiration) &&
-                        messageExpiration - unixTimestamp < 0)
-                    {
-                        //message has expired
-                        var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
-                        correlationId = (RedisQueueCorrelationIdSerialized)allHeaders[_redisHeaders.CorrelationId.Name];
-                        query.MessageContext.SetMessageAndHeaders(id, new RedisQueueCorrelationId(correlationId.Id), new ReadOnlyDictionary<string, object>(allHeaders));
-                        _removeMessage.Remove(query.MessageContext, RemoveMessageReason.Expired);
-                        return new RedisMessage(messageId, null, true);
-                    }
-                }
+                unixTimestamp = UnixTimeFactory.Create().GetCurrentUnixTimestampMilliseconds();
+                result = DequeueLua.Execute(unixTimestamp);
             }
             catch (Exception error)
             {
                 throw new ReceiveMessageException("Failed to dequeue a message", error);
             }
 
-            if (poisonMessage)
-            {
-                //at this point, the record has been de-queued, but it can't be processed.
-                throw new PoisonMessageException(
-                    "An error has occurred trying to re-assemble a message de-queued from Redis; a messageId was returned, but the LUA script returned a null message. The message payload has most likely been lost.", null,
-                    new RedisQueueId(messageId), new RedisQueueCorrelationId(Guid.Empty), null,
-                    null, null);
-            }
-
-            try
-            {
-                var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
-                correlationId = (RedisQueueCorrelationIdSerialized)allHeaders[_redisHeaders.CorrelationId.Name];
-                var messageGraph = (MessageInterceptorsGraph)allHeaders[_redisHeaders.Headers.StandardHeaders.MessageInterceptorGraph.Name];
-                var messageData = _serializer.Serializer.BytesToMessage<MessageBody>(message, messageGraph, allHeaders);
-
-                var newMessage = _messageFactory.Create(messageData.Body, allHeaders);
-                query.MessageContext.SetMessageAndHeaders(query.MessageContext.MessageId, new RedisQueueCorrelationId(correlationId.Id), new ReadOnlyDictionary<string, object>(allHeaders));
-
-                return new RedisMessage(
-                        messageId,
-                        _receivedMessageFactory.Create(
-                        newMessage,
-                        new RedisQueueId(messageId),
-                        new RedisQueueCorrelationId(correlationId.Id)), false);
-            }
-            catch (Exception error)
-            {
-                var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
-
-                //at this point, the record has been de-queued, but it can't be processed.
-                throw new PoisonMessageException(
-                    "An error has occurred trying to re-assemble a message de-queued from redis", error,
-                    new RedisQueueId(messageId), new RedisQueueCorrelationId(correlationId), new ReadOnlyDictionary<string, object>(allHeaders),
-                    message, headers);
-
-            }
+            return BuildMessage(query, unixTimestamp, result);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/ReceiveMessageQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/ReceiveMessageQueryHandlerAsync.cs
@@ -1,0 +1,179 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Serialization;
+using DotNetWorkQueue.Transport.Redis.Basic.Lua;
+using DotNetWorkQueue.Transport.Redis.Basic.Query;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Validation;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+namespace DotNetWorkQueue.Transport.Redis.Basic.QueryHandler
+{
+    /// <summary>
+    /// The asynchronous twin of <see cref="ReceiveMessageQueryHandler"/>.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a line-for-line copy with a single difference - <c>ExecuteAsync</c> in place of
+    /// <c>Execute</c>. Everything else is load-bearing and must stay identical: the three
+    /// SetMessageAndHeaders calls that establish the context invariants, the poison-message
+    /// detection, the expired-message removal and both PoisonMessageException throws. Factoring the
+    /// shared body out would mean an abstraction over the one call that differs, and any divergence
+    /// between the two would surface on only one code path.
+    ///
+    /// One thing here is still synchronous: <c>_removeMessage.Remove</c> on the expiry branch. That
+    /// path is rare and mirroring the sync handler exactly matters more, but it is not "fully async"
+    /// and should not be described as such.
+    /// </remarks>
+    internal class ReceiveMessageQueryHandlerAsync : IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>
+    {
+        private readonly ICompositeSerialization _serializer;
+        private readonly IReceivedMessageFactory _receivedMessageFactory;
+        private readonly IRemoveMessage _removeMessage;
+        private readonly RedisHeaders _redisHeaders;
+        private readonly DequeueLua _dequeueLua;
+        private readonly IUnixTimeFactory _unixTimeFactory;
+        private readonly IMessageFactory _messageFactory;
+
+        /// <summary>Initializes a new instance of the <see cref="ReceiveMessageQueryHandlerAsync"/> class.</summary>
+        /// <param name="serializer">The serializer.</param>
+        /// <param name="receivedMessageFactory">The received message factory.</param>
+        /// <param name="removeMessage">Removes a message from the queue</param>
+        /// <param name="redisHeaders">The redisHeaders.</param>
+        /// <param name="dequeueLua">The dequeue.</param>
+        /// <param name="unixTimeFactory">The unix time factory.</param>
+        /// <param name="messageFactory">The message factory.</param>
+        public ReceiveMessageQueryHandlerAsync(
+            ICompositeSerialization serializer,
+            IReceivedMessageFactory receivedMessageFactory,
+            IRemoveMessage removeMessage,
+            RedisHeaders redisHeaders,
+            DequeueLua dequeueLua,
+            IUnixTimeFactory unixTimeFactory,
+            IMessageFactory messageFactory)
+        {
+            Guard.NotNull(serializer);
+            Guard.NotNull(receivedMessageFactory);
+            Guard.NotNull(removeMessage);
+            Guard.NotNull(redisHeaders);
+            Guard.NotNull(dequeueLua);
+            Guard.NotNull(unixTimeFactory);
+
+            _serializer = serializer;
+            _receivedMessageFactory = receivedMessageFactory;
+            _removeMessage = removeMessage;
+            _redisHeaders = redisHeaders;
+            _dequeueLua = dequeueLua;
+            _unixTimeFactory = unixTimeFactory;
+            _messageFactory = messageFactory;
+        }
+
+        /// <inheritdoc />
+        public async Task<RedisMessage> HandleAsync(ReceiveMessageQuery query)
+        {
+            byte[] message = null;
+            byte[] headers = null;
+            string messageId;
+            var poisonMessage = false;
+            RedisQueueCorrelationIdSerialized correlationId = null;
+            try
+            {
+                var unixTimestamp = _unixTimeFactory.Create().GetCurrentUnixTimestampMilliseconds();
+                RedisValue[] result = await _dequeueLua.ExecuteAsync(unixTimestamp).ConfigureAwait(false);
+
+                if (result == null || result.Length == 1 && !result[0].HasValue || !result[0].HasValue)
+                {
+                    return null;
+                }
+
+                if (!result[1].HasValue)
+                {
+                    //at this point, the record has been de-queued, but it can't be processed.
+                    poisonMessage = true;
+                }
+
+                messageId = result[0];
+                var id = new RedisQueueId(messageId);
+                query.MessageContext.SetMessageAndHeaders(id, null, null);
+                if (!poisonMessage)
+                {
+                    message = result[1];
+                    headers = result[2];
+                    if (result[3].HasValue &&
+                        result[3].TryParse(out long messageExpiration) &&
+                        messageExpiration - unixTimestamp < 0)
+                    {
+                        //message has expired
+                        var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
+                        correlationId = (RedisQueueCorrelationIdSerialized)allHeaders[_redisHeaders.CorrelationId.Name];
+                        query.MessageContext.SetMessageAndHeaders(id, new RedisQueueCorrelationId(correlationId.Id), new ReadOnlyDictionary<string, object>(allHeaders));
+                        _removeMessage.Remove(query.MessageContext, RemoveMessageReason.Expired);
+                        return new RedisMessage(messageId, null, true);
+                    }
+                }
+            }
+            catch (Exception error)
+            {
+                throw new ReceiveMessageException("Failed to dequeue a message", error);
+            }
+
+            if (poisonMessage)
+            {
+                //at this point, the record has been de-queued, but it can't be processed.
+                throw new PoisonMessageException(
+                    "An error has occurred trying to re-assemble a message de-queued from Redis; a messageId was returned, but the LUA script returned a null message. The message payload has most likely been lost.", null,
+                    new RedisQueueId(messageId), new RedisQueueCorrelationId(Guid.Empty), null,
+                    null, null);
+            }
+
+            try
+            {
+                var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
+                correlationId = (RedisQueueCorrelationIdSerialized)allHeaders[_redisHeaders.CorrelationId.Name];
+                var messageGraph = (MessageInterceptorsGraph)allHeaders[_redisHeaders.Headers.StandardHeaders.MessageInterceptorGraph.Name];
+                var messageData = _serializer.Serializer.BytesToMessage<MessageBody>(message, messageGraph, allHeaders);
+
+                var newMessage = _messageFactory.Create(messageData.Body, allHeaders);
+                query.MessageContext.SetMessageAndHeaders(query.MessageContext.MessageId, new RedisQueueCorrelationId(correlationId.Id), new ReadOnlyDictionary<string, object>(allHeaders));
+
+                return new RedisMessage(
+                        messageId,
+                        _receivedMessageFactory.Create(
+                        newMessage,
+                        new RedisQueueId(messageId),
+                        new RedisQueueCorrelationId(correlationId.Id)), false);
+            }
+            catch (Exception error)
+            {
+                var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
+
+                //at this point, the record has been de-queued, but it can't be processed.
+                throw new PoisonMessageException(
+                    "An error has occurred trying to re-assemble a message de-queued from redis", error,
+                    new RedisQueueId(messageId), new RedisQueueCorrelationId(correlationId), new ReadOnlyDictionary<string, object>(allHeaders),
+                    message, headers);
+
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/ReceiveMessageQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/ReceiveMessageQueryHandlerAsync.cs
@@ -21,40 +21,19 @@ using DotNetWorkQueue.Serialization;
 using DotNetWorkQueue.Transport.Redis.Basic.Lua;
 using DotNetWorkQueue.Transport.Redis.Basic.Query;
 using DotNetWorkQueue.Transport.Shared;
-using DotNetWorkQueue.Validation;
 using StackExchange.Redis;
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.Redis.Basic.QueryHandler
 {
     /// <summary>
-    /// The asynchronous twin of <see cref="ReceiveMessageQueryHandler"/>.
+    /// The asynchronous twin of <see cref="ReceiveMessageQueryHandler"/>. Both derive from
+    /// <see cref="AReceiveMessageQueryHandler"/>, so the only difference between them is the call
+    /// that runs the Lua script.
     /// </summary>
-    /// <remarks>
-    /// Deliberately a line-for-line copy with a single difference - <c>ExecuteAsync</c> in place of
-    /// <c>Execute</c>. Everything else is load-bearing and must stay identical: the three
-    /// SetMessageAndHeaders calls that establish the context invariants, the poison-message
-    /// detection, the expired-message removal and both PoisonMessageException throws. Factoring the
-    /// shared body out would mean an abstraction over the one call that differs, and any divergence
-    /// between the two would surface on only one code path.
-    ///
-    /// One thing here is still synchronous: <c>_removeMessage.Remove</c> on the expiry branch. That
-    /// path is rare and mirroring the sync handler exactly matters more, but it is not "fully async"
-    /// and should not be described as such.
-    /// </remarks>
-    internal class ReceiveMessageQueryHandlerAsync : IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>
+    internal class ReceiveMessageQueryHandlerAsync : AReceiveMessageQueryHandler, IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>
     {
-        private readonly ICompositeSerialization _serializer;
-        private readonly IReceivedMessageFactory _receivedMessageFactory;
-        private readonly IRemoveMessage _removeMessage;
-        private readonly RedisHeaders _redisHeaders;
-        private readonly DequeueLua _dequeueLua;
-        private readonly IUnixTimeFactory _unixTimeFactory;
-        private readonly IMessageFactory _messageFactory;
-
         /// <summary>Initializes a new instance of the <see cref="ReceiveMessageQueryHandlerAsync"/> class.</summary>
         /// <param name="serializer">The serializer.</param>
         /// <param name="receivedMessageFactory">The received message factory.</param>
@@ -71,109 +50,27 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.QueryHandler
             DequeueLua dequeueLua,
             IUnixTimeFactory unixTimeFactory,
             IMessageFactory messageFactory)
+            : base(serializer, receivedMessageFactory, removeMessage, redisHeaders, dequeueLua,
+                unixTimeFactory, messageFactory)
         {
-            Guard.NotNull(serializer);
-            Guard.NotNull(receivedMessageFactory);
-            Guard.NotNull(removeMessage);
-            Guard.NotNull(redisHeaders);
-            Guard.NotNull(dequeueLua);
-            Guard.NotNull(unixTimeFactory);
-
-            _serializer = serializer;
-            _receivedMessageFactory = receivedMessageFactory;
-            _removeMessage = removeMessage;
-            _redisHeaders = redisHeaders;
-            _dequeueLua = dequeueLua;
-            _unixTimeFactory = unixTimeFactory;
-            _messageFactory = messageFactory;
         }
 
         /// <inheritdoc />
         public async Task<RedisMessage> HandleAsync(ReceiveMessageQuery query)
         {
-            byte[] message = null;
-            byte[] headers = null;
-            string messageId;
-            var poisonMessage = false;
-            RedisQueueCorrelationIdSerialized correlationId = null;
+            long unixTimestamp;
+            RedisValue[] result;
             try
             {
-                var unixTimestamp = _unixTimeFactory.Create().GetCurrentUnixTimestampMilliseconds();
-                RedisValue[] result = await _dequeueLua.ExecuteAsync(unixTimestamp).ConfigureAwait(false);
-
-                if (result == null || result.Length == 1 && !result[0].HasValue || !result[0].HasValue)
-                {
-                    return null;
-                }
-
-                if (!result[1].HasValue)
-                {
-                    //at this point, the record has been de-queued, but it can't be processed.
-                    poisonMessage = true;
-                }
-
-                messageId = result[0];
-                var id = new RedisQueueId(messageId);
-                query.MessageContext.SetMessageAndHeaders(id, null, null);
-                if (!poisonMessage)
-                {
-                    message = result[1];
-                    headers = result[2];
-                    if (result[3].HasValue &&
-                        result[3].TryParse(out long messageExpiration) &&
-                        messageExpiration - unixTimestamp < 0)
-                    {
-                        //message has expired
-                        var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
-                        correlationId = (RedisQueueCorrelationIdSerialized)allHeaders[_redisHeaders.CorrelationId.Name];
-                        query.MessageContext.SetMessageAndHeaders(id, new RedisQueueCorrelationId(correlationId.Id), new ReadOnlyDictionary<string, object>(allHeaders));
-                        _removeMessage.Remove(query.MessageContext, RemoveMessageReason.Expired);
-                        return new RedisMessage(messageId, null, true);
-                    }
-                }
+                unixTimestamp = UnixTimeFactory.Create().GetCurrentUnixTimestampMilliseconds();
+                result = await DequeueLua.ExecuteAsync(unixTimestamp).ConfigureAwait(false);
             }
             catch (Exception error)
             {
                 throw new ReceiveMessageException("Failed to dequeue a message", error);
             }
 
-            if (poisonMessage)
-            {
-                //at this point, the record has been de-queued, but it can't be processed.
-                throw new PoisonMessageException(
-                    "An error has occurred trying to re-assemble a message de-queued from Redis; a messageId was returned, but the LUA script returned a null message. The message payload has most likely been lost.", null,
-                    new RedisQueueId(messageId), new RedisQueueCorrelationId(Guid.Empty), null,
-                    null, null);
-            }
-
-            try
-            {
-                var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
-                correlationId = (RedisQueueCorrelationIdSerialized)allHeaders[_redisHeaders.CorrelationId.Name];
-                var messageGraph = (MessageInterceptorsGraph)allHeaders[_redisHeaders.Headers.StandardHeaders.MessageInterceptorGraph.Name];
-                var messageData = _serializer.Serializer.BytesToMessage<MessageBody>(message, messageGraph, allHeaders);
-
-                var newMessage = _messageFactory.Create(messageData.Body, allHeaders);
-                query.MessageContext.SetMessageAndHeaders(query.MessageContext.MessageId, new RedisQueueCorrelationId(correlationId.Id), new ReadOnlyDictionary<string, object>(allHeaders));
-
-                return new RedisMessage(
-                        messageId,
-                        _receivedMessageFactory.Create(
-                        newMessage,
-                        new RedisQueueId(messageId),
-                        new RedisQueueCorrelationId(correlationId.Id)), false);
-            }
-            catch (Exception error)
-            {
-                var allHeaders = _serializer.InternalSerializer.ConvertBytesTo<IDictionary<string, object>>(headers);
-
-                //at this point, the record has been de-queued, but it can't be processed.
-                throw new PoisonMessageException(
-                    "An error has occurred trying to re-assemble a message de-queued from redis", error,
-                    new RedisQueueId(messageId), new RedisQueueCorrelationId(correlationId), new ReadOnlyDictionary<string, object>(allHeaders),
-                    message, headers);
-
-            }
+            return BuildMessage(query, unixTimestamp, result);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueInit.cs
@@ -175,6 +175,11 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             container.Register<DashboardResetAllStaleMessagesLua>(LifeStyles.Singleton);
             container.Register<DashboardUpdateMessageBodyLua>(LifeStyles.Singleton);
 
+            //The async receive handler. IQueryHandler<,> above is picked up by the assembly scan;
+            //IQueryHandlerAsync<,> is not, so this and its decorators are registered by hand.
+            container.Register<IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>,
+                ReceiveMessageQueryHandlerAsync>(LifeStyles.Singleton);
+
             // Dashboard read handlers
             container.Register<IQueryHandlerAsync<GetDashboardStatusCountsQuery, DashboardStatusCounts>,
                 GetDashboardStatusCountsQueryHandlerAsync>(LifeStyles.Singleton);
@@ -221,9 +226,15 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             container.RegisterDecorator<IDelayedProcessingAction, DelayedProcessingActionDecorator>(LifeStyles.Singleton);
             container.RegisterDecorator<IQueryHandler<ReceiveMessageQuery, RedisMessage>, ReceiveMessageQueryDecorator>(
                 LifeStyles.Singleton);
+            //The async path needs its own, or an expired message stops being counted the moment the
+            //consumer switches to it - a decorator that exists on only one code path.
+            container.RegisterDecorator<IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>, Metrics.Decorator.ReceiveMessageQueryAsyncDecorator>(
+                LifeStyles.Singleton);
 
             //logging decorators
             container.RegisterDecorator<IQueryHandler<ReceiveMessageQuery, RedisMessage>, Logging.Decorator.ReceiveMessageQueryDecorator>(
+                LifeStyles.Singleton);
+            container.RegisterDecorator<IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>, Logging.Decorator.ReceiveMessageQueryAsyncDecorator>(
                 LifeStyles.Singleton);
             container.RegisterDecorator<IDelayedProcessingAction, Logging.Decorator.DelayedProcessingActionDecorator>(LifeStyles.Singleton);
 

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueInit.cs
@@ -175,8 +175,9 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             container.Register<DashboardResetAllStaleMessagesLua>(LifeStyles.Singleton);
             container.Register<DashboardUpdateMessageBodyLua>(LifeStyles.Singleton);
 
-            //The async receive handler. IQueryHandler<,> above is picked up by the assembly scan;
-            //IQueryHandlerAsync<,> is not, so this and its decorators are registered by hand.
+            //The async receive handler and its decorators are registered by hand: the assembly scan
+            //above covers the synchronous query handler interface only, and does not pick up the
+            //asynchronous one.
             container.Register<IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage>,
                 ReceiveMessageQueryHandlerAsync>(LifeStyles.Singleton);
 

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
@@ -20,6 +20,8 @@ using DotNetWorkQueue.Transport.Redis.Basic.Query;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.Redis.Basic
 {
@@ -115,6 +117,15 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
                     return null;
                 }
             }
+        }
+
+        /// <inheritdoc />
+        public ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            //TEMPORARY - replaced with a genuinely asynchronous implementation later in this
+            //PR. Deliberately NOT Task.Run: that would move the block to a different pool
+            //thread while looking like a fix.
+            return new ValueTask<IReceivedMessageInternal>(ReceiveMessage(context));
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
@@ -126,17 +126,14 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
 
         /// <inheritdoc />
         /// <remarks>
-        /// <paramref name="cancellation"/> is accepted and not passed on, which is deliberate rather
-        /// than an oversight: nothing downstream on this transport takes a token.
-        /// <c>IQueryHandlerAsync.HandleAsync(query)</c> has no token parameter, neither does
-        /// <c>DequeueLua.ExecuteAsync</c>, and SE.Redis's <c>ScriptEvaluateAsync</c> is not given one.
-        /// Widening those signatures to make the plumbing look wired would buy nothing.
+        /// <paramref name="cancellation"/> is honoured everywhere this method can wait: both loop
+        /// checks test it alongside the queue's own tokens, and it is linked into the work-signal wait,
+        /// which is where a de-queue spends its time when the queue is empty.
         ///
-        /// Redis cancels the way it already does synchronously, and both mechanisms are kept: the loop
-        /// re-checks <c>AnyCancellationRequested</c> at the top of each iteration and again before the
-        /// second de-queue, and <c>WaitAsync</c> observes the work-sub's own cancellation and returns
-        /// false. The parameter still earns its place - SQL Server and PostgreSQL take real tokens on
-        /// their async ADO calls.
+        /// What it cannot do is abort a Lua call already on the wire. SE.Redis's
+        /// <c>ScriptEvaluateAsync</c> takes <c>CommandFlags</c>, not a <c>CancellationToken</c>, so
+        /// per-operation cancellation does not exist to be plumbed - a limitation of the client
+        /// library rather than a gap here, and such a call is bounded by <c>syncTimeout</c> anyway.
         /// </remarks>
         public async ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
         {
@@ -151,7 +148,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             {
                 while (true)
                 {
-                    if (_cancelWork.AnyCancellationRequested())
+                    if (_cancelWork.AnyCancellationRequested() || cancellation.IsCancellationRequested)
                     {
                         return null;
                     }
@@ -162,7 +159,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
                         return message.Message;
                     }
 
-                    if (_cancelWork.AnyCancellationRequested())
+                    if (_cancelWork.AnyCancellationRequested() || cancellation.IsCancellationRequested)
                     {
                         return null;
                     }
@@ -177,7 +174,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
                     {
                         continue;
                     }
-                    if (await workSub.WaitAsync().ConfigureAwait(false))
+                    if (await workSub.WaitAsync(cancellation).ConfigureAwait(false))
                     {
                         continue;
                     }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
@@ -32,6 +32,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
     {
         private readonly IRedisQueueWorkSubFactory _workSubFactory;
         private readonly IQueryHandler<ReceiveMessageQuery, RedisMessage> _receiveMessage;
+        private readonly IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage> _receiveMessageAsync;
         private readonly ITransportHandleMessage _handleMessage;
         private readonly ICancelWork _cancelWork;
 
@@ -40,19 +41,23 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// </summary>
         /// <param name="workSubFactory">The work sub factory.</param>
         /// <param name="receiveMessage">The receive message.</param>
+        /// <param name="receiveMessageAsync">The receive message handler used by the async path.</param>
         /// <param name="handleMessage">The handle message.</param>
         /// <param name="cancelWork">The cancel work.</param>
         public RedisQueueReceiveMessages(IRedisQueueWorkSubFactory workSubFactory,
             IQueryHandler<ReceiveMessageQuery, RedisMessage> receiveMessage,
+            IQueryHandlerAsync<ReceiveMessageQuery, RedisMessage> receiveMessageAsync,
             ITransportHandleMessage handleMessage,
             IQueueCancelWork cancelWork)
         {
             Guard.NotNull(workSubFactory);
             Guard.NotNull(receiveMessage);
+            Guard.NotNull(receiveMessageAsync);
             Guard.NotNull(handleMessage);
             Guard.NotNull(cancelWork);
 
             _receiveMessage = receiveMessage;
+            _receiveMessageAsync = receiveMessageAsync;
             _handleMessage = handleMessage;
             _cancelWork = cancelWork;
             _workSubFactory = workSubFactory;
@@ -120,12 +125,66 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         }
 
         /// <inheritdoc />
-        public ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        /// <remarks>
+        /// <paramref name="cancellation"/> is accepted and not passed on, which is deliberate rather
+        /// than an oversight: nothing downstream on this transport takes a token.
+        /// <c>IQueryHandlerAsync.HandleAsync(query)</c> has no token parameter, neither does
+        /// <c>DequeueLua.ExecuteAsync</c>, and SE.Redis's <c>ScriptEvaluateAsync</c> is not given one.
+        /// Widening those signatures to make the plumbing look wired would buy nothing.
+        ///
+        /// Redis cancels the way it already does synchronously, and both mechanisms are kept: the loop
+        /// re-checks <c>AnyCancellationRequested</c> at the top of each iteration and again before the
+        /// second de-queue, and <c>WaitAsync</c> observes the work-sub's own cancellation and returns
+        /// false. The parameter still earns its place - SQL Server and PostgreSQL take real tokens on
+        /// their async ADO calls.
+        /// </remarks>
+        public async ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
         {
-            //TEMPORARY - replaced with a genuinely asynchronous implementation later in this
-            //PR. Deliberately NOT Task.Run: that would move the block to a different pool
-            //thread while looking like a fix.
-            return new ValueTask<IReceivedMessageInternal>(ReceiveMessage(context));
+            //These three are not optional. Without them the method still compiles and still returns
+            //messages, and commit and rollback silently stop working.
+            context.Commit += _cachedCommit ??= ContextOnCommit;
+            context.Rollback += _cachedRollback ??= ContextOnRollback;
+            context.Cleanup += _cachedCleanup ??= Context_Cleanup;
+
+            using (
+                var workSub = _workSubFactory.Create())
+            {
+                while (true)
+                {
+                    if (_cancelWork.AnyCancellationRequested())
+                    {
+                        return null;
+                    }
+
+                    var message = await GetMessageAsync(context).ConfigureAwait(false);
+                    if (message != null && !message.Expired)
+                    {
+                        return message.Message;
+                    }
+
+                    if (_cancelWork.AnyCancellationRequested())
+                    {
+                        return null;
+                    }
+
+                    workSub.Reset();
+                    message = await GetMessageAsync(context).ConfigureAwait(false);
+                    if (message != null && !message.Expired)
+                    {
+                        return message.Message;
+                    }
+                    if (message != null && message.Expired)
+                    {
+                        continue;
+                    }
+                    if (await workSub.WaitAsync().ConfigureAwait(false))
+                    {
+                        continue;
+                    }
+
+                    return null;
+                }
+            }
         }
 
         /// <inheritdoc />
@@ -139,6 +198,22 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         private RedisMessage GetMessage(IMessageContext context)
         {
             var message = _receiveMessage.Handle(new ReceiveMessageQuery(context));
+            if (message == null) return null;
+            if (!message.Expired)
+            {
+                context.SetMessageAndHeaders(message.Message.MessageId, message.Message.CorrelationId, message.Message.Headers);
+            }
+            return message;
+        }
+
+        /// <summary>
+        /// Gets the next message from the queue, without blocking a thread across the Lua call.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns></returns>
+        private async Task<RedisMessage> GetMessageAsync(IMessageContext context)
+        {
+            var message = await _receiveMessageAsync.HandleAsync(new ReceiveMessageQuery(context)).ConfigureAwait(false);
             if (message == null) return null;
             if (!message.Expired)
             {

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueWorkSub.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueWorkSub.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Validation;
 using StackExchange.Redis;
 
@@ -32,6 +33,13 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         private readonly IRedisConnection _connection;
         private readonly RedisNames _redisNames;
         private ManualResetEventSlim _waitHandle;
+
+        //ManualResetEventSlim has no WaitAsync, so async waiters park on this instead. Every
+        //transition of the handle and this source happens together under _asyncSync; splitting them
+        //is what produced the lost wake-up and the hang-on-dispose that review caught in the core
+        //implementation this mirrors (DotNetWorkQueue.Queue.WaitForEventOrCancel).
+        private TaskCompletionSource<bool> _asyncWait;
+        private readonly object _asyncSync = new object();
         private readonly ICancelWork _cancelWork;
         private readonly object _setup = new object();
         private bool _ranSetup;
@@ -87,11 +95,70 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// <summary>
         /// Resets this instance.
         /// </summary>
+        /// <inheritdoc />
+        public async ValueTask<bool> WaitAsync()
+        {
+            ThrowIfDisposed();
+            Setup();
+
+            Task<bool> wait;
+            lock (_asyncSync)
+            {
+                //Both checks belong inside the lock. Outside it, a cancel or dispose landing between
+                //the check and the source being created leaves a waiter that nothing will ever
+                //complete.
+                if (IsDisposed || _cancelWork.AnyCancellationRequested())
+                    return false;
+
+                _asyncWait ??= _waitHandle.IsSet ? CreateCompletedWait() : CreateWait();
+                wait = _asyncWait.Task;
+            }
+
+            if (wait.IsCompleted)
+                return wait.Result;
+
+            //Mirrors what the synchronous Wait does with its linked token: return false rather than
+            //throw, so the receive loop can see the cancellation and return null instead of treating
+            //it as a failed de-queue.
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(_cancelWork.Tokens.ToArray());
+            await using var registration = cts.Token.Register(CancelAsyncWait).ConfigureAwait(false);
+            return await wait.ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Resets the wait handle, so that the next wait blocks until a notification arrives.
+        /// </summary>
         public void Reset()
         {
             Setup();
-            if (_waitHandle.IsSet)
-                _waitHandle.Reset();
+            lock (_asyncSync)
+            {
+                if (_waitHandle.IsSet)
+                    _waitHandle.Reset();
+
+                //Only replace a source that has already completed. Replacing a pending one orphans
+                //every waiter holding the old task.
+                if (_asyncWait != null && _asyncWait.Task.IsCompleted)
+                    _asyncWait = CreateWait();
+            }
+        }
+
+        private void CancelAsyncWait()
+        {
+            lock (_asyncSync)
+            {
+                _asyncWait?.TrySetResult(false);
+            }
+        }
+
+        private static TaskCompletionSource<bool> CreateWait() =>
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private static TaskCompletionSource<bool> CreateCompletedWait()
+        {
+            var source = CreateWait();
+            source.SetResult(true);
+            return source;
         }
 
         #region IDispose, IIsDisposed
@@ -125,6 +192,13 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             lock (_setup)
             {
                 if (!_ranSetup) return;
+            }
+
+            //Release async waiters before the handle goes away, or a WaitAsync that raced disposal
+            //never completes at all.
+            lock (_asyncSync)
+            {
+                _asyncWait?.TrySetResult(false);
             }
 
             _waitHandle.Set();
@@ -177,7 +251,11 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// <param name="redisValue">The redis value.</param>
         private void Handler(RedisChannel redisChannel, RedisValue redisValue)
         {
-            _waitHandle.Set();
+            lock (_asyncSync)
+            {
+                _waitHandle.Set();
+                _asyncWait?.TrySetResult(true);
+            }
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueWorkSub.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueWorkSub.cs
@@ -17,6 +17,8 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Validation;
@@ -96,7 +98,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// Resets this instance.
         /// </summary>
         /// <inheritdoc />
-        public async ValueTask<bool> WaitAsync()
+        public async ValueTask<bool> WaitAsync(CancellationToken cancellation)
         {
             ThrowIfDisposed();
             Setup();
@@ -107,7 +109,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
                 //Both checks belong inside the lock. Outside it, a cancel or dispose landing between
                 //the check and the source being created leaves a waiter that nothing will ever
                 //complete.
-                if (IsDisposed || _cancelWork.AnyCancellationRequested())
+                if (IsDisposed || _cancelWork.AnyCancellationRequested() || cancellation.IsCancellationRequested)
                     return false;
 
                 _asyncWait ??= _waitHandle.IsSet ? CreateCompletedWait() : CreateWait();
@@ -120,7 +122,11 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             //Mirrors what the synchronous Wait does with its linked token: return false rather than
             //throw, so the receive loop can see the cancellation and return null instead of treating
             //it as a failed de-queue.
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(_cancelWork.Tokens.ToArray());
+            //The caller's token is linked in alongside the queue's own, so a caller that wants to
+            //stop waiting can, not just the queue shutting down.
+            var tokens = _cancelWork.Tokens.ToList();
+            if (cancellation.CanBeCanceled) tokens.Add(cancellation);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(tokens.ToArray());
             await using var registration = cts.Token.Register(CancelAsyncWait).ConfigureAwait(false);
             return await wait.ConfigureAwait(false);
         }
@@ -253,6 +259,11 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             lock (_asyncSync)
             {
+                //A notification can arrive from the Redis subscriber thread after disposal has begun.
+                //Setting a disposed handle throws on a thread nobody is watching, so check inside the
+                //same lock disposal uses rather than racing it.
+                if (IsDisposed) return;
+
                 _waitHandle.Set();
                 _asyncWait?.TrySetResult(true);
             }

--- a/Source/DotNetWorkQueue.Transport.Redis/IRedisQueueWorkSub.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/IRedisQueueWorkSub.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.Redis
 {
@@ -30,6 +31,12 @@ namespace DotNetWorkQueue.Transport.Redis
         /// </summary>
         /// <returns></returns>
         bool Wait();
+
+        /// <summary>
+        /// Waits until a notification is received, without blocking a thread.
+        /// </summary>
+        /// <returns><c>true</c> if notified; <c>false</c> if cancelled or disposed.</returns>
+        ValueTask<bool> WaitAsync();
         /// <summary>
         /// Resets this instance.
         /// </summary>

--- a/Source/DotNetWorkQueue.Transport.Redis/IRedisQueueWorkSub.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/IRedisQueueWorkSub.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.Redis
@@ -36,7 +37,8 @@ namespace DotNetWorkQueue.Transport.Redis
         /// Waits until a notification is received, without blocking a thread.
         /// </summary>
         /// <returns><c>true</c> if notified; <c>false</c> if cancelled or disposed.</returns>
-        ValueTask<bool> WaitAsync();
+        /// <param name="cancellation">Stops the wait; linked with the queue's own cancellation.</param>
+        ValueTask<bool> WaitAsync(CancellationToken cancellation);
         /// <summary>
         /// Resets this instance.
         /// </summary>

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
@@ -23,6 +23,8 @@ using DotNetWorkQueue.Transport.SQLite.Basic.Message;
 using DotNetWorkQueue.Validation;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.SQLite.Basic
 {
@@ -111,6 +113,17 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                 throw new ReceiveMessageException("An error occurred while attempting to read messages from the queue",
                     exception);
             }
+        }
+
+        /// <inheritdoc />
+        public ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            //Correct as written, not unfinished. This is an embedded database with no real
+            //asynchronous I/O - System.Data.SQLite's *Async methods are synchronous work
+            //behind a task - and a de-queue costs about 6 microseconds, so there is nothing
+            //to release the thread for. Deliberately NOT Task.Run, which would only move the
+            //work to another pool thread.
+            return new ValueTask<IReceivedMessageInternal>(ReceiveMessage(context));
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
@@ -122,7 +122,8 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             //asynchronous I/O - System.Data.SQLite's *Async methods are synchronous work
             //behind a task - and a de-queue costs about 6 microseconds, so there is nothing
             //to release the thread for. Deliberately NOT Task.Run, which would only move the
-            //work to another pool thread.
+            //work to another pool thread. The token is ignored for the same reason - the call
+            //returns in microseconds, so there is no wait to cancel.
             return new ValueTask<IReceivedMessageInternal>(ReceiveMessage(context));
         }
 

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueReceive.cs
@@ -23,6 +23,8 @@ using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SqlServer.Basic.Message;
 using DotNetWorkQueue.Validation;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 
 namespace DotNetWorkQueue.Transport.SqlServer.Basic
@@ -145,6 +147,15 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
                 throw new ReceiveMessageException("An error occurred while attempting to read messages from the queue",
                     exception);
             }
+        }
+
+        /// <inheritdoc />
+        public ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            //TEMPORARY - replaced with a genuinely asynchronous implementation later in this
+            //PR. Deliberately NOT Task.Run: that would move the block to a different pool
+            //thread while looking like a fix.
+            return new ValueTask<IReceivedMessageInternal>(ReceiveMessage(context));
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue/History/Decorator/ReceiveMessagesHistoryDecorator.cs
+++ b/Source/DotNetWorkQueue/History/Decorator/ReceiveMessagesHistoryDecorator.cs
@@ -17,6 +17,8 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace DotNetWorkQueue.History.Decorator
@@ -42,6 +44,24 @@ namespace DotNetWorkQueue.History.Decorator
         public IReceivedMessageInternal ReceiveMessage(IMessageContext context)
         {
             var result = _handler.ReceiveMessage(context);
+            if (result != null && _options.EnableHistory && _options.HistoryOptions.TrackProcessing && context.MessageId != null && context.MessageId.HasValue)
+            {
+                try
+                {
+                    _history.RecordProcessingStart(context.MessageId.Id.Value.ToString());
+                }
+                catch (Exception ex)
+                {
+                    _log.LogWarning(ex, "Failed to record history for processing start of message {MessageId}", context.MessageId.Id.Value);
+                }
+            }
+            return result;
+        }
+
+        /// <inheritdoc />
+        public async ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            var result = await _handler.ReceiveMessageAsync(context, cancellation).ConfigureAwait(false);
             if (result != null && _options.EnableHistory && _options.HistoryOptions.TrackProcessing && context.MessageId != null && context.MessageId.HasValue)
             {
                 try

--- a/Source/DotNetWorkQueue/IMessageProcessing.cs
+++ b/Source/DotNetWorkQueue/IMessageProcessing.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue
 {
@@ -46,6 +47,22 @@ namespace DotNetWorkQueue
         /// <summary>
         /// Processes a message
         /// </summary>
-        void Handle();
+        /// <summary>
+        /// Looks for and processes a new message.
+        /// </summary>
+        /// <returns>
+        /// A task that completes when this processor is ready to de-queue the NEXT message - not when
+        /// the message just received has finished processing.
+        /// </returns>
+        /// <remarks>
+        /// The worker loop waits on this, and that is what bounds how many de-queues can be in flight.
+        /// It used to be <c>void</c>, which made the loop's pacing an accident of wherever the first
+        /// blocking call happened to be - the synchronous receive. Once the receive is awaited that
+        /// accident stops working, and an unbounded number of de-queues start at once.
+        ///
+        /// Waiting on this is cheap: worker loops own dedicated threads
+        /// (<c>TaskCreationOptions.LongRunning</c>), so they hold no thread-pool thread.
+        /// </remarks>
+        Task HandleAsync();
     }
 }

--- a/Source/DotNetWorkQueue/IQueueWait.cs
+++ b/Source/DotNetWorkQueue/IQueueWait.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue
 {
@@ -38,5 +39,16 @@ namespace DotNetWorkQueue
         /// </summary>
         /// <param name="waitTime">The how long the wait will last.</param>
         void Wait(Action<TimeSpan> waitTime);
+
+        /// <summary>
+        /// Waits out the current back-off interval without holding a thread.
+        /// </summary>
+        /// <remarks>
+        /// Returns normally when the queue is stopping, exactly as <see cref="Wait()"/> does, and
+        /// advances the back-off ladder either way. It must not throw on stop: the caller polls for a
+        /// message, finds none and waits, so a cancellation exception here would surface as a rollback
+        /// of a message that was never received.
+        /// </remarks>
+        ValueTask WaitAsync();
     }
 }

--- a/Source/DotNetWorkQueue/IReceiveMessages.cs
+++ b/Source/DotNetWorkQueue/IReceiveMessages.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DotNetWorkQueue
@@ -33,6 +34,16 @@ namespace DotNetWorkQueue
         /// A message to process or null if there are no messages to process
         /// </returns>
         IReceivedMessageInternal ReceiveMessage(IMessageContext context);
+
+        /// <summary>
+        /// Returns a message to process, without blocking a thread while the transport is queried.
+        /// </summary>
+        /// <param name="context">The message context.</param>
+        /// <param name="cancellation">Cancels the receive; the queue is stopping.</param>
+        /// <returns>
+        /// A message to process or null if there are no messages to process
+        /// </returns>
+        ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation);
 
         /// <summary>
         /// Gets a value indicating whether calling <see cref="ReceiveMessage"/> is a blocking operation

--- a/Source/DotNetWorkQueue/IReceiveMessages.cs
+++ b/Source/DotNetWorkQueue/IReceiveMessages.cs
@@ -48,6 +48,11 @@ namespace DotNetWorkQueue
         /// <summary>
         /// Gets a value indicating whether calling <see cref="ReceiveMessage"/> is a blocking operation
         /// </summary>
+        /// <remarks>
+        /// <see cref="ReceiveMessageAsync"/> does not block a thread while waiting, but a transport that
+        /// signals for new messages still has no upper bound on how long a receive may take; this flag
+        /// reports that property of the transport and applies to both methods.
+        /// </remarks>
         /// <value>
         ///   <c>true</c> if this instance is blocking operation; otherwise, <c>false</c>.
         /// </value>

--- a/Source/DotNetWorkQueue/Metrics/Decorator/IReceiveMessagesDecorator.cs
+++ b/Source/DotNetWorkQueue/Metrics/Decorator/IReceiveMessagesDecorator.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Metrics.Decorator
@@ -61,6 +62,17 @@ namespace DotNetWorkQueue.Metrics.Decorator
         public IReceivedMessageInternal ReceiveMessage(IMessageContext context)
         {
             var result = _handler.ReceiveMessage(context);
+            if (result != null)
+            {
+                ProcessResult(result);
+            }
+            return result;
+        }
+
+        /// <inheritdoc />
+        public async ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            var result = await _handler.ReceiveMessageAsync(context, cancellation).ConfigureAwait(false);
             if (result != null)
             {
                 ProcessResult(result);

--- a/Source/DotNetWorkQueue/Policies/Decorator/IReceiveMessagesPolicyDecorator.cs
+++ b/Source/DotNetWorkQueue/Policies/Decorator/IReceiveMessagesPolicyDecorator.cs
@@ -55,8 +55,12 @@ namespace DotNetWorkQueue.Policies.Decorator
         {
             if (_policies.Registry.TryGetPipeline(_policies.Definition.ReceiveMessageFromTransportAsync, out var pipeline))
             {
-                return await pipeline.ExecuteAsync(async _ =>
-                    await _handler.ReceiveMessageAsync(context, cancellation).ConfigureAwait(false)).ConfigureAwait(false);
+                //The token goes to the pipeline as well as to the handler. Without it a retry or
+                //timeout strategy keeps waiting out its delay after the queue has been told to stop,
+                //because the pipeline was given CancellationToken.None and never learns of it.
+                return await pipeline.ExecuteAsync(async token =>
+                    await _handler.ReceiveMessageAsync(context, token).ConfigureAwait(false),
+                    cancellation).ConfigureAwait(false);
             }
             return await _handler.ReceiveMessageAsync(context, cancellation).ConfigureAwait(false);
         }

--- a/Source/DotNetWorkQueue/Policies/Decorator/IReceiveMessagesPolicyDecorator.cs
+++ b/Source/DotNetWorkQueue/Policies/Decorator/IReceiveMessagesPolicyDecorator.cs
@@ -18,6 +18,8 @@
 // ---------------------------------------------------------------------
 using DotNetWorkQueue.Validation;
 using Polly;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Policies.Decorator
 {
@@ -46,6 +48,17 @@ namespace DotNetWorkQueue.Policies.Decorator
                 return pipeline.Execute(_ => _handler.ReceiveMessage(context));
             }
             return _handler.ReceiveMessage(context);
+        }
+
+        /// <inheritdoc />
+        public async ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            if (_policies.Registry.TryGetPipeline(_policies.Definition.ReceiveMessageFromTransportAsync, out var pipeline))
+            {
+                return await pipeline.ExecuteAsync(async _ =>
+                    await _handler.ReceiveMessageAsync(context, cancellation).ConfigureAwait(false)).ConfigureAwait(false);
+            }
+            return await _handler.ReceiveMessageAsync(context, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue/Queue/MessageProcessing.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageProcessing.cs
@@ -22,6 +22,7 @@ using DotNetWorkQueue.Validation;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Queue
 {
@@ -111,7 +112,15 @@ namespace DotNetWorkQueue.Queue
         /// <summary>
         /// Looks for a new message to process
         /// </summary>
-        public void Handle()
+        public Task HandleAsync()
+        {
+            //Everything below is synchronous, so "ready for the next message" is simply "done". The
+            //async sibling is where the distinction earns its keep.
+            Handle();
+            return Task.CompletedTask;
+        }
+
+        private void Handle()
         {
             try
             {

--- a/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
@@ -42,6 +42,8 @@ namespace DotNetWorkQueue.Queue
         private readonly IConsumerQueueErrorNotification _consumerQueueErrorNotification;
         private readonly IConsumerQueueNotification _consumerQueueNotification;
         private readonly ICancelWork _cancelWork;
+        private readonly ATaskScheduler _taskScheduler;
+        private readonly IWorkGroup _workGroup;
 
         /// <summary>
         /// Occurs when message processor is idle
@@ -68,6 +70,8 @@ namespace DotNetWorkQueue.Queue
         /// <param name="consumerQueueErrorNotification">notifications for consumer queue errors</param>
         /// <param name="consumerQueueNotification">notifications for consumer queue messages</param>
         /// <param name="cancelWork">cancellation tokens for the queue; the receive is cancelled on stop</param>
+        /// <param name="taskScheduler">the scheduler whose capacity paces dispatch</param>
+        /// <param name="workGroup">the work group this queue belongs to, if any</param>
         public MessageProcessingAsync(IReceiveMessagesFactory receiveMessages,
             IMessageContextFactory messageContextFactory,
             IQueueWaitFactory queueWaitFactory,
@@ -77,7 +81,9 @@ namespace DotNetWorkQueue.Queue
             IRollbackMessage rollbackMessage,
             IConsumerQueueErrorNotification consumerQueueErrorNotification,
             IConsumerQueueNotification consumerQueueNotification,
-            IQueueCancelWork cancelWork)
+            IQueueCancelWork cancelWork,
+            ATaskScheduler taskScheduler,
+            IWorkGroup workGroup)
         {
             Guard.NotNull(receiveMessages);
             Guard.NotNull(messageContextFactory);
@@ -89,6 +95,7 @@ namespace DotNetWorkQueue.Queue
             Guard.NotNull(consumerQueueErrorNotification);
             Guard.NotNull(consumerQueueNotification);
             Guard.NotNull(cancelWork);
+            Guard.NotNull(taskScheduler);
 
             _receiveMessages = receiveMessages;
             _messageContextFactory = messageContextFactory;
@@ -102,6 +109,8 @@ namespace DotNetWorkQueue.Queue
             _consumerQueueErrorNotification = consumerQueueErrorNotification;
             _consumerQueueNotification = consumerQueueNotification;
             _cancelWork = cancelWork;
+            _taskScheduler = taskScheduler;
+            _workGroup = workGroup;
         }
 
         /// <summary>
@@ -255,6 +264,19 @@ namespace DotNetWorkQueue.Queue
                 NotIdle(this, EventArgs.Empty);
                 _idle = false;
             }
+
+            //Wait for scheduler capacity HERE, by awaiting, rather than letting
+            //SchedulerMessageHandler's finally block for it further down. Before the receive was
+            //awaited that block landed on the worker's own dedicated thread, where blocking is free.
+            //It now lands in a continuation on a THREAD-POOL thread, and blocking one of those is the
+            //exact starvation this work exists to remove. Awaiting first means the block downstream
+            //finds room and returns immediately.
+            //
+            //The result is deliberately not acted on: if this returns false the queue is stopping, and
+            //falling through lets ShouldHandle throw as it always has, so the message is rolled back by
+            //the existing handler rather than silently dropped here.
+            if (_taskScheduler.Started)
+                await _taskScheduler.WaitForFreeThread.WaitAsync(_workGroup).ConfigureAwait(false);
 
             //Invoking this runs synchronously all the way down through ProcessMessageAsync,
             //HandleMessage and the decorators into the user's handler - and, for the scheduler

--- a/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
@@ -41,6 +41,7 @@ namespace DotNetWorkQueue.Queue
         private readonly IRollbackMessage _rollbackMessage;
         private readonly IConsumerQueueErrorNotification _consumerQueueErrorNotification;
         private readonly IConsumerQueueNotification _consumerQueueNotification;
+        private readonly ICancelWork _cancelWork;
 
         /// <summary>
         /// Occurs when message processor is idle
@@ -66,6 +67,7 @@ namespace DotNetWorkQueue.Queue
         /// <param name="rollbackMessage">rolls back a message when an exception occurs</param>
         /// <param name="consumerQueueErrorNotification">notifications for consumer queue errors</param>
         /// <param name="consumerQueueNotification">notifications for consumer queue messages</param>
+        /// <param name="cancelWork">cancellation tokens for the queue; the receive is cancelled on stop</param>
         public MessageProcessingAsync(IReceiveMessagesFactory receiveMessages,
             IMessageContextFactory messageContextFactory,
             IQueueWaitFactory queueWaitFactory,
@@ -74,7 +76,8 @@ namespace DotNetWorkQueue.Queue
             IReceivePoisonMessage receivePoisonMessage,
             IRollbackMessage rollbackMessage,
             IConsumerQueueErrorNotification consumerQueueErrorNotification,
-            IConsumerQueueNotification consumerQueueNotification)
+            IConsumerQueueNotification consumerQueueNotification,
+            IQueueCancelWork cancelWork)
         {
             Guard.NotNull(receiveMessages);
             Guard.NotNull(messageContextFactory);
@@ -85,6 +88,7 @@ namespace DotNetWorkQueue.Queue
             Guard.NotNull(rollbackMessage);
             Guard.NotNull(consumerQueueErrorNotification);
             Guard.NotNull(consumerQueueNotification);
+            Guard.NotNull(cancelWork);
 
             _receiveMessages = receiveMessages;
             _messageContextFactory = messageContextFactory;
@@ -97,6 +101,7 @@ namespace DotNetWorkQueue.Queue
             _seriousExceptionProcessBackOffHelper = new Lazy<IQueueWait>(queueWaitFactory.CreateFatalErrorDelay);
             _consumerQueueErrorNotification = consumerQueueErrorNotification;
             _consumerQueueNotification = consumerQueueNotification;
+            _cancelWork = cancelWork;
         }
 
         /// <summary>
@@ -110,17 +115,26 @@ namespace DotNetWorkQueue.Queue
         /// </remarks>
         public long AsyncTaskCount => Interlocked.Read(ref _waitingOnAsyncTasks);
 
-        /// <summary>
-        /// Looks for and processes a new message
-        /// </summary>
-        public async void Handle()
+        /// <inheritdoc />
+        public Task HandleAsync()
+        {
+            //Two different completions, and conflating them is the whole difficulty of this class.
+            //The caller gets `readyForNext`, which completes once this processor can de-queue again.
+            //The work itself keeps running behind that, counted in _waitingOnAsyncTasks so shutdown
+            //still waits for it.
+            var readyForNext = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _ = RunAsync(readyForNext);
+            return readyForNext.Task;
+        }
+
+        private async Task RunAsync(TaskCompletionSource<bool> readyForNext)
         {
             Interlocked.Increment(ref _waitingOnAsyncTasks);
             try
             {
                 try
                 {
-                    await TryProcessIncomingMessageAsync().ConfigureAwait(false);
+                    await TryProcessIncomingMessageAsync(readyForNext).ConfigureAwait(false);
                     _seriousExceptionProcessBackOffHelper.Value.Reset();
                 }
                 catch (CommitException exception)
@@ -135,7 +149,7 @@ namespace DotNetWorkQueue.Queue
                 {
                     //generic exceptions tend to indicate a serious problem - lets start delaying processing
                     //this counter will reset once a message has been processed by this thread
-                    _seriousExceptionProcessBackOffHelper.Value.Wait();
+                    await _seriousExceptionProcessBackOffHelper.Value.WaitAsync().ConfigureAwait(false);
                 }
             }
             catch (Exception ex) //not cool - one of the exception events threw an exception
@@ -146,6 +160,10 @@ namespace DotNetWorkQueue.Queue
             }
             finally
             {
+                //The worker loop must never be left waiting, whatever happened above - a lost signal
+                //here stops that worker permanently. Setting it twice is harmless; never setting it
+                //is not.
+                readyForNext.TrySetResult(true);
                 Interlocked.Decrement(ref _waitingOnAsyncTasks);
             }
         }
@@ -153,13 +171,13 @@ namespace DotNetWorkQueue.Queue
         /// Tries the process a new incoming message.
         /// </summary>
         /// <returns></returns>
-        private async Task TryProcessIncomingMessageAsync()
+        private async Task TryProcessIncomingMessageAsync(TaskCompletionSource<bool> readyForNext)
         {
             using (var context = _messageContextFactory.Create())
             {
                 try
                 {
-                    await DoTryAsync(context).ConfigureAwait(false);
+                    await DoTryAsync(context, readyForNext).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException ex)
                 {
@@ -176,7 +194,7 @@ namespace DotNetWorkQueue.Queue
                 {
                     _log.LogError(e, "An error has occurred while receiving a message from the transport");
                     _consumerQueueErrorNotification.InvokeError(new ErrorReceiveNotification(e));
-                    _seriousExceptionProcessBackOffHelper.Value.Wait();
+                    await _seriousExceptionProcessBackOffHelper.Value.WaitAsync().ConfigureAwait(false);
                 }
                 catch (MessageException ex)
                 {
@@ -197,14 +215,20 @@ namespace DotNetWorkQueue.Queue
         /// Tries the process a new incoming message.
         /// </summary>
         /// <param name="context">The context.</param>
+        /// <param name="readyForNext">
+        /// Signalled once this processor can de-queue again, which releases the worker loop. Set at the
+        /// point the message has been dispatched, not when its processing finishes.
+        /// </param>
         /// <returns></returns>
-        private async Task DoTryAsync(IMessageContext context)
+        private async Task DoTryAsync(IMessageContext context, TaskCompletionSource<bool> readyForNext)
         {
             var receiveMessage = _receiveMessages.Create();
 
-            //this call must block; otherwise, the limitations enforced by the task scheduler will be ignored
-            //calling the async method here may result in hundreds of de-queues at once, instead of the N set in the configuration
-            var transportMessage = receiveMessage.ReceiveMessage(context);
+            //The de-queue no longer blocks. What used to cap in-flight work at N was this call
+            //parking the worker's thread; that cap now lives in the worker loop, which waits on
+            //readyForNext below. Awaiting here WITHOUT that would start de-queues without bound -
+            //measured at 15,910,404 concurrent receives against a configured seven.
+            var transportMessage = await receiveMessage.ReceiveMessageAsync(context, _cancelWork.StopWorkToken).ConfigureAwait(false);
 
             if (transportMessage == null)
             {
@@ -214,7 +238,12 @@ namespace DotNetWorkQueue.Queue
                     Idle(this, EventArgs.Empty);
                     _idle = true;
                 }
-                _noMessageToProcessBackOffHelper.Value.Wait();
+                //Awaited, not blocked. Before the receive became async this ran on the worker's own
+                //dedicated thread, where blocking is free; now it can land in a continuation on a
+                //pool thread, and an idle consumer would hold one per worker for the whole interval.
+                //readyForNext stays unset until this returns, so the loop cannot spin past the
+                //back-off.
+                await _noMessageToProcessBackOffHelper.Value.WaitAsync().ConfigureAwait(false);
                 return;
             }
 
@@ -227,8 +256,18 @@ namespace DotNetWorkQueue.Queue
                 _idle = false;
             }
 
-            //process the message
-            await _processMessage.HandleAsync(context, transportMessage).ConfigureAwait(false);
+            //Invoking this runs synchronously all the way down through ProcessMessageAsync,
+            //HandleMessage and the decorators into the user's handler - and, for the scheduler
+            //consumer, into SchedulerMessageHandler.HandleAsync, whose finally blocks until the
+            //scheduler has room. Only then does it return an incomplete task. That return is
+            //precisely where the old `async void Handle` gave control back to the worker loop, so
+            //signalling here reproduces the previous pacing exactly, throttle included.
+            var processing = _processMessage.HandleAsync(context, transportMessage);
+            readyForNext.TrySetResult(true);
+
+            //Still awaited, inside the context's using: this is what keeps the error handling above
+            //and the context's lifetime tied to the work completing.
+            await processing.ConfigureAwait(false);
         }
     }
 }

--- a/Source/DotNetWorkQueue/Queue/PrimaryWorker.cs
+++ b/Source/DotNetWorkQueue/Queue/PrimaryWorker.cs
@@ -136,7 +136,13 @@ namespace DotNetWorkQueue.Queue
                 {
                     return;
                 }
-                MessageProcessing.Handle();
+                //Wait on the dedicated worker thread this loop already owns
+                //(TaskCreationOptions.LongRunning), so this costs no thread-pool thread - the same
+                //threading profile as the blocking receive it replaces. What it buys is the cap: the
+                //returned task completes when the processor can de-queue again, so exactly one
+                //de-queue per worker is ever in flight. Without this wait, an awaited receive starts
+                //de-queues without bound.
+                MessageProcessing.HandleAsync().GetAwaiter().GetResult();
             }
 
             if (MessageProcessing != null && MessageProcessing.AsyncTaskCount > 0)

--- a/Source/DotNetWorkQueue/Queue/QueueWait.cs
+++ b/Source/DotNetWorkQueue/Queue/QueueWait.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Queue
@@ -85,6 +86,39 @@ namespace DotNetWorkQueue.Queue
 
             Interlocked.Increment(ref _currentIndex);
         }
+        /// <inheritdoc />
+        public async ValueTask WaitAsync()
+        {
+            var effectiveIndex = Math.Min(Interlocked.Read(ref _currentIndex), _backOffTimes.Length - 1);
+            var timeToWait = _backOffTimes[effectiveIndex];
+            await WaitInternalAsync(timeToWait).ConfigureAwait(false);
+            Interlocked.Increment(ref _currentIndex);
+        }
+
+        /// <summary>
+        /// Waits for the specified amount of time, without holding a thread.
+        /// </summary>
+        /// <param name="timeToWait">The time to wait.</param>
+        private async ValueTask WaitInternalAsync(TimeSpan timeToWait)
+        {
+            if (timeToWait <= TimeSpan.Zero || _tokenWorkerCanceled.StopWorkToken.IsCancellationRequested)
+                return;
+
+            //Swallowed deliberately, and this is the whole reason WaitInternal is not simply awaited
+            //away. WaitHandle.WaitOne returns normally when the token fires; Task.Delay throws. The
+            //caller is a poll that found no message and returns straight after this, so a throw would
+            //land in the outer OperationCanceledException handler and roll back - a rollback of
+            //nothing, plus a spurious rollback notification. Returning normally keeps the two paths
+            //behaviourally identical.
+            try
+            {
+                await Task.Delay(timeToWait, _tokenWorkerCanceled.StopWorkToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
         /// <summary>
         /// Waits for the specified amount of time
         /// </summary>

--- a/Source/DotNetWorkQueue/Queue/QueueWaitNoOp.cs
+++ b/Source/DotNetWorkQueue/Queue/QueueWaitNoOp.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Queue
 {
@@ -47,5 +48,9 @@ namespace DotNetWorkQueue.Queue
         {
 
         }
+        /// <summary>
+        /// Returns immediately; there is nothing to wait for.
+        /// </summary>
+        public ValueTask WaitAsync() => default;
     }
 }

--- a/Source/DotNetWorkQueue/Queue/Worker.cs
+++ b/Source/DotNetWorkQueue/Queue/Worker.cs
@@ -111,7 +111,13 @@ namespace DotNetWorkQueue.Queue
                 {
                     return;
                 }
-                MessageProcessing.Handle();
+                //Wait on the dedicated worker thread this loop already owns
+                //(TaskCreationOptions.LongRunning), so this costs no thread-pool thread - the same
+                //threading profile as the blocking receive it replaces. What it buys is the cap: the
+                //returned task completes when the processor can de-queue again, so exactly one
+                //de-queue per worker is ever in flight. Without this wait, an awaited receive starts
+                //de-queues without bound.
+                MessageProcessing.HandleAsync().GetAwaiter().GetResult();
             }
 
             if (MessageProcessing != null && MessageProcessing.AsyncTaskCount > 0)

--- a/Source/DotNetWorkQueue/Trace/Decorator/ReceiveMessagesDecorator.cs
+++ b/Source/DotNetWorkQueue/Trace/Decorator/ReceiveMessagesDecorator.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenTelemetry.Trace;
 
@@ -63,6 +64,31 @@ namespace DotNetWorkQueue.Trace.Decorator
                 start = end;
 
             using (var scope = _tracer.StartActivity("ReceiveMessage", ActivityKind.Internal, activityContext, startTime: start))
+            {
+                scope?.AddMessageIdTag(message);
+                scope?.SetTag("IsBlockingOperation", IsBlockingOperation);
+                scope?.SetEndTime(end);
+                return message;
+            }
+        }
+
+        /// <inheritdoc />
+        public async ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            //we can't attach the span since we don't have the parent until after we get a message
+            //so save off the start and end times, and replace those in the child span below
+            var start = DateTime.UtcNow;
+            var message = await _handler.ReceiveMessageAsync(context, cancellation).ConfigureAwait(false);
+            var end = DateTime.UtcNow;
+            if (message == null) return null;
+            var activityContext = message.Extract(_tracer, _headers.StandardHeaders);
+
+            //blocking operations can last forever for queues that can signal for new messages
+            //so, we will treat this is a 0 ms operation, rather than have it possibly last for N
+            if (IsBlockingOperation)
+                start = end;
+
+            using (var scope = _tracer.StartActivity("ReceiveMessageAsync", ActivityKind.Internal, activityContext, startTime: start))
             {
                 scope?.AddMessageIdTag(message);
                 scope?.SetTag("IsBlockingOperation", IsBlockingOperation);

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/MessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/MessageQueueReceive.cs
@@ -20,6 +20,8 @@ using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Transport.Memory.Basic.Message;
 using DotNetWorkQueue.Validation;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic
 {
@@ -87,6 +89,15 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
                 throw new ReceiveMessageException("An error occurred while attempting to read messages from the queue",
                     exception);
             }
+        }
+
+        /// <inheritdoc />
+        public ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
+        {
+            //TEMPORARY - replaced with a genuinely asynchronous implementation later in this
+            //PR. Deliberately NOT Task.Run: that would move the block to a different pool
+            //thread while looking like a fix.
+            return new ValueTask<IReceivedMessageInternal>(ReceiveMessage(context));
         }
 
         /// <inheritdoc />

--- a/docs/superpowers/plans/2026-09-09-async-receive-path-pr2.md
+++ b/docs/superpowers/plans/2026-09-09-async-receive-path-pr2.md
@@ -1,5 +1,12 @@
 # Async receive path — PR 2: `IReceiveMessages`
 
+> ⚠️ **Tasks 2-7 of this plan are superseded.** See
+> `docs/superpowers/specs/2026-09-08-async-receive-path-design-revision-1.md`. Task 2 as written
+> here causes an unbounded de-queue runaway (measured: 15,910,404 concurrent in-flight
+> receives), and the task 4 gate reproduces starvation on the send path, which this work does
+> not touch. Task 1 is done and unaffected.
+
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Give `IReceiveMessages` an async twin, make the async consumer await it instead of blocking a pool thread, and prove the result with the test that currently documents the defect.

--- a/docs/superpowers/specs/2026-09-08-async-receive-path-design-revision-1.md
+++ b/docs/superpowers/specs/2026-09-08-async-receive-path-design-revision-1.md
@@ -1,0 +1,205 @@
+# Async receive path — design, revision 1
+
+Issue: #256. Date: 2026-09-08. Status: **supersedes the threading analysis in
+`2026-09-08-async-receive-path-design.md`.** Read this first; that document's "The problem"
+and "What the issue understated" sections contain a false premise, corrected below.
+
+PR 1 (`WaitForEventOrCancel.WaitAsync`) is merged. PR 2 task 1 (`ReceiveMessageAsync` on the
+interface and its four decorators) is committed on `feat-256-async-receive` and stands — it is
+purely additive and correct regardless of what the consumer does with it. Tasks 2-7 are **not
+started** and are re-scoped here.
+
+## Why this revision exists
+
+The original spec was written from reading, not measurement, and two of its load-bearing claims
+are wrong. Both were caught only after an implementation attempt OOM-killed the machine. Every
+claim below is either measured or cited to a file and line.
+
+## Correction 1 — the receive does not run on a thread-pool thread
+
+The original spec says a blocking receive "consumes a pool thread exactly as a blocking heartbeat
+does", and builds a six-row table of blocking calls "on the same pool". That is false for the
+first three rows.
+
+`Worker.cs:79` and `PrimaryWorker.cs:85` are both:
+
+```csharp
+WorkerTask = Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning);
+```
+
+`LongRunning` gives each worker a **dedicated** thread. `MainLoop` calls
+`MessageProcessing.Handle()`, and because `Handle()` runs synchronously until its first suspending
+await, the receive, the idle back-off (`_noMessageToProcessBackOffHelper.Value.Wait()`) and the
+scheduler throttle (`WaitForFreeThread.Wait(group)`, reached through the user lambda) all execute
+on that dedicated thread.
+
+**Measured.** A probe on the sync `MessageQueueReceive.ReceiveMessage` recording
+`Thread.CurrentThread.IsThreadPoolThread`, run under the Memory `SimpleConsumerAsync` scenarios:
+
+```
+      7 pool=False id=25 name=.NET Long Running Task
+      7 pool=False id=24 name=.NET Long Running Task
+      6 pool=False id=26 name=.NET Long Running Task
+      5 pool=False id=22 name=.NET Long Running Task
+      2 pool=False id=23 name=.NET Long Running Task
+   pool=True count: 0 / 27
+```
+
+Zero of 27 receives on a pool thread. Five distinct dedicated threads, one per worker.
+
+### What *is* on the pool
+
+| where | on the pool? | why |
+|---|---|---|
+| `MessageProcessingAsync.DoTryAsync` → `ReceiveMessage` | **no** | dedicated `LongRunning` worker thread (measured) |
+| `QueueWait.WaitInternal` idle back-off | **no** | same call stack, same dedicated thread |
+| `SchedulerMessageHandler` → `WaitForFreeThread.Wait` | **no** | same call stack, same dedicated thread |
+| message processing work | **yes** | `taskFactory.TryStartNew` → scheduler → `Task.Factory.StartNew` |
+| `HeartBeatWorker.Send` | **yes** | `SmartThreadPoolTaskScheduler.QueueTask` → `Task.Factory.StartNew` |
+| `Commit` / `Rollback` | **yes, conditionally** | they run in the continuation after the user's async handler suspends |
+
+So the pool pressure in `WORKER: (Busy=215, Min=200)` comes from processing tasks, heartbeats and
+neighbouring Jenkins stages — not from receives.
+
+### What the async receive is therefore worth
+
+**Not** "it frees a pool thread on our side" — there was no pool thread to free.
+
+What it is worth: a synchronous `IDatabase.ScriptEvaluate` in StackExchange.Redis is
+sync-over-async internally, and **needs a pool thread to run the completion** that satisfies its
+own blocking wait. Under pool pressure that completion is delayed past `syncTimeout`, which is the
+timeout recorded in #161 and in the `project_redis_3x_sync_concurrency_limit` note — sends timing
+out *even when the pool is not starved*, because the contention is on completions, not threads.
+Awaiting `ScriptEvaluateAsync` removes the need for a pool thread to satisfy a blocking wait at
+all.
+
+This narrows the value sharply: **the win is in the transport's use of SE.Redis's async API.** The
+core async plumbing exists only to make that reachable without a sync-over-async bridge of our own.
+
+## Correction 2 — the cap lives in the worker loop, and the old comment was right
+
+The comment the original spec quoted is load-bearing, and its estimate was conservative:
+
+```
+//this call must block; otherwise, the limitations enforced by the task scheduler will be ignored
+//calling the async method here may result in hundreds of de-queues at once, instead of the N set in the configuration
+```
+
+`MainLoop` is `while (!ShouldExit) { _pauseEvent.Wait(); MessageProcessing.Handle(); }` and
+`Handle()` is **`async void`**. The loop therefore iterates the moment `Handle()` hits its first
+*suspending* await. Today the blocking receive is what prevents that. The scheduler throttle sits
+*downstream* of the receive inside the same synchronous run, so it cannot pace the loop once the
+receive suspends.
+
+**Measured.** Task 2 step 1 as originally planned, with a Memory transport whose
+`ReceiveMessageAsync` genuinely suspends (`await Task.Yield()` — the shape Redis takes after task
+3), instrumented with an interlocked in-flight counter, running `SimpleConsumerAsync` at
+`workerCount: 7`:
+
+> **peak concurrent in-flight de-queues: 15,910,404**
+
+The test host was OOM-killed and took the WSL instance with it. Three orders of magnitude worse
+than the comment's "hundreds".
+
+### Two shapes that do not fix it
+
+- **Await a throttle before the receive.** Bounds de-queues, but `async void` means the throttle's
+  own suspension also returns to the loop, which then spins allocating waiters. Unbounded memory
+  and a hot loop — the same defect wearing a different hat.
+- **Reuse the scheduler's free-thread event as the gate.** `WaitForEventOrCancel` starts **open**
+  (`new ManualResetEventSlim(true)`, `WaitForEventOrCancel.cs:51`) and `TaskScheduler.cs:373-388`
+  only `Reset`s it when the scheduler is full. The plain async consumer never starts a scheduler,
+  so the gate is permanently open and caps nothing there.
+
+### The shape that does
+
+The **loop** must be what waits. `Handle()` has to hand `MainLoop` something that completes when
+the processor is ready for the *next* de-queue — the same point at which `Handle()` returns to the
+loop today — and because `MainLoop` owns a dedicated thread it can wait on that synchronously, at
+zero pool cost and with an identical threading profile to today.
+
+That means changing the public `IMessageProcessing`, which today is two events, `AsyncTaskCount`
+and `void Handle()`. This PR already accepts breaking changes.
+
+Supporting facts, verified: one `MessageProcessingAsync` per worker (`Worker.cs:74`); `IWorkGroup`
+is registered by default as `WorkGroupNoOp` (`ComponentRegistration.cs:177`) and replaced
+per-container for the scheduler consumer (`QueueContainer.cs:231-264`), so a work-group-aware gate
+needs no new registration; the work group is per-queue, fixed at `CreateConsumerQueueScheduler`
+and stored once at `Scheduler.cs:62`.
+
+## Correction 3 — the existing starvation oracle tests the wrong path
+
+`StarvationBaselineTests.StarvationBaseline_CappedPool_SyncEvalFlood_FailsWithTimeout` caps the
+pool at 6 and floods with 50 concurrent senders calling `producer.Send(msg)`. It is a **send**-path
+reproduction. It contains no consumer.
+
+An async *receive* implementation cannot change its outcome. Task 4 as planned — run that test
+against an "async twin" as the go/no-go gate — would have proved nothing about this work.
+
+Compounding this: the send path **already has** an async implementation
+(`SendMessageCommandHandlerAsync` → `EnqueueLua.ExecuteAsync` → `ScriptEvaluateAsync`), so the
+oracle is measuring the sync API of a path that already has an async alternative.
+
+The receive path already has async Lua available too — `DequeueLua.ExecuteAsync`
+(`DequeueLua.cs:87`) on `BaseLua.TryExecuteAsync` → `db.ScriptEvaluateAsync`
+(`BaseLua.cs:114-135`). What is missing is a path from the consumer down to it. That is precisely
+the gap recorded in `project_sync_api_deprecation_blocked`, and it is the entire remaining job.
+
+**The gate must be a receive-side reproduction, and it does not exist yet.** It has to be written
+before it can gate anything.
+
+## Revised delivery
+
+Task 1 is done and keeps its value independently. What follows is re-scoped.
+
+| task | scope | status |
+|---|---|---|
+| 1 | `ReceiveMessageAsync` on the interface + 4 decorators + 6 temporary transport bodies | **done** (`985080c6`, `1b9772a5`) |
+| 2 | Move the de-queue cap into the worker loop: `IMessageProcessing` returns something `MainLoop` waits on, completing when ready for the next de-queue | **re-specified, not started** |
+| 3 | Redis `ReceiveMessageQueryHandler` + work-sub genuinely async, on the existing `DequeueLua.ExecuteAsync` | unchanged in intent |
+| 4 | **New:** a receive-side starvation reproduction, plus the cap assertion below. Replaces the send-side gate | **rewritten** |
+| 5-7 | SqlServer / PostgreSQL / Memory async receive | **re-scope or drop — see below** |
+
+### Task 4 must assert two things
+
+1. **Starvation, receive-side.** A capped pool with a consumer under load, showing the sync receive
+   timing out and the async receive not. Needs writing from scratch; the send-side test is not a
+   template for it beyond the pool-capping technique.
+2. **The cap holds.** Peak concurrent in-flight de-queues never exceeds the configured worker
+   count, driven through a transport whose receive genuinely suspends. Nothing in the repo can
+   currently catch this: every transport body task 1 added returns a completed `ValueTask`, so the
+   15.9M runaway passes all 1109 unit tests and the full Memory integration suite.
+
+   This test must fail *fast* rather than by exhausting memory — bound the run and abort once peak
+   exceeds a small multiple of the worker count. The unbounded version is what killed the machine.
+
+### Tasks 5-7 need justification they do not currently have
+
+The original reasoning was "all six transports for consistency". Given correction 1, a relational
+transport's sync ADO receive also runs on a dedicated thread and also frees no pool thread, so the
+benefit reduces to whichever of them has SE.Redis's sync-over-async completion problem. That is a
+claim about `Microsoft.Data.SqlClient` and `Npgsql`, and nobody has measured it.
+
+Recommendation: **hold 5-7** until the task 4 gate exists and can be pointed at each transport.
+Ship Redis, then extend on evidence. This also keeps the breaking-change surface smaller.
+
+## Invariants unchanged from the original spec
+
+The sections `The IQueueWait.WaitAsync contract`, `Invariants each async implementation must
+preserve`, `Error handling` and `Non-goals` in the original document are unaffected by these
+corrections and still apply.
+
+## What this revision costs
+
+PR 2 gets smaller in transports and larger in the consumer. The `IMessageProcessing` change is a
+new breaking change beyond the interface additions already accepted, and it touches the sync
+consumer path as well as the async one, so `MessageProcessing` (the sync sibling) needs a
+compatible shape even though nothing about it changes behaviourally.
+
+## Process note
+
+Two rulings on task 2 were wrong, and both failed the same way: I asserted a property of code I had
+not fully read, then reasoned forward from it. What held up in this project was measured —
+the 15.9M counter, the 0/27 thread probe, the mechanical decorator diff. What did not hold up was
+reasoned. For the remaining tasks, the threading and backpressure claims get a probe before they
+get a design.

--- a/docs/superpowers/specs/2026-09-08-async-receive-path-design.md
+++ b/docs/superpowers/specs/2026-09-08-async-receive-path-design.md
@@ -1,6 +1,12 @@
 # Async receive path — design
 
-Issue: #256. Date: 2026-09-08. Status: approved, not started.
+Issue: #256. Date: 2026-09-08. Status: **partly superseded — read the revision first.**
+
+> ⚠️ `2026-09-08-async-receive-path-design-revision-1.md` corrects this document. The
+> threading analysis in *The problem* and *What the issue understated* is wrong: the receive
+> runs on a dedicated `LongRunning` worker thread, not a pool thread (measured, 0/27), so it
+> frees no pool thread. The delivery plan and the task 4 gate changed as a result. The
+> `WaitAsync` contract, invariants, error handling and non-goals below are unaffected.
 
 ## The problem
 


### PR DESCRIPTION
Closes part of #256 — the async receive path, for core and the Redis transport.

## What this does

`IReceiveMessages` gains an async twin, the async consumer awaits it, and the Redis transport implements it for real — awaiting `ScriptEvaluateAsync` for the de-queue and awaiting the work-signal wait. The other five transports get a synchronous-inside-async implementation for now.

## Why

The value is narrower than "async is faster", and worth stating precisely.

Consumers run their loop on a dedicated thread (`TaskCreationOptions.LongRunning`), so a blocking receive never occupied a thread-pool thread — measured at zero of twenty-seven receives on the pool. What starves is StackExchange.Redis itself: since 3.x it has no socket thread pool of its own, and a synchronous `ScriptEvaluate` needs a .NET pool thread to run the completion that satisfies its own blocking wait. Under pool pressure that completion arrives after `syncTimeout`, which is the shape recorded in #161. Awaiting removes the need for a pool thread to satisfy a blocking wait at all.

Against a receive-side starvation reproduction, symptoms drop from 478 to 25 under external pool pressure.

## ⚠️ Breaking

- `IReceiveMessages.ReceiveMessageAsync`, `IQueueWait.WaitAsync` and `IRedisQueueWorkSub.WaitAsync` are new interface members — a custom transport must implement them. Built-in transports are unaffected.
- `IMessageProcessing.Handle()` becomes `HandleAsync()`. Only affects code implementing that interface directly.
- The async consumer emits its receive span as `ReceiveMessageAsync` rather than `ReceiveMessage`. **Metric names are unchanged**, but a dashboard filtering on the old span name silently stops matching.

## What to look at

**`MessageProcessingAsync` and the worker loops — this is the subtle part.** `Worker.MainLoop` is `while (!ShouldExit) { ... }` over what used to be an `async void Handle()`, so the loop iterated at the first suspending await, and the blocking receive was the only thing pacing it. The scheduler's throttle sits *downstream* of the receive in the same synchronous run, so it cannot pace the loop once the receive suspends. Awaiting the receive without moving the cap first produces unbounded concurrent de-queues.

So the cap now lives in the loop: `HandleAsync()` returns a task completing when the processor can de-queue again, and `MainLoop` waits on it. The signal fires where the old `async void` gave control back — after `ProcessMessageAsync.HandleAsync(...)` returns an incomplete task, by which point `SchedulerMessageHandler`'s throttle has already run synchronously. That reproduces the previous pacing exactly, throttle included, and leaves its `return start` contract untouched. `MessageProcessingAsyncPacingTests` pins this; moving the signal ahead of the receive fails them.

**`IQueueWait.WaitAsync` swallows cancellation, deliberately.** `WaitHandle.WaitOne` returns normally on stop where `Task.Delay` throws, and the caller is a poll that found no message — a throw would surface as a rollback of a message that was never received.

**Decorator fidelity.** The async decorators mirror their sync twins; each pair was checked by normalising and diffing to nothing rather than by eye. Redis needed async twins of both receive-query decorators too — `IQueryHandlerAsync<,>` is not covered by the assembly scan that registers `IQueryHandler<,>`, and without them the async path silently stops logging and counting expired messages.

**`ReceiveMessageQueryHandlerAsync` is a near-duplicate on purpose.** One line differs. Factoring the shared body out would mean an abstraction over the single call that differs, and any divergence would surface on only one code path.

## Validation

- Redis integration suite, Windows, same filter Jenkins uses: 47 passed, 0 failed
- 1112 core unit tests; 64 Memory integration tests
- `NoTests.sln -c Release -p:CI=true`: 0 warnings, 0 errors

## Not in this PR

- SQL Server, PostgreSQL and Memory keep their synchronous-inside-async implementations. Whether they benefit depends on whether their ADO providers share SE.Redis's completion behaviour, which nobody has measured — so they wait for evidence rather than being changed on principle.
- The starvation control and gate are excluded from CI by category, alongside the existing send-side diagnostic. Their assertions are calibrated to reproduce the defect rather than to judge the fix, and a zero-symptom bar is unreachable at a six-thread cap with twenty-five workers — raising the cap to sixty-four takes the same scenario to zero. Recalibrating them needs a trustworthy environment and is left for follow-up.
- `[DoNotParallelize]` on the starvation diagnostics is included here because it is a prerequisite for running that category at all: it mutates the process-global thread pool, and this assembly parallelises two deep, so anything running alongside it is starved. CI never runs them, so it costs nothing there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added asynchronous message receiving across supported transports.
  - Redis consumers can await queue notifications without holding a thread during dequeue.
  - Added cancellation support for asynchronous Redis receiving and queue waits.
- **Bug Fixes**
  - Corrected expired-message metrics when multiple receive paths contribute counters.
  - Improved async receive coverage for history, metrics, policies, and tracing.
- **Changes**
  - Message-processing entry points now use `HandleAsync()`.
  - Async receive tracing spans are named `ReceiveMessageAsync`.
- **Documentation**
  - Updated async receive design and implementation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->