### PR TITLE
An async command-handler abstraction for the no-output commands (#284)

### DIFF
--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryCommandHandlerDecoratorAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Decorator/RetryCommandHandlerDecoratorAsyncTests.cs
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using DotNetWorkQueue.Transport.PostgreSQL.Decorator;
+using DotNetWorkQueue.Transport.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Decorator
+{
+    /// <summary>
+    /// The no-output async retry decorator. Mirrors the with-output tests beside it; the two differ
+    /// only in whether the handler returns a value.
+    /// </summary>
+    [TestClass]
+    public class RetryCommandHandlerDecoratorAsyncTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecoratorAsync<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            await sut.HandleAsync(cmd);
+
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.GetOrAddPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync,
+                builder => builder.AddTimeout(System.TimeSpan.FromSeconds(30)));
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecoratorAsync<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            await sut.HandleAsync(cmd);
+
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            policies.Registry.Returns(new ResiliencePipelineRegistry<string>());
+
+            var sut = new RetryCommandHandlerDecoratorAsync<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            await sut.HandleAsync(cmd);
+
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueInit.cs
@@ -232,6 +232,8 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
 
             container.RegisterDecorator(typeof(ICommandHandler<>),
                 typeof(RetryCommandHandlerDecorator<>), LifeStyles.Singleton);
+            container.RegisterDecorator(typeof(ICommandHandlerAsync<>),
+                typeof(RetryCommandHandlerDecoratorAsync<>), LifeStyles.Singleton);
 
             container.RegisterDecorator(typeof(ICommandHandlerWithOutputAsync<,>),
                 typeof(RetryCommandHandlerOutputDecoratorAsync<,>), LifeStyles.Singleton);

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryCommandHandlerDecoratorAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/RetryCommandHandlerDecoratorAsync.cs
@@ -1,0 +1,73 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Validation;
+using Polly;
+
+namespace DotNetWorkQueue.Transport.PostgreSQL.Decorator
+{
+    /// <inheritdoc />
+    internal class RetryCommandHandlerDecoratorAsync<TCommand> : ICommandHandlerAsync<TCommand>
+    {
+        private readonly ICommandHandlerAsync<TCommand> _decorated;
+        private readonly IPolicies _policies;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryCommandHandlerDecoratorAsync{TCommand}" /> class.
+        /// </summary>
+        /// <param name="decorated">The decorated handler.</param>
+        /// <param name="policies">The policies.</param>
+        public RetryCommandHandlerDecoratorAsync(ICommandHandlerAsync<TCommand> decorated,
+            IPolicies policies)
+        {
+            Guard.NotNull(decorated);
+            Guard.NotNull(policies);
+
+            _decorated = decorated;
+            _policies = policies;
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(TCommand command)
+        {
+            //IRetrySkippable is deliberately not honoured here, matching the synchronous no-output
+            //decorator. Only the two send commands implement it, and those run through the
+            //with-output handler - so a check here would be dead code today, and adding it to one
+            //side would make the same command retry differently depending on which path called it.
+            ResiliencePipeline pipeline = null;
+            try
+            {
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync, out pipeline);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                await pipeline.ExecuteAsync(async _ => await _decorated.HandleAsync(command).ConfigureAwait(false)).ConfigureAwait(false);
+            else
+                await _decorated.HandleAsync(command).ConfigureAwait(false);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryCommandHandlerDecoratorAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/RetryCommandHandlerDecoratorAsyncTests.cs
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Transport.SQLite.Decorator;
+using DotNetWorkQueue.Transport.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
+{
+    /// <summary>
+    /// The no-output async retry decorator. Mirrors the with-output tests beside it; the two differ
+    /// only in whether the handler returns a value.
+    /// </summary>
+    [TestClass]
+    public class RetryCommandHandlerDecoratorAsyncTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecoratorAsync<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            await sut.HandleAsync(cmd);
+
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.GetOrAddPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync,
+                builder => builder.AddTimeout(System.TimeSpan.FromSeconds(30)));
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecoratorAsync<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            await sut.HandleAsync(cmd);
+
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            policies.Registry.Returns(new ResiliencePipelineRegistry<string>());
+
+            var sut = new RetryCommandHandlerDecoratorAsync<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            await sut.HandleAsync(cmd);
+
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueInit.cs
@@ -68,6 +68,8 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
 
             container.RegisterDecorator(typeof(ICommandHandler<>),
                 typeof(RetryCommandHandlerDecorator<>), LifeStyles.Singleton);
+            container.RegisterDecorator(typeof(ICommandHandlerAsync<>),
+                typeof(RetryCommandHandlerDecoratorAsync<>), LifeStyles.Singleton);
 
             container.RegisterDecorator(typeof(ICommandHandlerWithOutputAsync<,>),
                 typeof(RetryCommandHandlerOutputDecoratorAsync<,>), LifeStyles.Singleton);

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryCommandHandlerDecoratorAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/RetryCommandHandlerDecoratorAsync.cs
@@ -1,0 +1,74 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Validation;
+using Polly;
+
+namespace DotNetWorkQueue.Transport.SQLite.Decorator
+{
+    /// <inheritdoc />
+    internal class RetryCommandHandlerDecoratorAsync<TCommand> : ICommandHandlerAsync<TCommand>
+    {
+        private readonly ICommandHandlerAsync<TCommand> _decorated;
+        private readonly IPolicies _policies;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryCommandHandlerDecoratorAsync{TCommand}" /> class.
+        /// </summary>
+        /// <param name="decorated">The decorated handler.</param>
+        /// <param name="policies">The policies.</param>
+        public RetryCommandHandlerDecoratorAsync(ICommandHandlerAsync<TCommand> decorated,
+            IPolicies policies)
+        {
+            Guard.NotNull(decorated);
+            Guard.NotNull(policies);
+
+            _decorated = decorated;
+            _policies = policies;
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(TCommand command)
+        {
+            //IRetrySkippable is deliberately not honoured here, matching the synchronous no-output
+            //decorator. Only the two send commands implement it, and those run through the
+            //with-output handler - so a check here would be dead code today, and adding it to one
+            //side would make the same command retry differently depending on which path called it.
+            ResiliencePipeline pipeline = null;
+            try
+            {
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync, out pipeline);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                await pipeline.ExecuteAsync(async _ => await _decorated.HandleAsync(command).ConfigureAwait(false)).ConfigureAwait(false);
+            else
+                await _decorated.HandleAsync(command).ConfigureAwait(false);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Shared/ICommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Shared/ICommandHandlerAsync.cs
@@ -1,0 +1,41 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+
+namespace DotNetWorkQueue.Transport.Shared
+{
+    /// <summary>
+    /// Handles a command that produces no output, without blocking a thread.
+    /// </summary>
+    /// <typeparam name="TCommand">The type of the command.</typeparam>
+    /// <remarks>
+    /// The asynchronous twin of <see cref="ICommandHandler{TCommand}"/>, and the no-output sibling of
+    /// <see cref="ICommandHandlerWithOutputAsync{TCommand, TOutput}"/>.
+    ///
+    /// No cancellation token, deliberately: neither of the two async handler abstractions already
+    /// here takes one, and cancellation is observed at the queue level rather than per command. A
+    /// token on this one alone would be the inconsistency.
+    /// </remarks>
+    public interface ICommandHandlerAsync<in TCommand>
+    {
+        /// <summary>Handles the specified command.</summary>
+        /// <param name="command">The command.</param>
+        Task HandleAsync(TCommand command);
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryCommandHandlerDecoratorAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Decorator/RetryCommandHandlerDecoratorAsyncTests.cs
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using DotNetWorkQueue.Transport.SqlServer.Decorator;
+using DotNetWorkQueue.Transport.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Polly;
+using Polly.Registry;
+
+namespace DotNetWorkQueue.Transport.SqlServer.Tests.Decorator
+{
+    /// <summary>
+    /// The no-output async retry decorator. Mirrors the with-output tests beside it; the two differ
+    /// only in whether the handler returns a value.
+    /// </summary>
+    [TestClass]
+    public class RetryCommandHandlerDecoratorAsyncTests
+    {
+        public sealed class FakeCommand { }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecoratorAsync<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            await sut.HandleAsync(cmd);
+
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.GetOrAddPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync,
+                builder => builder.AddTimeout(System.TimeSpan.FromSeconds(30)));
+            policies.Registry.Returns(registry);
+
+            var sut = new RetryCommandHandlerDecoratorAsync<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            await sut.HandleAsync(cmd);
+
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<FakeCommand>>();
+            var policies = Substitute.For<IPolicies>();
+            policies.Registry.Returns(new ResiliencePipelineRegistry<string>());
+
+            var sut = new RetryCommandHandlerDecoratorAsync<FakeCommand>(decorated, policies);
+            var cmd = new FakeCommand();
+
+            await sut.HandleAsync(cmd);
+
+            await decorated.Received(1).HandleAsync(cmd);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueInit.cs
@@ -207,6 +207,8 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
 
             container.RegisterDecorator(typeof(ICommandHandler<>),
                 typeof(RetryCommandHandlerDecorator<>), LifeStyles.Singleton);
+            container.RegisterDecorator(typeof(ICommandHandlerAsync<>),
+                typeof(RetryCommandHandlerDecoratorAsync<>), LifeStyles.Singleton);
 
             container.RegisterDecorator(typeof(ICommandHandlerWithOutputAsync<,>),
                 typeof(RetryCommandHandlerOutputDecoratorAsync<,>), LifeStyles.Singleton);

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryCommandHandlerDecoratorAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Decorator/RetryCommandHandlerDecoratorAsync.cs
@@ -1,0 +1,73 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using DotNetWorkQueue.Validation;
+using Polly;
+
+namespace DotNetWorkQueue.Transport.SqlServer.Decorator
+{
+    /// <inheritdoc />
+    internal class RetryCommandHandlerDecoratorAsync<TCommand> : ICommandHandlerAsync<TCommand>
+    {
+        private readonly ICommandHandlerAsync<TCommand> _decorated;
+        private readonly IPolicies _policies;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryCommandHandlerDecoratorAsync{TCommand}" /> class.
+        /// </summary>
+        /// <param name="decorated">The decorated handler.</param>
+        /// <param name="policies">The policies.</param>
+        public RetryCommandHandlerDecoratorAsync(ICommandHandlerAsync<TCommand> decorated,
+            IPolicies policies)
+        {
+            Guard.NotNull(decorated);
+            Guard.NotNull(policies);
+
+            _decorated = decorated;
+            _policies = policies;
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(TCommand command)
+        {
+            //IRetrySkippable is deliberately not honoured here, matching the synchronous no-output
+            //decorator. Only the two send commands implement it, and those run through the
+            //with-output handler - so a check here would be dead code today, and adding it to one
+            //side would make the same command retry differently depending on which path called it.
+            ResiliencePipeline pipeline = null;
+            try
+            {
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.RetryCommandHandlerAsync, out pipeline);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before the last handler call.
+                // Fall through to direct handler — same semantics as the "no policy" branch.
+            }
+
+            if (pipeline != null)
+                await pipeline.ExecuteAsync(async _ => await _decorated.HandleAsync(command).ConfigureAwait(false)).ConfigureAwait(false);
+            else
+                await _decorated.HandleAsync(command).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
Foundation for #284. First of three PRs into one release.

**Nothing consumes this yet**, so it cannot change behaviour. That is deliberate — the conversions land separately, where they can be reviewed as behaviour changes rather than buried in a wide diff.

## Why a new abstraction

#284's measurement pass found that three of the six calls it tracks — the poison handler, `Remove`, and the history writes — reach the transport through `ICommandHandler<TCommand>`. That returns `void`, so it cannot be awaited. The only async handler abstraction in the codebase is `ICommandHandlerWithOutputAsync`, added for the send path, and these commands have no output to carry.

So this adds the missing no-output sibling:

```csharp
public interface ICommandHandlerAsync<in TCommand>
{
    Task HandleAsync(TCommand command);
}
```

## Decisions worth a reviewer's attention

**No cancellation token.** Neither `ICommandHandlerWithOutputAsync` nor `IQueryHandlerAsync` takes one, and cancellation is observed at the queue level. A token on this interface alone would be the inconsistency, not the fix.

**The retry decorators deliberately do not honour `IRetrySkippable`.** This looks like an omission next to the async *with-output* decorator, which does check it — so the reasoning is in a comment at the call site to stop it being "fixed" later. Only `RelationalSendMessageCommand` and `RelationalSendMessageCommandBatch` implement that interface, and both run through the with-output handler. A check here would be dead code today, and adding it to one side would make the same command retry differently depending on which path called it. The sync no-output decorator does not check it either, so this matches its own twin rather than its async cousin.

**Registering an open-generic decorator with nothing to decorate is safe** — container verification passes in all three transport suites. Worth stating because it is the obvious thing to doubt about an inert PR.

## What is here

- `ICommandHandlerAsync<TCommand>` in `Transport.Shared`
- `RetryCommandHandlerDecoratorAsync<TCommand>` for SQL Server, PostgreSQL and SQLite, each mirroring the sync decorator already beside it, registered next to it
- Tests for each: pipeline registered, no pipeline registered, and the disposed-registry shutdown race the sync versions already cover

No changelog entry. Nothing here is consumer-visible until something implements the interface; the entry belongs with the behaviour change.

## Validation

1118 core unit tests, 197 SQL Server, 182 PostgreSQL, 224 SQLite. `NoTests.sln -c Release -p:CI=true` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous command-handler support across PostgreSQL, SQLite, and SQL Server transports.
  * Added automatic retry handling for asynchronous command handlers when a retry policy is configured.
  * Added safe direct execution when no retry policy is available or the policy registry is unavailable.

* **Tests**
  * Added coverage for configured retries, missing policies, and disposed policy registries across supported transports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->