### PR TITLE
Move the relational ADO abstraction onto System.Data.Common (#286)

### DIFF
--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using AutoFixture;
 using AutoFixture.AutoNSubstitute;
 using DotNetWorkQueue.Transport.PostgreSQL.Basic;
@@ -124,23 +125,23 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic.CommandHandler
             public SetJobLastKnownEventCommandHandler Handler { get; set; }
             public PostgreSqlCommandStringCache CommandCache { get; set; }
             public IDbConnectionFactory DbConnectionFactory { get; set; }
-            public IDbConnection Connection { get; set; }
-            public IDbCommand Command { get; set; }
-            public System.Collections.Generic.List<IDbDataParameter> Parameters { get; set; }
+            public DbConnection Connection { get; set; }
+            public DbCommand Command { get; set; }
+            public System.Collections.Generic.List<DbParameter> Parameters { get; set; }
         }
 
         private static HandleFixture CreateHandleFixture()
         {
             var commandCache = CreateCommandCache();
             var dbConnectionFactory = Substitute.For<IDbConnectionFactory>();
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var parametersList = new System.Collections.Generic.List<IDbDataParameter>();
-            var parameters = Substitute.For<IDataParameterCollection>();
-            parameters.Add(Arg.Do<object>(p => parametersList.Add((IDbDataParameter)p)));
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var parametersList = new System.Collections.Generic.List<DbParameter>();
+            var parameters = Substitute.For<DbParameterCollection>();
+            parameters.Add(Arg.Do<object>(p => parametersList.Add((DbParameter)p)));
 
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             connection.CreateCommand().Returns(command);
             dbConnectionFactory.Create().Returns(connection);
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandPrepareHandler/DeleteTableCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandPrepareHandler/DeleteTableCommandPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
@@ -40,7 +41,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(DeleteTableCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DeleteTableCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText =
                 _commandCache.GetCommand(commandType, command.Table.ToLowerInvariant());

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandPrepareHandler/ResetHeartBeatCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/CommandPrepareHandler/ResetHeartBeatCommandPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
@@ -48,7 +49,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.CommandPrepareHandler
         /// <param name="command">The command.</param>
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
-        public void Handle(ResetHeartBeatCommand<long> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(ResetHeartBeatCommand<long> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.ResetHeartbeat);
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/DbConnectionFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/DbConnectionFactory.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Validation;
 using Npgsql;
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             _connectionInformation = connectionInformation;
         }
         /// <inheritdoc />
-        public IDbConnection Create()
+        public DbConnection Create()
         {
             return new NpgsqlConnection(_connectionInformation.ConnectionString);
         }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/QueryPrepareHandler/FindErrorRecordsToDeleteQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/QueryPrepareHandler/FindErrorRecordsToDeleteQueryPrepareHandler.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -56,7 +57,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.QueryPrepareHandler
             _getTime = timeFactory.Create();
         }
         /// <inheritdoc />
-        public void Handle(FindErrorMessagesToDeleteQuery<long> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(FindErrorMessagesToDeleteQuery<long> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/QueryPrepareHandler/FindExpiredRecordsToDeleteQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/QueryPrepareHandler/FindExpiredRecordsToDeleteQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -54,7 +55,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.QueryPrepareHandler
         /// <param name="query">The query.</param>
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
-        public void Handle(FindExpiredMessagesToDeleteQuery<long> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(FindExpiredMessagesToDeleteQuery<long> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/QueryPrepareHandler/FindRecordsToResetByHeartBeatQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/QueryPrepareHandler/FindRecordsToResetByHeartBeatQueryPrepareHandler.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
@@ -61,7 +62,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic.QueryPrepareHandler
         /// <param name="query">The query.</param>
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
-        public void Handle(FindMessagesToResetByHeartBeatQuery<long> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(FindMessagesToResetByHeartBeatQuery<long> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText =
                 _commandCache.GetCommand(commandType);

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/GetColumnNamesFromTableQueryPrepareDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/GetColumnNamesFromTableQueryPrepareDecorator.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -43,7 +44,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Decorator
         }
 
         /// <inheritdoc />
-        public void Handle(GetColumnNamesFromTableQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetColumnNamesFromTableQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             //table name needs to be lower case
             _decorated.Handle(new GetColumnNamesFromTableQuery(query.ConnectionString, query.TableName.ToLowerInvariant()), dbCommand,

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/GetTableExistsQueryPrepareDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/GetTableExistsQueryPrepareDecorator.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -41,7 +42,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Decorator
         }
 
         /// <inheritdoc />
-        public void Handle(GetTableExistsQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetTableExistsQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             //table name needs to be lower case
             _decorated.Handle(new GetTableExistsQuery(query.ConnectionString, query.TableName.ToLowerInvariant()), dbCommand, commandType);

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/GetTableExistsTransactionQueryPrepareDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Decorator/GetTableExistsTransactionQueryPrepareDecorator.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -41,7 +42,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Decorator
         }
 
         /// <inheritdoc />
-        public void Handle(GetTableExistsTransactionQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetTableExistsTransactionQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             //table name needs to be lower case
             _decorated.Handle(new GetTableExistsTransactionQuery(query.Connection,

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/DashboardRequeueAllErrorMessagesCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/DashboardRequeueAllErrorMessagesCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler;
@@ -75,7 +76,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             // Should call Handle 3 times: DashboardRequeueAllErrors, ErrorTracking, MetaDataErrors
             prepareCommand.Received(3).Handle(
                 Arg.Any<DashboardRequeueAllErrorMessagesCommand>(),
-                Arg.Any<IDbCommand>(),
+                Arg.Any<DbCommand>(),
                 Arg.Any<CommandStringTypes>());
         }
 
@@ -91,7 +92,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             // Should call Handle 4 times: DashboardRequeueAllErrors, ErrorTracking, StatusTable, MetaDataErrors
             prepareCommand.Received(4).Handle(
                 Arg.Any<DashboardRequeueAllErrorMessagesCommand>(),
-                Arg.Any<IDbCommand>(),
+                Arg.Any<DbCommand>(),
                 Arg.Any<CommandStringTypes>());
         }
 
@@ -135,19 +136,19 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
             prepareCommand.Received(1).Handle(
                 Arg.Any<DashboardRequeueAllErrorMessagesCommand>(),
-                Arg.Any<IDbCommand>(),
+                Arg.Any<DbCommand>(),
                 CommandStringTypes.DashboardRequeueAllErrors);
             prepareCommand.Received(1).Handle(
                 Arg.Any<DashboardRequeueAllErrorMessagesCommand>(),
-                Arg.Any<IDbCommand>(),
+                Arg.Any<DbCommand>(),
                 CommandStringTypes.DashboardRequeueAllErrors_ErrorTracking);
             prepareCommand.Received(1).Handle(
                 Arg.Any<DashboardRequeueAllErrorMessagesCommand>(),
-                Arg.Any<IDbCommand>(),
+                Arg.Any<DbCommand>(),
                 CommandStringTypes.DashboardRequeueAllErrors_StatusTable);
             prepareCommand.Received(1).Handle(
                 Arg.Any<DashboardRequeueAllErrorMessagesCommand>(),
-                Arg.Any<IDbCommand>(),
+                Arg.Any<DbCommand>(),
                 CommandStringTypes.DashboardRequeueAllErrors_MetaDataErrors);
         }
 
@@ -160,7 +161,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
             prepareCommand.DidNotReceive().Handle(
                 Arg.Any<DashboardRequeueAllErrorMessagesCommand>(),
-                Arg.Any<IDbCommand>(),
+                Arg.Any<DbCommand>(),
                 CommandStringTypes.DashboardRequeueAllErrors_StatusTable);
         }
 
@@ -178,7 +179,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
         private static (DashboardRequeueAllErrorMessagesCommandHandler handler,
             IPrepareCommandHandler<DashboardRequeueAllErrorMessagesCommand> prepareCommand,
-            IDbCommand dbCommand)
+            DbCommand dbCommand)
             CreateHandlerWithMocks(bool enableStatusTable)
         {
             var (handler, prepareCommand, dbCommand) = CreateHandlerWithMocks(enableStatusTable, out _, out _, out _);
@@ -187,10 +188,10 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
         private static (DashboardRequeueAllErrorMessagesCommandHandler handler,
             IPrepareCommandHandler<DashboardRequeueAllErrorMessagesCommand> prepareCommand,
-            IDbCommand dbCommand)
+            DbCommand dbCommand)
             CreateHandlerWithMocks(bool enableStatusTable,
-                out IDbConnection connection,
-                out IDbTransaction transaction,
+                out DbConnection connection,
+                out DbTransaction transaction,
                 out ITransactionWrapper transactionWrapper)
         {
             var optionsFactory = Substitute.For<ITransportOptionsFactory>();
@@ -198,11 +199,11 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             options.EnableStatusTable.Returns(enableStatusTable);
             optionsFactory.Create().Returns(options);
 
-            connection = Substitute.For<IDbConnection>();
-            var dbCommand = Substitute.For<IDbCommand>();
+            connection = Substitute.For<DbConnection>();
+            var dbCommand = Substitute.For<DbCommand>();
             connection.CreateCommand().Returns(dbCommand);
 
-            transaction = Substitute.For<IDbTransaction>();
+            transaction = Substitute.For<DbTransaction>();
             transactionWrapper = Substitute.For<ITransactionWrapper>();
             transactionWrapper.BeginTransaction().Returns(transaction);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/DoesJobExistQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/DoesJobExistQueryHandlerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
@@ -17,10 +18,10 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         {
             var fixture = CreateFixture();
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
 
             connection.CreateCommand().Returns(command);
             reader.Read().Returns(false);
@@ -29,7 +30,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             // Table does not exist
             fixture.TableExists.Handle(Arg.Any<GetTableExistsQuery>()).Returns(false);
 
-            var query = new DoesJobExistQuery<IDbConnection, IDbTransaction>(
+            var query = new DoesJobExistQuery<DbConnection, DbTransaction>(
                 "testJob", DateTimeOffset.UtcNow, connection, transaction);
 
             var result = fixture.Handler.Handle(query);
@@ -42,10 +43,10 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         {
             var fixture = CreateFixture();
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
 
             connection.CreateCommand().Returns(command);
             reader.Read().Returns(true, false);
@@ -53,7 +54,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             fixture.ReadColumn.ReadAsInt32(CommandStringTypes.DoesJobExist, 0, reader)
                 .Returns((int)QueueStatuses.Waiting);
 
-            var query = new DoesJobExistQuery<IDbConnection, IDbTransaction>(
+            var query = new DoesJobExistQuery<DbConnection, DbTransaction>(
                 "testJob", DateTimeOffset.UtcNow, connection, transaction);
 
             var result = fixture.Handler.Handle(query);
@@ -67,16 +68,16 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             var fixture = CreateFixture();
             var scheduledTime = DateTimeOffset.UtcNow;
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var command = Substitute.For<IDbCommand>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var command = Substitute.For<DbCommand>();
 
             // First reader: no rows (status query)
-            var reader1 = Substitute.For<IDataReader>();
+            var reader1 = Substitute.For<DbDataReader>();
             reader1.Read().Returns(false);
 
             // Second reader: has row with matching schedule time
-            var reader2 = Substitute.For<IDataReader>();
+            var reader2 = Substitute.For<DbDataReader>();
             reader2.Read().Returns(true, false);
 
             connection.CreateCommand().Returns(command);
@@ -87,7 +88,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             fixture.ReadColumn.ReadAsDateTimeOffset(CommandStringTypes.GetJobLastScheduleTime, 0, reader2)
                 .Returns(scheduledTime);
 
-            var query = new DoesJobExistQuery<IDbConnection, IDbTransaction>(
+            var query = new DoesJobExistQuery<DbConnection, DbTransaction>(
                 "testJob", scheduledTime, connection, transaction);
 
             var result = fixture.Handler.Handle(query);
@@ -101,16 +102,16 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             var fixture = CreateFixture();
             var scheduledTime = DateTimeOffset.UtcNow;
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var command = Substitute.For<IDbCommand>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var command = Substitute.For<DbCommand>();
 
             // First reader: no rows
-            var reader1 = Substitute.For<IDataReader>();
+            var reader1 = Substitute.For<DbDataReader>();
             reader1.Read().Returns(false);
 
             // Second reader: has row with different schedule time
-            var reader2 = Substitute.For<IDataReader>();
+            var reader2 = Substitute.For<DbDataReader>();
             reader2.Read().Returns(true, false);
 
             connection.CreateCommand().Returns(command);
@@ -120,7 +121,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             fixture.ReadColumn.ReadAsDateTimeOffset(CommandStringTypes.GetJobLastScheduleTime, 0, reader2)
                 .Returns(scheduledTime.AddHours(1));
 
-            var query = new DoesJobExistQuery<IDbConnection, IDbTransaction>(
+            var query = new DoesJobExistQuery<DbConnection, DbTransaction>(
                 "testJob", scheduledTime, connection, transaction);
 
             var result = fixture.Handler.Handle(query);
@@ -133,10 +134,10 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         {
             var fixture = CreateFixture();
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
 
             connection.CreateCommand().Returns(command);
             reader.Read().Returns(false);
@@ -145,7 +146,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             // Table does not exist
             fixture.TableExists.Handle(Arg.Any<GetTableExistsQuery>()).Returns(false);
 
-            var query = new DoesJobExistQuery<IDbConnection, IDbTransaction>(
+            var query = new DoesJobExistQuery<DbConnection, DbTransaction>(
                 "testJob", DateTimeOffset.UtcNow, connection, transaction);
 
             var result = fixture.Handler.Handle(query);
@@ -158,16 +159,16 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         {
             var fixture = CreateFixture();
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var command = Substitute.For<IDbCommand>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var command = Substitute.For<DbCommand>();
 
             // First reader: no rows
-            var reader1 = Substitute.For<IDataReader>();
+            var reader1 = Substitute.For<DbDataReader>();
             reader1.Read().Returns(false);
 
             // Second reader: no rows in job table either
-            var reader2 = Substitute.For<IDataReader>();
+            var reader2 = Substitute.For<DbDataReader>();
             reader2.Read().Returns(false);
 
             connection.CreateCommand().Returns(command);
@@ -175,7 +176,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
             fixture.TableExists.Handle(Arg.Any<GetTableExistsQuery>()).Returns(true);
 
-            var query = new DoesJobExistQuery<IDbConnection, IDbTransaction>(
+            var query = new DoesJobExistQuery<DbConnection, DbTransaction>(
                 "testJob", DateTimeOffset.UtcNow, connection, transaction);
 
             var result = fixture.Handler.Handle(query);
@@ -188,11 +189,11 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         {
             var fixture = CreateFixture();
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
             var transactionWrapper = Substitute.For<ITransactionWrapper>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
 
             fixture.DbConnectionFactory.Create().Returns(connection);
             fixture.TransactionFactory.Create(connection).Returns(transactionWrapper);
@@ -204,7 +205,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             // Table doesn't exist
             fixture.TableExists.Handle(Arg.Any<GetTableExistsQuery>()).Returns(false);
 
-            var query = new DoesJobExistQuery<IDbConnection, IDbTransaction>(
+            var query = new DoesJobExistQuery<DbConnection, DbTransaction>(
                 "testJob", DateTimeOffset.UtcNow);
 
             var result = fixture.Handler.Handle(query);
@@ -219,10 +220,10 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         {
             var fixture = CreateFixture();
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
 
             connection.CreateCommand().Returns(command);
             reader.Read().Returns(true, false);
@@ -231,7 +232,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             fixture.ReadColumn.ReadAsInt32(CommandStringTypes.DoesJobExist, 0, reader)
                 .Returns((int)QueueStatuses.Processing);
 
-            var query = new DoesJobExistQuery<IDbConnection, IDbTransaction>(
+            var query = new DoesJobExistQuery<DbConnection, DbTransaction>(
                 "testJob", DateTimeOffset.UtcNow, connection, transaction);
 
             var result = fixture.Handler.Handle(query);
@@ -251,10 +252,10 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             tableNameHelper.JobTableName.Returns("JobTable");
             var dbConnectionFactory = Substitute.For<IDbConnectionFactory>();
             var transactionFactory = Substitute.For<ITransactionFactory>();
-            var prepareQuery = Substitute.For<IPrepareQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses>>();
+            var prepareQuery = Substitute.For<IPrepareQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses>>();
             var readColumn = Substitute.For<IReadColumn>();
 
-            var handler = new DoesJobExistQueryHandler<IDbConnection, IDbTransaction>(
+            var handler = new DoesJobExistQueryHandler<DbConnection, DbTransaction>(
                 commandCache,
                 connectionInfo,
                 tableExists,
@@ -293,14 +294,14 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
 
         private class TestFixture
         {
-            public DoesJobExistQueryHandler<IDbConnection, IDbTransaction> Handler { get; set; }
+            public DoesJobExistQueryHandler<DbConnection, DbTransaction> Handler { get; set; }
             public CommandStringCache CommandCache { get; set; }
             public IConnectionInformation ConnectionInfo { get; set; }
             public IQueryHandler<GetTableExistsQuery, bool> TableExists { get; set; }
             public ITableNameHelper TableNameHelper { get; set; }
             public IDbConnectionFactory DbConnectionFactory { get; set; }
             public ITransactionFactory TransactionFactory { get; set; }
-            public IPrepareQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> PrepareQuery { get; set; }
+            public IPrepareQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> PrepareQuery { get; set; }
             public IReadColumn ReadColumn { get; set; }
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/PurgeMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/PurgeMessageHistoryHandlerTests.cs
@@ -63,12 +63,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             return (new PurgeMessageHistoryHandler(factory, tableNameHelper), factory, options);
         }
 
-        private static (IDbConnection connection, IDbCommand command) SetupConnection(IDbConnectionFactory factory)
+        private static (DbConnection connection, DbCommand command) SetupConnection(IDbConnectionFactory factory)
         {
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var parameters = Substitute.For<IDataParameterCollection>();
-            var parameter = Substitute.For<IDbDataParameter>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var parameters = Substitute.For<DbParameterCollection>();
+            var parameter = Substitute.For<DbParameter>();
             command.CreateParameter().Returns(parameter);
             command.Parameters.Returns(parameters);
             connection.CreateCommand().Returns(command);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardConfigurationQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardConfigurationQueryHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
@@ -34,15 +35,15 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.IsNull(result);
         }
 
-        private static (IQueryHandler<GetDashboardConfigurationQuery, byte[]> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(bool hasRows)
+        private static (IQueryHandler<GetDashboardConfigurationQuery, byte[]> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(bool hasRows)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardConfigurationQuery, byte[]>>();
             var readColumn = Substitute.For<IReadColumn>();
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
             reader.Read().Returns(hasRows, false);
 
             factory.Create().Returns(connection);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardErrorMessageCountQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardErrorMessageCountQueryHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
@@ -33,15 +34,15 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.AreEqual(0L, result);
         }
 
-        private static (IQueryHandler<GetDashboardErrorMessageCountQuery, long> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(bool hasRows)
+        private static (IQueryHandler<GetDashboardErrorMessageCountQuery, long> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(bool hasRows)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardErrorMessageCountQuery, long>>();
             var readColumn = Substitute.For<IReadColumn>();
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
             reader.Read().Returns(hasRows, false);
 
             factory.Create().Returns(connection);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardErrorMessagesQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardErrorMessagesQueryHandlerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
@@ -44,15 +45,15 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.IsEmpty(result);
         }
 
-        private static (IQueryHandler<GetDashboardErrorMessagesQuery, IReadOnlyList<DashboardErrorMessage>> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(int rowCount)
+        private static (IQueryHandler<GetDashboardErrorMessagesQuery, IReadOnlyList<DashboardErrorMessage>> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(int rowCount)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardErrorMessagesQuery, IReadOnlyList<DashboardErrorMessage>>>();
             var readColumn = Substitute.For<IReadColumn>();
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
 
             if (rowCount > 0)
                 reader.Read().Returns(true, false);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessageBodyQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessageBodyQueryHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
 using DotNetWorkQueue.Transport.Shared;
@@ -39,15 +40,15 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.IsNull(result);
         }
 
-        private static (IQueryHandler<GetDashboardMessageBodyQuery, DashboardMessageBody> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(bool hasRows)
+        private static (IQueryHandler<GetDashboardMessageBodyQuery, DashboardMessageBody> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(bool hasRows)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardMessageBodyQuery, DashboardMessageBody>>();
             var readColumn = Substitute.For<IReadColumn>();
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
             reader.Read().Returns(hasRows, false);
 
             factory.Create().Returns(connection);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessageCountQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessageCountQueryHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
@@ -33,15 +34,15 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.AreEqual(0L, result);
         }
 
-        private static (IQueryHandler<GetDashboardMessageCountQuery, long> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(bool hasRows)
+        private static (IQueryHandler<GetDashboardMessageCountQuery, long> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(bool hasRows)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardMessageCountQuery, long>>();
             var readColumn = Substitute.For<IReadColumn>();
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
             reader.Read().Returns(hasRows, false);
 
             factory.Create().Returns(connection);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessageDetailQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessageDetailQueryHandlerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
@@ -41,7 +42,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.IsNull(result);
         }
 
-        private static (IQueryHandler<GetDashboardMessageDetailQuery, DashboardMessage> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(bool hasRows)
+        private static (IQueryHandler<GetDashboardMessageDetailQuery, DashboardMessage> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(bool hasRows)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardMessageDetailQuery, DashboardMessage>>();
@@ -50,9 +51,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             var options = Substitute.For<ITransportOptions>();
             optionsFactory.Create().Returns(options);
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
             reader.Read().Returns(hasRows, false);
 
             factory.Create().Returns(connection);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessageHeadersQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessageHeadersQueryHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
 using DotNetWorkQueue.Transport.Shared;
@@ -36,15 +37,15 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.IsNull(result);
         }
 
-        private static (IQueryHandler<GetDashboardMessageHeadersQuery, DashboardMessageHeaders> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(bool hasRows)
+        private static (IQueryHandler<GetDashboardMessageHeadersQuery, DashboardMessageHeaders> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(bool hasRows)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardMessageHeadersQuery, DashboardMessageHeaders>>();
             var readColumn = Substitute.For<IReadColumn>();
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
             reader.Read().Returns(hasRows, false);
 
             factory.Create().Returns(connection);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessagesQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardMessagesQueryHandlerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
@@ -42,7 +43,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.IsEmpty(result);
         }
 
-        private static (IQueryHandler<GetDashboardMessagesQuery, IReadOnlyList<DashboardMessage>> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(int rowCount)
+        private static (IQueryHandler<GetDashboardMessagesQuery, IReadOnlyList<DashboardMessage>> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(int rowCount)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardMessagesQuery, IReadOnlyList<DashboardMessage>>>();
@@ -51,9 +52,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             var options = Substitute.For<ITransportOptions>();
             optionsFactory.Create().Returns(options);
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
 
             if (rowCount == 0)
                 reader.Read().Returns(false);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
@@ -40,7 +41,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.IsEmpty(result);
         }
 
-        private static (IQueryHandler<GetDashboardStaleMessagesQuery, IReadOnlyList<DashboardMessage>> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(int rowCount)
+        private static (IQueryHandler<GetDashboardStaleMessagesQuery, IReadOnlyList<DashboardMessage>> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(int rowCount)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardStaleMessagesQuery, IReadOnlyList<DashboardMessage>>>();
@@ -49,9 +50,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             var options = Substitute.For<ITransportOptions>();
             optionsFactory.Create().Returns(options);
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
 
             if (rowCount > 0)
                 reader.Read().Returns(true, false);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardStatusCountsQueryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryHandler/GetDashboardStatusCountsQueryHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler;
@@ -43,15 +44,15 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryHandler
             Assert.AreEqual(0L, result.Total);
         }
 
-        private static (IQueryHandler<GetDashboardStatusCountsQuery, DashboardStatusCounts> handler, IReadColumn readColumn, IDataReader reader) CreateHandler(bool hasRows)
+        private static (IQueryHandler<GetDashboardStatusCountsQuery, DashboardStatusCounts> handler, IReadColumn readColumn, DbDataReader reader) CreateHandler(bool hasRows)
         {
             var factory = Substitute.For<IDbConnectionFactory>();
             var prepareQuery = Substitute.For<IPrepareQueryHandler<GetDashboardStatusCountsQuery, DashboardStatusCounts>>();
             var readColumn = Substitute.For<IReadColumn>();
 
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var reader = Substitute.For<IDataReader>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var reader = Substitute.For<DbDataReader>();
             reader.Read().Returns(hasRows, false);
 
             factory.Create().Returns(connection);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryMessageHistoryHandlerTests.cs
@@ -82,7 +82,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         {
             var (handler, factory, _) = Create(enabled: true);
             var (connection, command) = SetupConnection(factory);
-            var reader = Substitute.For<IDataReader>();
+            var reader = Substitute.For<DbDataReader>();
             reader.Read().Returns(false);
             command.ExecuteReader().Returns(reader);
 
@@ -98,7 +98,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         {
             var (handler, factory, _) = Create(enabled: true);
             var (connection, command) = SetupConnection(factory);
-            var reader = Substitute.For<IDataReader>();
+            var reader = Substitute.For<DbDataReader>();
             reader.Read().Returns(false);
             command.ExecuteReader().Returns(reader);
 
@@ -124,12 +124,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             return (new QueryMessageHistoryHandler(factory, tableNameHelper, pagination), factory, options);
         }
 
-        private static (IDbConnection connection, IDbCommand command) SetupConnection(IDbConnectionFactory factory)
+        private static (DbConnection connection, DbCommand command) SetupConnection(IDbConnectionFactory factory)
         {
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var parameters = Substitute.For<IDataParameterCollection>();
-            var parameter = Substitute.For<IDbDataParameter>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var parameters = Substitute.For<DbParameterCollection>();
+            var parameter = Substitute.For<DbParameter>();
             command.CreateParameter().Returns(parameter);
             command.Parameters.Returns(parameters);
             connection.CreateCommand().Returns(command);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DashboardDeleteAllErrorMessagesPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DashboardDeleteAllErrorMessagesPrepareHandlerTests.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandler;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
@@ -58,12 +59,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return new DashboardDeleteAllErrorMessagesPrepareHandler(new FakeCommandStringCache());
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DashboardRequeueErrorMessagePrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DashboardRequeueErrorMessagePrepareHandlerTests.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandler;
@@ -63,12 +64,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return new DashboardRequeueErrorMessagePrepareHandler(new FakeCommandStringCache(), optionsFactory);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DashboardResetStaleMessagePrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DashboardResetStaleMessagePrepareHandlerTests.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandler;
@@ -61,12 +62,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return new DashboardResetStaleMessagePrepareHandler(new FakeCommandStringCache());
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DashboardUpdateMessageBodyPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DashboardUpdateMessageBodyPrepareHandlerTests.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandler;
@@ -70,12 +71,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return new DashboardUpdateMessageBodyPrepareHandler(new FakeCommandStringCache());
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DataParameterCollection.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DataParameterCollection.cs
@@ -1,54 +1,84 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+using System.Data.Common;
 using System.Linq;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareHandler
 {
-    internal class DataParameterCollection : IDataParameterCollection
+    /// <summary>
+    /// An in-memory parameter collection for prepare-handler tests.
+    /// </summary>
+    /// <remarks>
+    /// Derives from <see cref="DbParameterCollection"/> rather than implementing
+    /// <c>IDataParameterCollection</c>, because <see cref="DbCommand.Parameters"/> is typed as the
+    /// abstract class. The convenience members below (<c>Any</c>, <c>First</c>) are what the tests
+    /// actually assert against and are kept unchanged.
+    /// </remarks>
+    internal class DataParameterCollection : DbParameterCollection
     {
-        private readonly List<IDbDataParameter> _parameters = new List<IDbDataParameter>();
+        private readonly List<DbParameter> _parameters = new List<DbParameter>();
 
-        public object this[string parameterName]
+        public override int Count => _parameters.Count;
+        public override object SyncRoot => this;
+
+        public bool Any(Func<DbParameter, bool> predicate) => _parameters.Any(predicate);
+
+        public DbParameter First(Func<DbParameter, bool> predicate) => _parameters.First(predicate);
+
+        public DbParameter First() => _parameters.First();
+
+        public override int Add(object value)
         {
-            get => _parameters.FirstOrDefault(p => p.ParameterName == parameterName);
-            set { }
-        }
-
-        public object this[int index]
-        {
-            get => _parameters[index];
-            set => _parameters[index] = (IDbDataParameter)value;
-        }
-
-        public int Count => _parameters.Count;
-        public bool IsFixedSize => false;
-        public bool IsReadOnly => false;
-        public bool IsSynchronized => false;
-        public object SyncRoot => this;
-
-        public int Add(object value)
-        {
-            _parameters.Add((IDbDataParameter)value);
+            _parameters.Add((DbParameter)value);
             return _parameters.Count - 1;
         }
 
-        public bool Any(System.Func<IDbDataParameter, bool> predicate) => _parameters.Any(predicate);
+        public override void AddRange(Array values)
+        {
+            foreach (var value in values)
+                _parameters.Add((DbParameter)value);
+        }
 
-        public IDbDataParameter First(System.Func<IDbDataParameter, bool> predicate) => _parameters.First(predicate);
+        public override void Clear() => _parameters.Clear();
 
-        public IDbDataParameter First() => _parameters.First();
+        public override bool Contains(string value) => _parameters.Any(p => p.ParameterName == value);
 
-        public void Clear() => _parameters.Clear();
-        public bool Contains(string parameterName) => _parameters.Any(p => p.ParameterName == parameterName);
-        public bool Contains(object value) => _parameters.Contains((IDbDataParameter)value);
-        public void CopyTo(System.Array array, int index) { }
-        public IEnumerator GetEnumerator() => _parameters.GetEnumerator();
-        public int IndexOf(string parameterName) => _parameters.FindIndex(p => p.ParameterName == parameterName);
-        public int IndexOf(object value) => _parameters.IndexOf((IDbDataParameter)value);
-        public void Insert(int index, object value) => _parameters.Insert(index, (IDbDataParameter)value);
-        public void Remove(object value) => _parameters.Remove((IDbDataParameter)value);
-        public void RemoveAt(string parameterName) => _parameters.RemoveAll(p => p.ParameterName == parameterName);
-        public void RemoveAt(int index) => _parameters.RemoveAt(index);
+        public override bool Contains(object value) => _parameters.Contains((DbParameter)value);
+
+        public override void CopyTo(Array array, int index) { }
+
+        public override IEnumerator GetEnumerator() => _parameters.GetEnumerator();
+
+        public override int IndexOf(string parameterName) =>
+            _parameters.FindIndex(p => p.ParameterName == parameterName);
+
+        public override int IndexOf(object value) => _parameters.IndexOf((DbParameter)value);
+
+        public override void Insert(int index, object value) =>
+            _parameters.Insert(index, (DbParameter)value);
+
+        public override void Remove(object value) => _parameters.Remove((DbParameter)value);
+
+        public override void RemoveAt(string parameterName) =>
+            _parameters.RemoveAll(p => p.ParameterName == parameterName);
+
+        public override void RemoveAt(int index) => _parameters.RemoveAt(index);
+
+        protected override DbParameter GetParameter(int index) => _parameters[index];
+
+        protected override DbParameter GetParameter(string parameterName) =>
+            _parameters.FirstOrDefault(p => p.ParameterName == parameterName);
+
+        protected override void SetParameter(int index, DbParameter value) => _parameters[index] = value;
+
+        protected override void SetParameter(string parameterName, DbParameter value)
+        {
+            var index = IndexOf(parameterName);
+            if (index >= 0)
+                _parameters[index] = value;
+            else
+                _parameters.Add(value);
+        }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DataParameterCollection.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/DataParameterCollection.cs
@@ -1,3 +1,21 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardConfigurationPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardConfigurationPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
@@ -34,12 +35,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             Assert.IsEmpty(command.Parameters);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardErrorMessageCountPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardErrorMessageCountPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
@@ -34,12 +35,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             Assert.IsEmpty(command.Parameters);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardErrorMessagesPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardErrorMessagesPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
@@ -38,12 +39,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             Assert.IsTrue(parameters.Any(p => p.ParameterName == "@PageSize"));
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardErrorRetriesPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardErrorRetriesPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
@@ -38,12 +39,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             Assert.AreEqual(42L, param.Value);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardJobsPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardJobsPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
@@ -34,12 +35,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             Assert.IsEmpty(command.Parameters);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessageBodyPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessageBodyPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
@@ -42,12 +43,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return new GetDashboardMessageBodyPrepareHandler(cache);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessageCountPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessageCountPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
@@ -49,12 +50,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             StringAssert.Contains(command.CommandText, "WHERE Status = @Status");
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessageDetailPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessageDetailPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
@@ -45,12 +46,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return new GetDashboardMessageDetailPrepareHandler(cache, optionsFactory);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessageHeadersPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessageHeadersPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
@@ -42,12 +43,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return new GetDashboardMessageHeadersPrepareHandler(cache);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessagesPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardMessagesPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
@@ -73,12 +74,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return new GetDashboardMessagesPrepareHandler(cache, optionsFactory);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
@@ -60,12 +61,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return new GetDashboardStaleMessagesPrepareHandler(cache, optionsFactory);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardStatusCountsPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardStatusCountsPrepareHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
@@ -34,12 +35,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             Assert.IsEmpty(command.Parameters);
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetQueueCountQueryPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetQueueCountQueryPrepareHandlerTests.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
@@ -85,12 +86,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             return factory;
         }
 
-        private static IDbCommand CreateDbCommand()
+        private static DbCommand CreateDbCommand()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
             var parameters = new DataParameterCollection();
             command.Parameters.Returns(parameters);
-            command.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            command.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             return command;
         }
     }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/WriteMessageHistoryHandlerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -159,20 +160,20 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         public void RecordComplete_WithoutStartedUtc_PassesDurationZero()
         {
             var (handler, factory, _) = Create(enabled: true);
-            var connection = Substitute.For<IDbConnection>();
+            var connection = Substitute.For<DbConnection>();
 
-            var allParams = new System.Collections.Generic.List<IDbDataParameter>();
+            var allParams = new System.Collections.Generic.List<DbParameter>();
             // Capture the CommandText of every command created during RecordComplete.
             var capturedCommandTexts = new System.Collections.Generic.List<string>();
 
-            IDbCommand MakeTrackingCommand(bool returnsDbNull = false)
+            DbCommand MakeTrackingCommand(bool returnsDbNull = false)
             {
-                var cmd = Substitute.For<IDbCommand>();
-                var paramCollection = Substitute.For<IDataParameterCollection>();
+                var cmd = Substitute.For<DbCommand>();
+                var paramCollection = Substitute.For<DbParameterCollection>();
                 cmd.Parameters.Returns(paramCollection);
                 cmd.CreateParameter().Returns(_ =>
                 {
-                    var p = Substitute.For<IDbDataParameter>();
+                    var p = Substitute.For<DbParameter>();
                     allParams.Add(p);
                     return p;
                 });
@@ -196,7 +197,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             handler.RecordComplete("q1");
 
             // Assert the @DurationMs parameter was set to 0L (StartedUtc was null → duration = 0).
-            IDbDataParameter durationParam = null;
+            DbParameter durationParam = null;
             foreach (var p in allParams)
             {
                 if ((string)p.ParameterName == "@DurationMs")
@@ -229,18 +230,18 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
         public void RecordError_WithoutStartedUtc_PassesDurationZero()
         {
             var (handler, factory, _) = Create(enabled: true);
-            var connection = Substitute.For<IDbConnection>();
+            var connection = Substitute.For<DbConnection>();
 
-            var allParams = new System.Collections.Generic.List<IDbDataParameter>();
+            var allParams = new System.Collections.Generic.List<DbParameter>();
 
-            IDbCommand MakeTrackingCommand(bool returnsDbNull = false)
+            DbCommand MakeTrackingCommand(bool returnsDbNull = false)
             {
-                var cmd = Substitute.For<IDbCommand>();
-                var paramCollection = Substitute.For<IDataParameterCollection>();
+                var cmd = Substitute.For<DbCommand>();
+                var paramCollection = Substitute.For<DbParameterCollection>();
                 cmd.Parameters.Returns(paramCollection);
                 cmd.CreateParameter().Returns(_ =>
                 {
-                    var p = Substitute.For<IDbDataParameter>();
+                    var p = Substitute.For<DbParameter>();
                     allParams.Add(p);
                     return p;
                 });
@@ -261,7 +262,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             handler.RecordError("q1", "some error");
 
             // Find the parameter named @DurationMs
-            IDbDataParameter durationParam = null;
+            DbParameter durationParam = null;
             foreach (var p in allParams)
             {
                 if ((string)p.ParameterName == "@DurationMs")
@@ -288,12 +289,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             return (new WriteMessageHistoryHandler(factory, tableNameHelper, options), factory, options);
         }
 
-        private static (IDbConnection connection, IDbCommand command) SetupConnection(IDbConnectionFactory factory)
+        private static (DbConnection connection, DbCommand command) SetupConnection(IDbConnectionFactory factory)
         {
-            var connection = Substitute.For<IDbConnection>();
-            var command = Substitute.For<IDbCommand>();
-            var parameters = Substitute.For<IDataParameterCollection>();
-            var parameter = Substitute.For<IDbDataParameter>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            var parameters = Substitute.For<DbParameterCollection>();
+            var parameter = Substitute.For<DbParameter>();
             command.CreateParameter().Returns(parameter);
             command.Parameters.Returns(parameters);
             connection.CreateCommand().Returns(command);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/IRelationalWorkerNotificationContractTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/IRelationalWorkerNotificationContractTests.cs
@@ -58,7 +58,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests
             Assert.AreEqual(
                 typeof(DbTransaction),
                 prop!.PropertyType,
-                "Transaction property must be typed as System.Data.Common.DbTransaction (NOT System.Data.IDbTransaction).");
+                "Transaction property must be typed as System.Data.Common.DbTransaction (NOT System.Data.DbTransaction).");
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/TestHelpers/AdoNetMockFixture.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/TestHelpers/AdoNetMockFixture.cs
@@ -21,35 +21,37 @@ using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using NSubstitute;
 
+using System.Data.Common;
+
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.TestHelpers
 {
     /// <summary>
     /// Shared ADO.NET mock scaffolding for synchronous handler unit tests.
-    /// Wires up <see cref="IDbConnectionFactory"/>, <see cref="IDbConnection"/>,
-    /// <see cref="IDbCommand"/>, and <see cref="IDataReader"/> substitutes using
-    /// the interface-based <see cref="IDbCommand.ExecuteReader"/> call chain.
+    /// Wires up <see cref="IDbConnectionFactory"/>, <see cref="DbConnection"/>,
+    /// <see cref="DbCommand"/>, and <see cref="IDataReader"/> substitutes using
+    /// the interface-based <see cref="DbCommand.ExecuteReader"/> call chain.
     /// </summary>
     internal sealed class AdoNetMockFixture
     {
         public IDbConnectionFactory ConnectionFactory { get; }
-        public IDbConnection Connection { get; }
-        public IDbCommand Command { get; }
-        public IDataReader Reader { get; }
+        public DbConnection Connection { get; }
+        public DbCommand Command { get; }
+        public DbDataReader Reader { get; }
         public IReadColumn ReadColumn { get; }
         public ITransactionFactory TransactionFactory { get; }
         public ITransactionWrapper TransactionWrapper { get; }
-        public IDbTransaction Transaction { get; }
+        public DbTransaction Transaction { get; }
 
         private AdoNetMockFixture(bool withTransaction)
         {
             ConnectionFactory = Substitute.For<IDbConnectionFactory>();
-            Connection = Substitute.For<IDbConnection>();
-            Command = Substitute.For<IDbCommand>();
-            Reader = Substitute.For<IDataReader>();
+            Connection = Substitute.For<DbConnection>();
+            Command = Substitute.For<DbCommand>();
+            Reader = Substitute.For<DbDataReader>();
             ReadColumn = Substitute.For<IReadColumn>();
             TransactionFactory = Substitute.For<ITransactionFactory>();
             TransactionWrapper = Substitute.For<ITransactionWrapper>();
-            Transaction = Substitute.For<IDbTransaction>();
+            Transaction = Substitute.For<DbTransaction>();
 
             ConnectionFactory.Create().Returns(Connection);
             Connection.CreateCommand().Returns(Command);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Command/DeleteMetaDataCommand.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Command/DeleteMetaDataCommand.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command
 {
@@ -32,8 +33,8 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command
         /// <param name="connection">The connection.</param>
         /// <param name="transaction">The transaction.</param>
         public DeleteMetaDataCommand(long queueId,
-            IDbConnection connection,
-            IDbTransaction transaction)
+            DbConnection connection,
+            DbTransaction transaction)
         {
             QueueId = queueId;
             Transaction = transaction;
@@ -54,7 +55,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command
         /// <value>
         /// The transaction.
         /// </value>
-        public IDbTransaction Transaction { get; }
+        public DbTransaction Transaction { get; }
 
         /// <summary>
         /// Gets the connection.
@@ -62,6 +63,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command
         /// <value>
         /// The connection.
         /// </value>
-        public IDbConnection Connection { get; }
+        public DbConnection Connection { get; }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Command/SetStatusTableStatusTransactionCommand.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Command/SetStatusTableStatusTransactionCommand.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command
 {
@@ -33,9 +34,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command
         /// <param name="status">The status.</param>
         /// <param name="transaction">The transaction.</param>
         public SetStatusTableStatusTransactionCommand(long queueId,
-            IDbConnection connection,
+            DbConnection connection,
             QueueStatuses status,
-            IDbTransaction transaction)
+            DbTransaction transaction)
         {
             QueueId = queueId;
             Transaction = transaction;
@@ -64,7 +65,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command
         /// <value>
         /// The connection.
         /// </value>
-        public IDbConnection Connection { get; }
+        public DbConnection Connection { get; }
 
         /// <summary>
         /// Gets the transaction.
@@ -72,6 +73,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command
         /// <value>
         /// The transaction.
         /// </value>
-        public IDbTransaction Transaction { get; }
+        public DbTransaction Transaction { get; }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/CreateQueueTablesAndSaveConfigurationCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/CreateQueueTablesAndSaveConfigurationCommandHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Transport.Shared;
@@ -94,7 +95,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
         /// <param name="conn">The connection.</param>
         /// <param name="trans">The trans.</param>
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query checked")]
-        private void SaveConfiguration(IDbConnection conn, IDbTransaction trans)
+        private void SaveConfiguration(DbConnection conn, DbTransaction trans)
         {
             using (var commandSql = conn.CreateCommand())
             {

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/DeleteTransactionalMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/DeleteTransactionalMessageCommandHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
@@ -30,9 +31,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
     /// Deletes a transactional message from the queue
     /// </summary>
     public class DeleteTransactionalMessageCommandHandler<TConnection, TTransaction, TCommand> : ICommandHandlerWithOutput<DeleteTransactionalMessageCommand, long>
-        where TConnection : IDbConnection
-        where TTransaction : IDbTransaction
-        where TCommand : IDbCommand
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
+        where TCommand : DbCommand
     {
         private readonly Lazy<ITransportOptions> _options;
         private readonly IConnectionHeader<TConnection, TTransaction, TCommand> _headers;

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
@@ -30,9 +31,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
     /// Moves a record from the meta table to the error table
     /// </summary>
     public class MoveRecordToErrorQueueCommandHandler<TConnection, TTransaction, TCommand> : ICommandHandler<MoveRecordToErrorQueueCommand<long>>
-        where TConnection : class, IDbConnection
-        where TTransaction : class, IDbTransaction
-        where TCommand : class, IDbCommand
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
+        where TCommand : DbCommand
     {
         private readonly ICommandHandler<DeleteMetaDataCommand> _deleteMetaCommandHandler;
         private readonly ICommandHandler<SetStatusTableStatusTransactionCommand> _setStatusCommandHandler;

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/CreateJobTablesCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/CreateJobTablesCommandPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 
@@ -27,7 +28,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
     public class CreateJobTablesCommandPrepareHandler : IPrepareCommandHandler<CreateJobTablesCommand<ITable>>
     {
         /// <inheritdoc />
-        public void Handle(CreateJobTablesCommand<ITable> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(CreateJobTablesCommand<ITable> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = command.Tables.Aggregate(string.Empty, (current, table) => current + table.Script() + Environment.NewLine);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/CreateQueueTablesAndSaveConfigurationCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/CreateQueueTablesAndSaveConfigurationCommandPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 
@@ -27,7 +28,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
     public class CreateQueueTablesAndSaveConfigurationCommandPrepareHandler : IPrepareCommandHandler<CreateQueueTablesAndSaveConfigurationCommand<ITable>>
     {
         /// <inheritdoc />
-        public void Handle(CreateQueueTablesAndSaveConfigurationCommand<ITable> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(CreateQueueTablesAndSaveConfigurationCommand<ITable> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = command.Tables.Aggregate(string.Empty, (current, table) => current + table.Script() + Environment.NewLine);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardDeleteAllErrorMessagesPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardDeleteAllErrorMessagesPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
         }
 
         /// <inheritdoc />
-        public void Handle(DashboardDeleteAllErrorMessagesCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DashboardDeleteAllErrorMessagesCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardRequeueAllErrorMessagesPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardRequeueAllErrorMessagesPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -43,7 +44,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
         }
 
         /// <inheritdoc />
-        public void Handle(DashboardRequeueAllErrorMessagesCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DashboardRequeueAllErrorMessagesCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = commandType == CommandStringTypes.DashboardRequeueAllErrors
                 ? string.Format(_commandCache.GetCommand(commandType), _dynamicColumns.Value)

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardRequeueErrorMessagePrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardRequeueErrorMessagePrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -43,7 +44,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
         }
 
         /// <inheritdoc />
-        public void Handle(DashboardRequeueErrorMessageCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DashboardRequeueErrorMessageCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             if (!dbCommand.Parameters.Contains("@QueueID"))
             {

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardResetAllStaleMessagesPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardResetAllStaleMessagesPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
         }
 
         /// <inheritdoc />
-        public void Handle(DashboardResetAllStaleMessagesCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DashboardResetAllStaleMessagesCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardResetStaleMessagePrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardResetStaleMessagePrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
         }
 
         /// <inheritdoc />
-        public void Handle(DashboardResetStaleMessageCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DashboardResetStaleMessageCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             if (!dbCommand.Parameters.Contains("@QueueID"))
             {

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardUpdateMessageBodyPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DashboardUpdateMessageBodyPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
         }
 
         /// <inheritdoc />
-        public void Handle(DashboardUpdateMessageBodyCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DashboardUpdateMessageBodyCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             if (!dbCommand.Parameters.Contains("@QueueID"))
             {

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DeleteMessageCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DeleteMessageCommandPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(DeleteMessageCommand<long> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DeleteMessageCommand<long> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             //set ID if not set
             if (!dbCommand.Parameters.Contains("@QueueID"))

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DeleteMetaDataCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DeleteMetaDataCommandPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(DeleteMetaDataCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DeleteMetaDataCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText =
                 _commandCache.GetCommand(CommandStringTypes.DeleteFromMetaData);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DeleteStatusTableStatusCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DeleteStatusTableStatusCommandPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
         }
 
         /// <inheritdoc />
-        public void Handle(DeleteStatusTableStatusCommand<long> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DeleteStatusTableStatusCommand<long> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.DeleteFromStatus);
             var param = dbCommand.CreateParameter();

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DeleteTableCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/DeleteTableCommandPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -36,7 +37,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(DeleteTableCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DeleteTableCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText =
                 _commandCache.GetCommand(commandType, command.Table);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/MoveRecordToErrorQueueCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/MoveRecordToErrorQueueCommandPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
             _buildSql = buildSql;
         }
         /// <inheritdoc />
-        public void Handle(MoveRecordToErrorQueueCommand<long> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(MoveRecordToErrorQueueCommand<long> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _buildSql.Create();
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/ResetHeartBeatCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/ResetHeartBeatCommandPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
         }
 
         /// <inheritdoc />
-        public void Handle(ResetHeartBeatCommand<long> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(ResetHeartBeatCommand<long> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.ResetHeartbeat);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SaveQueueConfigurationCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SaveQueueConfigurationCommandPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(SaveQueueConfigurationCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(SaveQueueConfigurationCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.SaveConfiguration);
             var param = dbCommand.CreateParameter();

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SendHeartBeatCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SendHeartBeatCommandPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -42,7 +43,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
             _getTime = getTimeFactory.Create();
         }
         /// <inheritdoc />
-        public DateTime Handle(SendHeartBeatCommand<long> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public DateTime Handle(SendHeartBeatCommand<long> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SetErrorCountCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SetErrorCountCommandPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(SetErrorCountCommand<T> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(SetErrorCountCommand<T> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
             var param = dbCommand.CreateParameter();

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SetStatusTableStatusCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SetStatusTableStatusCommandPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(SetStatusTableStatusCommand<long> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(SetStatusTableStatusCommand<long> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SetStatusTableStatusTransactionCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandPrepareHandler/SetStatusTableStatusTransactionCommandPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
 using DotNetWorkQueue.Validation;
 
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandPrepareHandl
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(SetStatusTableStatusTransactionCommand command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(SetStatusTableStatusTransactionCommand command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/ConnectionHeader.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/ConnectionHeader.cs
@@ -17,15 +17,16 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
 {
     /// <inheritdoc />
     public class ConnectionHeader<TConnection, TTransaction, TCommand> : IConnectionHeader<TConnection, TTransaction, TCommand>
-        where TConnection : IDbConnection
-        where TTransaction : IDbTransaction
-        where TCommand : IDbCommand
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
+        where TCommand : DbCommand
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionHeader{TConnection, TTransaction, TCommand}"/> class.

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Query/GetTableExistsTransactionQuery.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Query/GetTableExistsTransactionQuery.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
 
@@ -34,7 +35,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query
         /// <param name="connection">The connection.</param>
         /// <param name="trans">The trans.</param>
         /// <param name="tableName">Name of the table.</param>
-        public GetTableExistsTransactionQuery(IDbConnection connection, IDbTransaction trans, string tableName)
+        public GetTableExistsTransactionQuery(DbConnection connection, DbTransaction trans, string tableName)
         {
             Guard.NotNull(connection);
             Guard.NotNull(trans);
@@ -51,14 +52,14 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query
         /// <value>
         /// The connection.
         /// </value>
-        public IDbConnection Connection { get; }
+        public DbConnection Connection { get; }
         /// <summary>
         /// Gets the trans.
         /// </summary>
         /// <value>
         /// The trans.
         /// </value>
-        public IDbTransaction Trans { get; }
+        public DbTransaction Trans { get; }
         /// <summary>
         /// Gets the name of the table.
         /// </summary>

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Query/ReceiveMessageQuery.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Query/ReceiveMessageQuery.cs
@@ -28,8 +28,8 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query
     /// Dequeue a message from the queue.
     /// </summary>
     public class ReceiveMessageQuery<TConnection, TTransaction> : IQuery<IReceivedMessageInternal>
-        where TConnection : IDbConnection
-        where TTransaction : IDbTransaction
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ReceiveMessageQuery{TConnection, TTransaction}" /> class.

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryHandler/DoesJobExistQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryHandler/DoesJobExistQueryHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
@@ -25,8 +26,8 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler
 {
     /// <inheritdoc />
     public class DoesJobExistQueryHandler<TConnection, TTransaction> : IQueryHandler<DoesJobExistQuery<TConnection, TTransaction>, QueueStatuses>
-        where TConnection : class, IDbConnection
-        where TTransaction : class, IDbTransaction
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
     {
         private readonly CommandStringCache _commandCache;
         private readonly IConnectionInformation _connectionInformation;
@@ -95,7 +96,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler
 
         }
 
-        private QueueStatuses RunQuery(DoesJobExistQuery<TConnection, TTransaction> query, IDbConnection connection, IDbTransaction transaction)
+        private QueueStatuses RunQuery(DoesJobExistQuery<TConnection, TTransaction> query, DbConnection connection, DbTransaction transaction)
         {
             var returnStatus = QueueStatuses.NotQueued;
             using (var command = connection.CreateCommand())

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryHandler/GetMessageErrorsQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryHandler/GetMessageErrorsQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetMessageErrorsQuery<T> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetMessageErrorsQuery<T> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryMessageHistoryHandler.cs
@@ -168,7 +168,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
             };
         }
 
-        private static void AddParameter(IDbCommand command, string name, DbType dbType, object value)
+        private static void AddParameter(DbCommand command, string name, DbType dbType, object value)
         {
             var param = command.CreateParameter();
             param.ParameterName = name;

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/DoesJobExistQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/DoesJobExistQueryPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -24,8 +25,8 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
 {
     /// <inheritdoc />
     public class DoesJobExistQueryPrepareHandler<TConnection, TTransaction> : IPrepareQueryHandler<DoesJobExistQuery<TConnection, TTransaction>, QueueStatuses>
-        where TConnection : class, IDbConnection
-        where TTransaction : class, IDbTransaction
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
     {
         private readonly CommandStringCache _commandCache;
         /// <summary>
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(DoesJobExistQuery<TConnection, TTransaction> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(DoesJobExistQuery<TConnection, TTransaction> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/FindErrorRecordsToDeleteQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/FindErrorRecordsToDeleteQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -50,7 +51,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(FindErrorMessagesToDeleteQuery<T> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(FindErrorMessagesToDeleteQuery<T> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/FindExpiredRecordsToDeleteQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/FindExpiredRecordsToDeleteQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(FindExpiredMessagesToDeleteQuery<T> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(FindExpiredMessagesToDeleteQuery<T> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/FindRecordsToResetByHeartBeatQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/FindRecordsToResetByHeartBeatQueryPrepareHandler.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -45,7 +46,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _configuration = configuration;
         }
         /// <inheritdoc />
-        public void Handle(FindMessagesToResetByHeartBeatQuery<T> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(FindMessagesToResetByHeartBeatQuery<T> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText =
                 _commandCache.GetCommand(commandType);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetColumnNamesFromTableQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetColumnNamesFromTableQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(GetColumnNamesFromTableQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetColumnNamesFromTableQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText =
                 _commandCache.GetCommand(commandType, query.TableName);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardConfigurationPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardConfigurationPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -32,7 +33,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
 
-        public void Handle(GetDashboardConfigurationQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardConfigurationQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.GetDashboardConfiguration);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardErrorMessageCountPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardErrorMessageCountPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -32,7 +33,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
 
-        public void Handle(GetDashboardErrorMessageCountQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardErrorMessageCountQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.GetDashboardErrorMessageCount);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardErrorMessagesPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardErrorMessagesPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -34,7 +35,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
 
-        public void Handle(GetDashboardErrorMessagesQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardErrorMessagesQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.GetDashboardErrorMessages);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardErrorRetriesPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardErrorRetriesPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -34,7 +35,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
 
-        public void Handle(GetDashboardErrorRetriesQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardErrorRetriesQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.GetDashboardErrorRetries);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardJobsPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardJobsPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -34,7 +35,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
 
-        public void Handle(GetDashboardJobsQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardJobsQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.GetDashboardJobs);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessageBodyPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessageBodyPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -33,7 +34,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
 
-        public void Handle(GetDashboardMessageBodyQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardMessageBodyQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.GetDashboardMessageBody);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessageCountPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessageCountPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -32,7 +33,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
 
-        public void Handle(GetDashboardMessageCountQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardMessageCountQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             var sql = _commandCache.GetCommand(CommandStringTypes.GetDashboardMessageCount);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessageDetailPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessageDetailPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _dynamicColumns = new Lazy<string>(() => DashboardDynamicColumnHelper.BuildDynamicColumns(optionsFactory.Create()));
         }
 
-        public void Handle(GetDashboardMessageDetailQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardMessageDetailQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = string.Format(_commandCache.GetCommand(commandType), _dynamicColumns.Value);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessageHeadersPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessageHeadersPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -33,7 +34,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
 
-        public void Handle(GetDashboardMessageHeadersQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardMessageHeadersQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.GetDashboardMessageHeaders);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessagesPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardMessagesPrepareHandler.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _dynamicColumns = new Lazy<string>(() => DashboardDynamicColumnHelper.BuildDynamicColumns(optionsFactory.Create()));
         }
 
-        public void Handle(GetDashboardMessagesQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardMessagesQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             var sql = string.Format(_commandCache.GetCommand(CommandStringTypes.GetDashboardMessages), _dynamicColumns.Value);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandler.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _dynamicColumns = new Lazy<string>(() => DashboardDynamicColumnHelper.BuildDynamicColumns(optionsFactory.Create()));
         }
 
-        public void Handle(GetDashboardStaleMessagesQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardStaleMessagesQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = string.Format(_commandCache.GetCommand(CommandStringTypes.GetDashboardStaleMessages), _dynamicColumns.Value);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardStatusCountsPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardStatusCountsPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
@@ -33,7 +34,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
 
-        public void Handle(GetDashboardStatusCountsQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetDashboardStatusCountsQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.GetDashboardStatusCounts);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetErrorRecordExistsQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetErrorRecordExistsQueryPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetErrorRecordExistsQuery<T> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetErrorRecordExistsQuery<T> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetErrorRetryCountQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetErrorRetryCountQueryPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetErrorRetryCountQuery<T> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetErrorRetryCountQuery<T> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetHeaderQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetHeaderQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -40,7 +41,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetHeaderQuery<T> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetHeaderQuery<T> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetJobIdQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetJobIdQueryPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetJobIdQuery<T> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetJobIdQuery<T> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
             var param = dbCommand.CreateParameter();

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetJobLastKnownEventQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetJobLastKnownEventQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetJobLastKnownEventQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetJobLastKnownEventQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetQueueCountQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetQueueCountQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -42,7 +43,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _options = new Lazy<ITransportOptions>(options.Create);
         }
 
-        public void Handle(GetQueueCountQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetQueueCountQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             if (query.Status.HasValue && _options.Value.EnableStatus) //status means nothing if not enabled on the queue
             {

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetQueueOptionsQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetQueueOptionsQueryPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -37,7 +38,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(GetQueueOptionsQuery<TTransportOptions> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetQueueOptionsQuery<TTransportOptions> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetTableExistsQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetTableExistsQueryPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -43,7 +44,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetTableExistsQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetTableExistsQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetTableExistsTransactionQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetTableExistsTransactionQueryPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -45,7 +46,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetTableExistsTransactionQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetTableExistsTransactionQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetUtcDateQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetUtcDateQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -40,7 +41,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             _commandCache = commandCache;
         }
         /// <inheritdoc />
-        public void Handle(GetUtcDateQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetUtcDateQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/TransactionFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/TransactionFactory.cs
@@ -16,7 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
-using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
 {
@@ -24,7 +24,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
     public class TransactionFactory : ITransactionFactory
     {
         /// <inheritdoc />
-        public ITransactionWrapper Create(IDbConnection connection)
+        public ITransactionWrapper Create(DbConnection connection)
         {
             return new TransactionWrapper(connection);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/TransactionWrapper.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/TransactionWrapper.cs
@@ -16,7 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
-using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
@@ -28,15 +28,15 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         /// Initializes a new instance of the <see cref="TransactionWrapper"/> class.
         /// </summary>
         /// <param name="connection">The connection.</param>
-        public TransactionWrapper(IDbConnection connection)
+        public TransactionWrapper(DbConnection connection)
         {
             Guard.NotNull(connection);
             Connection = connection;
         }
         /// <inheritdoc />
-        public IDbConnection Connection { get; set; }
+        public DbConnection Connection { get; set; }
         /// <inheritdoc />
-        public IDbTransaction BeginTransaction()
+        public DbTransaction BeginTransaction()
         {
             return Connection.BeginTransaction();
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Configuration;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
@@ -234,7 +235,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
             }
         }
 
-        private DateTime? GetStartedUtc(IDbConnection connection, string queueId)
+        private DateTime? GetStartedUtc(DbConnection connection, string queueId)
         {
             using (var command = connection.CreateCommand())
             {
@@ -255,7 +256,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
             }
         }
 
-        private static void AddParameter(IDbCommand command, string name, DbType dbType, object value)
+        private static void AddParameter(DbCommand command, string name, DbType dbType, object value)
         {
             var param = command.CreateParameter();
             param.ParameterName = name;

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/IConnectionHeader.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/IConnectionHeader.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase
 {
@@ -27,9 +28,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
     /// <typeparam name="TTransaction">The type of the transaction.</typeparam>
     /// <typeparam name="TCommand">The type of the command.</typeparam>
     public interface IConnectionHeader<TConnection, TTransaction, out TCommand>
-        where TConnection : IDbConnection
-        where TTransaction : IDbTransaction
-        where TCommand : IDbCommand
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
+        where TCommand : DbCommand
     {
         /// <summary>
         /// Gets the connection.

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/IConnectionHolder.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/IConnectionHolder.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase
 {
@@ -31,9 +32,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
     /// <seealso cref="System.IDisposable" />
     /// <seealso cref="DotNetWorkQueue.IIsDisposed" />
     public interface IConnectionHolder<TConnection, TTransaction, out TCommand> : IDisposable, IIsDisposed
-        where TConnection : IDbConnection
-        where TTransaction : IDbTransaction
-        where TCommand : IDbCommand
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
+        where TCommand : DbCommand
     {
         /// <summary>
         /// Gets or sets the connection.

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/IConnectionHolderFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/IConnectionHolderFactory.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase
 {
@@ -27,9 +28,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
     /// <typeparam name="TTransaction">The type of the transaction.</typeparam>
     /// <typeparam name="TCommand">The type of the command.</typeparam>
     public interface IConnectionHolderFactory<TConnection, TTransaction, out TCommand>
-        where TConnection : IDbConnection
-        where TTransaction : IDbTransaction
-        where TCommand : IDbCommand
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
+        where TCommand : DbCommand
     {
         /// <summary>
         /// Creates a new instance of <see cref="IConnectionHolder{TConnection, TTransaction, TCommand}"/>

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/IDbConnectionFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/IDbConnectionFactory.cs
@@ -16,12 +16,12 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
-using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase
 {
     /// <summary>
-    /// Creates a new <see cref="IDbConnection"/>
+    /// Creates a new <see cref="DbConnection"/>
     /// </summary>
     public interface IDbConnectionFactory
     {
@@ -29,6 +29,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
         /// Creates a new connection to the database
         /// </summary>
         /// <returns></returns>
-        IDbConnection Create();
+        DbConnection Create();
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/IPrepareCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/IPrepareCommandHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase
@@ -33,6 +34,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
         /// <param name="command">The command.</param>
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
-        void Handle(TCommand command, IDbCommand dbCommand, CommandStringTypes commandType);
+        void Handle(TCommand command, DbCommand dbCommand, CommandStringTypes commandType);
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/IPrepareCommandHandlerWithOutput.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/IPrepareCommandHandlerWithOutput.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase
@@ -35,6 +36,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
         /// <returns></returns>
-        TOutput Handle(TCommand command, IDbCommand dbCommand, CommandStringTypes commandType);
+        TOutput Handle(TCommand command, DbCommand dbCommand, CommandStringTypes commandType);
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/IPrepareQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/IPrepareQueryHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.Shared;
 
@@ -35,6 +36,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
         /// <param name="query">The query.</param>
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
-        void Handle(TQuery query, IDbCommand dbCommand, CommandStringTypes commandType);
+        void Handle(TQuery query, DbCommand dbCommand, CommandStringTypes commandType);
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/ITransactionFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/ITransactionFactory.cs
@@ -16,7 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
-using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase
 {
@@ -30,6 +30,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
         /// </summary>
         /// <param name="connection"></param>
         /// <returns></returns>
-        ITransactionWrapper Create(IDbConnection connection);
+        ITransactionWrapper Create(DbConnection connection);
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/ITransactionWrapper.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/ITransactionWrapper.cs
@@ -16,7 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
-using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase
 {
@@ -32,11 +32,11 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
         /// <value>
         /// The connection.
         /// </value>
-        IDbConnection Connection { get; set; }
+        DbConnection Connection { get; set; }
         /// <summary>
         /// Begins the transaction.
         /// </summary>
         /// <returns></returns>
-        IDbTransaction BeginTransaction();
+        DbTransaction BeginTransaction();
     }
 }

--- a/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/VerifyQueueData.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/VerifyQueueData.cs
@@ -5,6 +5,11 @@ using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using System;
 using System.Data;
+using System.Data.Common;
+//System.Data.Common gained its own DbDataSource in .NET 7, which collides with this
+//transport's type of the same name. An explicit alias wins over a namespace import, so the
+//bare name below keeps meaning the SQLite one.
+using DbDataSource = DotNetWorkQueue.Transport.SQLite.Basic.DbDataSource;
 using System.Data.SQLite;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -236,7 +241,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests
         /// enough to diagnose.
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query Ok")]
-        private static void AssertRecordCount(IDbCommand command, string tableName, int expected)
+        private static void AssertRecordCount(DbCommand command, string tableName, int expected)
         {
             command.CommandText = $"select count(*) from {tableName}";
             int records;
@@ -254,7 +259,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests
         }
 
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query Ok")]
-        private static string DumpRows(IDbCommand command, string tableName, int maxRows = 10)
+        private static string DumpRows(DbCommand command, string tableName, int maxRows = 10)
         {
             var output = new StringBuilder();
             command.CommandText = $"select * from {tableName} limit {maxRows}";

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Globalization;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
@@ -34,28 +35,28 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic.CommandHandler
             var commandCache = CreateCommandCache();
             var handler = new SetJobLastKnownEventCommandHandler(commandCache);
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var dbCommand = Substitute.For<IDbCommand>();
-            var parameters = Substitute.For<IDataParameterCollection>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var dbCommand = Substitute.For<DbCommand>();
+            var parameters = Substitute.For<DbParameterCollection>();
             dbCommand.Parameters.Returns(parameters);
             dbCommand.CreateParameter().Returns(
-                _ => Substitute.For<IDbDataParameter>(),
-                _ => Substitute.For<IDbDataParameter>(),
-                _ => Substitute.For<IDbDataParameter>());
+                _ => Substitute.For<DbParameter>(),
+                _ => Substitute.For<DbParameter>(),
+                _ => Substitute.For<DbParameter>());
             connection.CreateCommand().Returns(dbCommand);
 
             var eventTime = new DateTimeOffset(2026, 3, 25, 10, 0, 0, TimeSpan.Zero);
             var scheduledTime = new DateTimeOffset(2026, 3, 25, 9, 0, 0, TimeSpan.Zero);
 
-            var command = new SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>(
+            var command = new SetJobLastKnownEventCommand<DbConnection, DbTransaction>(
                 "TestJob", eventTime, scheduledTime, connection, transaction);
 
             handler.Handle(command);
 
             dbCommand.Received(1).ExecuteNonQuery();
             dbCommand.Received(1).Transaction = transaction;
-            parameters.Received(3).Add(Arg.Any<IDbDataParameter>());
+            parameters.Received(3).Add(Arg.Any<DbParameter>());
         }
 
         [TestMethod]
@@ -64,15 +65,15 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic.CommandHandler
             var commandCache = CreateCommandCache();
             var handler = new SetJobLastKnownEventCommandHandler(commandCache);
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var dbCommand = Substitute.For<IDbCommand>();
-            var parameters = Substitute.For<IDataParameterCollection>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var dbCommand = Substitute.For<DbCommand>();
+            var parameters = Substitute.For<DbParameterCollection>();
             dbCommand.Parameters.Returns(parameters);
 
-            var param1 = Substitute.For<IDbDataParameter>();
-            var param2 = Substitute.For<IDbDataParameter>();
-            var param3 = Substitute.For<IDbDataParameter>();
+            var param1 = Substitute.For<DbParameter>();
+            var param2 = Substitute.For<DbParameter>();
+            var param3 = Substitute.For<DbParameter>();
             var callCount = 0;
             dbCommand.CreateParameter().Returns(_ =>
             {
@@ -89,7 +90,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic.CommandHandler
             var eventTime = new DateTimeOffset(2026, 3, 25, 10, 0, 0, TimeSpan.Zero);
             var scheduledTime = new DateTimeOffset(2026, 3, 25, 9, 0, 0, TimeSpan.Zero);
 
-            var command = new SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>(
+            var command = new SetJobLastKnownEventCommand<DbConnection, DbTransaction>(
                 "MyJob", eventTime, scheduledTime, connection, transaction);
 
             handler.Handle(command);
@@ -113,15 +114,15 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic.CommandHandler
             var commandCache = CreateCommandCache();
             var handler = new SetJobLastKnownEventCommandHandler(commandCache);
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var dbCommand = Substitute.For<IDbCommand>();
-            var parameters = Substitute.For<IDataParameterCollection>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var dbCommand = Substitute.For<DbCommand>();
+            var parameters = Substitute.For<DbParameterCollection>();
             dbCommand.Parameters.Returns(parameters);
-            dbCommand.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            dbCommand.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             connection.CreateCommand().Returns(dbCommand);
 
-            var command = new SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>(
+            var command = new SetJobLastKnownEventCommand<DbConnection, DbTransaction>(
                 "TestJob",
                 DateTimeOffset.UtcNow,
                 DateTimeOffset.UtcNow,
@@ -141,15 +142,15 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic.CommandHandler
             var commandCache = CreateCommandCache();
             var handler = new SetJobLastKnownEventCommandHandler(commandCache);
 
-            var connection = Substitute.For<IDbConnection>();
-            var transaction = Substitute.For<IDbTransaction>();
-            var dbCommand = Substitute.For<IDbCommand>();
-            var parameters = Substitute.For<IDataParameterCollection>();
+            var connection = Substitute.For<DbConnection>();
+            var transaction = Substitute.For<DbTransaction>();
+            var dbCommand = Substitute.For<DbCommand>();
+            var parameters = Substitute.For<DbParameterCollection>();
             dbCommand.Parameters.Returns(parameters);
-            dbCommand.CreateParameter().Returns(_ => Substitute.For<IDbDataParameter>());
+            dbCommand.CreateParameter().Returns(_ => Substitute.For<DbParameter>());
             connection.CreateCommand().Returns(dbCommand);
 
-            var command = new SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>(
+            var command = new SetJobLastKnownEventCommand<DbConnection, DbTransaction>(
                 "TestJob", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, connection, transaction);
 
             handler.Handle(command);

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/PooledAdoSurfaceTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/PooledAdoSurfaceTests.cs
@@ -155,6 +155,63 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             Assert.Throws<NotSupportedException>(() => command.Connection = null);
         }
 
+        [TestMethod]
+        public void Connection_CloseIsANoOp_SoThePooledConnectionStaysUsable()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+            connection.Open();
+
+            //Close deliberately does nothing. Closing the inner connection would defeat the pool and
+            //throw away the statements SQLite compiled for its commands, which is the whole point of
+            //this type. Callers that dispose or close should get a connection that still works.
+            connection.Close();
+
+            Assert.AreEqual(ConnectionState.Open, connection.State);
+            using var command = factory.CreateCommand(connection, Count);
+            Assert.AreEqual(0L, (long)command.ExecuteScalar());
+        }
+
+        [TestMethod]
+        public void Connection_OpeningTwiceIsHarmless()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+
+            connection.Open();
+            connection.Open();
+
+            Assert.AreEqual(ConnectionState.Open, connection.State);
+        }
+
+        [TestMethod]
+        public void Connection_ReportsTheStringItWasRentedFor()
+        {
+            var factory = CreateFactory();
+            var connectionString = NewDatabase();
+            using var connection = (PooledConnection)factory.CreateConnection(connectionString, false);
+            connection.Open();
+
+            //Not the string that was passed in: the factory normalises it before renting, so what
+            //comes back describes the same database rather than matching character for character.
+            Assert.IsFalse(string.IsNullOrEmpty(connection.ConnectionString));
+            StringAssert.Contains(connection.ConnectionString, "t.db");
+            Assert.IsNotNull(connection.Database);
+        }
+
+        [TestMethod]
+        public void Connection_ChangeDatabaseReachesTheInnerConnection()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+            connection.Open();
+
+            //System.Data.SQLite does not implement this, so the call is expected to fail rather than
+            //succeed. What is asserted is that it reaches the inner connection rather than being
+            //swallowed - a silent no-op here would hide a caller's mistake.
+            Assert.ThrowsExactly<NotImplementedException>(() => connection.ChangeDatabase("other"));
+        }
+
         private static DbFactory CreateFactory()
         {
             var containerFactory = Substitute.For<IContainerFactory>();

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/PooledAdoSurfaceTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/PooledAdoSurfaceTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Data.SQLite;
+using System.IO;
+using DotNetWorkQueue.IoC;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
+{
+    /// <summary>
+    /// The ADO surface that <see cref="PooledConnection"/> and <see cref="PooledCommand"/> inherit
+    /// from <see cref="DbConnection"/> and <see cref="DbCommand"/>.
+    ///
+    /// These two used to implement the old <c>IDbConnection</c> and <c>IDbCommand</c> interfaces,
+    /// which have no asynchronous members and so blocked any async path on the relational transports.
+    /// Deriving from the base classes brought members with it - DataSource, ServerVersion,
+    /// DesignTimeVisible, and the protected Create/Begin/Execute methods the public ones route
+    /// through - and none of them were exercised by anything.
+    ///
+    /// The behaviour that matters is asserted alongside: a pooled command still refuses a different
+    /// CommandText, and a pooled connection still refuses a different connection string. Those two
+    /// refusals are what keep a command filed under a key that describes it, which is what makes the
+    /// statement caching correct rather than merely fast.
+    /// </summary>
+    [TestClass]
+    public class PooledAdoSurfaceTests
+    {
+        private const string Count = "SELECT COUNT(*) FROM t";
+        private string _dir;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "dnwq-ado-surface", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            SQLiteConnection.ClearAllPools();
+            try { Directory.Delete(_dir, true); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+        }
+
+        [TestMethod]
+        public void Connection_ExposesTheInnerConnectionsIdentity()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+            connection.Open();
+
+            Assert.IsFalse(string.IsNullOrEmpty(connection.DataSource), "DataSource came back empty");
+            Assert.IsFalse(string.IsNullOrEmpty(connection.ServerVersion), "ServerVersion came back empty");
+            Assert.AreEqual(ConnectionState.Open, connection.State);
+            Assert.IsTrue(connection.ConnectionTimeout >= 0);
+        }
+
+        [TestMethod]
+        public void Connection_RefusesADifferentConnectionString()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+
+            Assert.Throws<NotSupportedException>(() => connection.ConnectionString = "Data Source=other;Version=3;");
+        }
+
+        [TestMethod]
+        public void Connection_CreatesCommandsAndTransactionsThroughTheBase()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+            connection.Open();
+
+            //Both of these route through the protected CreateDbCommand and BeginDbTransaction.
+            using var command = connection.CreateCommand();
+            Assert.IsNotNull(command);
+
+            using var transaction = connection.BeginTransaction();
+            Assert.IsNotNull(transaction);
+            transaction.Rollback();
+        }
+
+        [TestMethod]
+        public void Command_ExposesTheAdoSurfaceItInherits()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+            connection.Open();
+            using var command = factory.CreateCommand(connection, Count);
+
+            command.DesignTimeVisible = true;
+            Assert.IsTrue(command.DesignTimeVisible);
+
+            command.CommandType = CommandType.Text;
+            Assert.AreEqual(CommandType.Text, command.CommandType);
+
+            command.UpdatedRowSource = UpdateRowSource.None;
+            Assert.AreEqual(UpdateRowSource.None, command.UpdatedRowSource);
+
+            Assert.IsNotNull(command.Parameters);
+            Assert.IsNotNull(command.CreateParameter());
+            //Connection hands back the underlying SQLiteConnection rather than the pooled
+            //wrapper, which is what it did before this class derived from DbCommand. Asserted
+            //because it is surprising, not because it is desirable.
+            Assert.IsInstanceOfType<SQLiteConnection>(command.Connection);
+            Assert.AreNotSame(connection, command.Connection);
+
+            command.CommandTimeout = 42;
+            Assert.AreEqual(42, command.CommandTimeout);
+        }
+
+        [TestMethod]
+        public void Command_ReadsThroughTheProtectedExecuteReader()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+            connection.Open();
+            using var command = factory.CreateCommand(connection, Count);
+
+            //The public ExecuteReader is not virtual; it routes through ExecuteDbDataReader, which is
+            //the member the pooled command actually overrides.
+            using var reader = command.ExecuteReader();
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(0, reader.GetInt32(0));
+        }
+
+        [TestMethod]
+        public void Command_RefusesADifferentCommandTextButAcceptsTheSameOne()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+            connection.Open();
+            using var command = factory.CreateCommand(connection, Count);
+
+            //Re-assigning the text it already holds is the normal shape of the callers and must not
+            //throw; a different text would leave it filed under a key that no longer describes it.
+            command.CommandText = Count;
+            Assert.AreEqual(Count, command.CommandText);
+
+            Assert.Throws<NotSupportedException>(() => command.CommandText = "SELECT 1");
+        }
+
+        [TestMethod]
+        public void Command_RefusesADifferentConnection()
+        {
+            var factory = CreateFactory();
+            using var connection = (PooledConnection)factory.CreateConnection(NewDatabase(), false);
+            connection.Open();
+            using var command = factory.CreateCommand(connection, Count);
+
+            Assert.Throws<NotSupportedException>(() => command.Connection = null);
+        }
+
+        private static DbFactory CreateFactory()
+        {
+            var containerFactory = Substitute.For<IContainerFactory>();
+            containerFactory.Create().Returns(Substitute.For<IContainer>());
+            return new DbFactory(containerFactory);
+        }
+
+        private string NewDatabase(string name = "t.db")
+        {
+            var path = Path.Combine(_dir, name);
+            var connectionString = $"Data Source={path};Version=3;";
+            using var seed = new SQLiteConnection(connectionString);
+            seed.Open();
+            using var cmd = seed.CreateCommand();
+            cmd.CommandText = "CREATE TABLE t(id INTEGER PRIMARY KEY);";
+            cmd.ExecuteNonQuery();
+            return connectionString;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/ReaderAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/ReaderAsyncTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Data.SQLite;
 using System.IO;
 using System.Threading.Tasks;
@@ -95,7 +96,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
         [TestMethod]
         public async Task ACommandFromAnotherProvider_IsRejectedClearly()
         {
-            var command = Substitute.For<IDbCommand>();
+            var command = Substitute.For<DbCommand>();
 
             var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(
                 () => new ReaderAsync().ExecuteNonQueryAsync(command));

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/SqliteSendToJobQueueTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/SqliteSendToJobQueueTests.cs
@@ -9,6 +9,8 @@ using DotNetWorkQueue.Transport.SQLite.Basic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
+using System.Data.Common;
+
 namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
 {
     [TestClass]
@@ -26,14 +28,14 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
         {
             var sut = CreateSut(out var deps);
             deps.DoesJobExist
-                .Handle(Arg.Any<DoesJobExistQuery<IDbConnection, IDbTransaction>>())
+                .Handle(Arg.Any<DoesJobExistQuery<DbConnection, DbTransaction>>())
                 .Returns(QueueStatuses.Processed);
 
             var result = sut.DoesJobExistTest("job-name", DateTimeOffset.UtcNow);
 
             Assert.AreEqual(QueueStatuses.Processed, result);
             deps.DoesJobExist.Received(1)
-                .Handle(Arg.Any<DoesJobExistQuery<IDbConnection, IDbTransaction>>());
+                .Handle(Arg.Any<DoesJobExistQuery<DbConnection, DbTransaction>>());
         }
 
         [TestMethod]
@@ -43,9 +45,9 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             const string jobName = "my-recurring-job";
             var scheduled = new DateTimeOffset(2025, 1, 15, 12, 30, 0, TimeSpan.Zero);
 
-            DoesJobExistQuery<IDbConnection, IDbTransaction> captured = null;
+            DoesJobExistQuery<DbConnection, DbTransaction> captured = null;
             deps.DoesJobExist
-                .Handle(Arg.Do<DoesJobExistQuery<IDbConnection, IDbTransaction>>(q => captured = q))
+                .Handle(Arg.Do<DoesJobExistQuery<DbConnection, DbTransaction>>(q => captured = q))
                 .Returns(QueueStatuses.Waiting);
 
             sut.DoesJobExistTest(jobName, scheduled);
@@ -97,7 +99,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             {
                 Queue = Substitute.For<IProducerMethodQueue>(),
                 DoesJobExist =
-                    Substitute.For<IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses>>(),
+                    Substitute.For<IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses>>(),
                 RemoveMessage = Substitute.For<IRemoveMessage>(),
                 GetJobId = Substitute.For<IQueryHandler<GetJobIdQuery<long>, long>>(),
                 CreateJobMetaData = new CreateJobMetaData(Substitute.For<IJobSchedulerMetaData>()),
@@ -116,7 +118,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
         private sealed class Deps
         {
             public IProducerMethodQueue Queue { get; set; }
-            public IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> DoesJobExist { get; set; }
+            public IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> DoesJobExist { get; set; }
             public IRemoveMessage RemoveMessage { get; set; }
             public IQueryHandler<GetJobIdQuery<long>, long> GetJobId { get; set; }
             public CreateJobMetaData CreateJobMetaData { get; set; }
@@ -128,7 +130,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
         {
             public TestableSqliteSendToJobQueue(
                 IProducerMethodQueue queue,
-                IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> doesJobExist,
+                IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> doesJobExist,
                 IRemoveMessage removeMessage,
                 IQueryHandler<GetJobIdQuery<long>, long> getJobId,
                 CreateJobMetaData createJobMetaData,

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/BeginTransactionRetryDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/BeginTransactionRetryDecoratorTests.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Transport.SQLite.Decorator;
@@ -32,7 +33,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
         [TestMethod]
         public void BeginTransaction_WhenRegistryDisposed_FallsThroughToDecorated()
         {
-            var decoratedTxn = Substitute.For<IDbTransaction>();
+            var decoratedTxn = Substitute.For<DbTransaction>();
             var decorated = Substitute.For<ISQLiteTransactionWrapper>();
             decorated.BeginTransaction().Returns(decoratedTxn);
             var policies = Substitute.For<IPolicies>();
@@ -51,7 +52,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
         [TestMethod]
         public void BeginTransaction_WhenPipelineRegistered_ExecutesThroughPipeline()
         {
-            var decoratedTxn = Substitute.For<IDbTransaction>();
+            var decoratedTxn = Substitute.For<DbTransaction>();
             var decorated = Substitute.For<ISQLiteTransactionWrapper>();
             decorated.BeginTransaction().Returns(decoratedTxn);
             var policies = Substitute.For<IPolicies>();
@@ -71,7 +72,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
         [TestMethod]
         public void BeginTransaction_WhenNoPipelineRegistered_CallsDecoratedDirectly()
         {
-            var decoratedTxn = Substitute.For<IDbTransaction>();
+            var decoratedTxn = Substitute.For<DbTransaction>();
             var decorated = Substitute.For<ISQLiteTransactionWrapper>();
             decorated.BeginTransaction().Returns(decoratedTxn);
             var policies = Substitute.For<IPolicies>();

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessage.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using DotNetWorkQueue.Serialization;
@@ -29,7 +30,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
 {
     internal static class SendMessage
     {
-        internal static IDbCommand CreateMetaDataRecord(TimeSpan? delay, TimeSpan expiration, IDbConnection connection,
+        internal static DbCommand CreateMetaDataRecord(TimeSpan? delay, TimeSpan expiration, DbConnection connection,
             IMessage message, IAdditionalMessageData data, ITableNameHelper tableNameHelper,
             IHeaders headers, SqLiteMessageQueueTransportOptions options, IGetTime getTime, IDbFactory dbFactory)
         {
@@ -44,8 +45,8 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
 
 
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query checked")]
-        internal static IDbCommand GetMainCommand(SendMessageCommand commandSend,
-            IDbConnection connection,
+        internal static DbCommand GetMainCommand(SendMessageCommand commandSend,
+            DbConnection connection,
             IDbCommandStringCache commandCache,
             IHeaders headers,
             ICompositeSerialization serializer,
@@ -111,7 +112,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         }
 
         /// <summary>The parameter values for <see cref="BuildStatusCommandText"/>.</summary>
-        internal static void AddStatusCommandParameters(IDbCommand command,
+        internal static void AddStatusCommandParameters(DbCommand command,
             IAdditionalMessageData data,
             long id,
             SqLiteMessageQueueTransportOptions options,
@@ -183,7 +184,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         }
 
         /// <summary>The parameter values for <see cref="BuildMetaCommandText"/>.</summary>
-        private static void AddMetaCommandParameters(IDbCommand command,
+        private static void AddMetaCommandParameters(DbCommand command,
             IAdditionalMessageData data,
             SqLiteMessageQueueTransportOptions options,
             TimeSpan? delay,
@@ -216,7 +217,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         /// </summary>
         /// <param name="command">The command.</param>
         /// <param name="data">The data.</param>
-        private static void AddUserColumnsParams(IDbCommand command, IAdditionalMessageData data)
+        private static void AddUserColumnsParams(DbCommand command, IAdditionalMessageData data)
         {
             foreach (var metadata in data.AdditionalMetaData)
             {

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageBatch.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageBatch.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
@@ -66,7 +67,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         /// <param name="tableNameHelper">Supplies the queue (body) table name.</param>
         /// <param name="rows">The serialized body and header bytes per message, in input order.</param>
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Table name is from configuration; values are parameterized")]
-        internal static void BuildBodyInsertReturningCommand(IDbCommand command,
+        internal static void BuildBodyInsertReturningCommand(DbCommand command,
             ITableNameHelper tableNameHelper,
             IReadOnlyList<(byte[] Body, byte[] Headers)> rows)
         {

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageCommandBatchHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageCommandBatchHandler.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using DotNetWorkQueue.Configuration;
@@ -144,7 +145,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         }
 
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query OK")]
-        private void ProcessChunk(IDbConnection connection, IDbTransaction trans,
+        private void ProcessChunk(DbConnection connection, DbTransaction trans,
             IReadOnlyList<QueueMessage<IMessage, IAdditionalMessageData>> chunk,
             SqLiteMessageQueueTransportOptions options,
             IQueueOutputMessage[] results, ref int globalIndex)

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageCommandBatchHandlerAsync.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
@@ -143,7 +144,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         }
 
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query OK")]
-        private async Task<int> ProcessChunkAsync(IDbConnection connection, IDbTransaction trans,
+        private async Task<int> ProcessChunkAsync(DbConnection connection, DbTransaction trans,
             IReadOnlyList<QueueMessage<IMessage, IAdditionalMessageData>> chunk,
             SqLiteMessageQueueTransportOptions options,
             IQueueOutputMessage[] results, int globalIndex)

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageCommandHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
@@ -44,8 +45,8 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         private readonly TransportConfigurationSend _configurationSend;
         private readonly IGetTime _getTime;
         private readonly IDbFactory _dbFactory;
-        private readonly ICommandHandler<SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>> _sendJobStatus;
-        private readonly IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> _jobExistsHandler;
+        private readonly ICommandHandler<SetJobLastKnownEventCommand<DbConnection, DbTransaction>> _sendJobStatus;
+        private readonly IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> _jobExistsHandler;
         private readonly IJobSchedulerMetaData _jobSchedulerMetaData;
         private readonly DatabaseExists _databaseExists;
 
@@ -78,7 +79,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
             TransportConfigurationSend configurationSend,
             IGetTimeFactory getTimeFactory,
             IDbFactory dbFactory,
-            ICommandHandler<SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>> sendJobStatus, IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> jobExistsHandler,
+            ICommandHandler<SetJobLastKnownEventCommand<DbConnection, DbTransaction>> sendJobStatus, IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> jobExistsHandler,
             IJobSchedulerMetaData jobSchedulerMetaData,
             DatabaseExists databaseExists)
         {
@@ -145,7 +146,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
                     eventTime = _jobSchedulerMetaData.GetEventTime(commandSend.MessageData);
                 }
 
-                IDbCommand commandStatus = null;
+                DbCommand commandStatus = null;
                 using (var command = SendMessage.GetMainCommand(commandSend, connection, _commandCache, _headers, _serializer, _dbFactory))
                 {
                     long id;
@@ -162,7 +163,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
                         {
                             try
                             {
-                                if (string.IsNullOrWhiteSpace(jobName) || _jobExistsHandler.Handle(new DoesJobExistQuery<IDbConnection, IDbTransaction>(jobName, scheduledTime, connection, trans)) ==
+                                if (string.IsNullOrWhiteSpace(jobName) || _jobExistsHandler.Handle(new DoesJobExistQuery<DbConnection, DbTransaction>(jobName, scheduledTime, connection, trans)) ==
                                     QueueStatuses.NotQueued)
                                 {
                                     command.Transaction = trans;
@@ -196,7 +197,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
 
                                         if (!string.IsNullOrWhiteSpace(jobName))
                                         {
-                                            _sendJobStatus.Handle(new SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>(jobName, eventTime,
+                                            _sendJobStatus.Handle(new SetJobLastKnownEventCommand<DbConnection, DbTransaction>(jobName, eventTime,
                                                 scheduledTime, connection, trans));
                                         }
                                         trans.Commit();
@@ -230,7 +231,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         /// <param name="connection">The connection.</param>
         /// <param name="data">The data.</param>
         /// <returns></returns>
-        private IDbCommand CreateStatusRecord(IDbConnection connection, IAdditionalMessageData data)
+        private DbCommand CreateStatusRecord(DbConnection connection, IAdditionalMessageData data)
         {
             var command = _dbFactory.CreateCommand(connection,
                 SendMessage.BuildStatusCommandText(_tableNameHelper, data, _options.Value));

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Exceptions;
@@ -45,8 +46,8 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         private readonly TransportConfigurationSend _configurationSend;
         private readonly IGetTime _getTime;
         private readonly IDbFactory _dbFactory;
-        private readonly ICommandHandler<SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>> _sendJobStatus;
-        private readonly IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> _jobExistsHandler;
+        private readonly ICommandHandler<SetJobLastKnownEventCommand<DbConnection, DbTransaction>> _sendJobStatus;
+        private readonly IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> _jobExistsHandler;
         private readonly IJobSchedulerMetaData _jobSchedulerMetaData;
         private readonly DatabaseExists _databaseExists;
 
@@ -81,7 +82,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
             TransportConfigurationSend configurationSend,
             IGetTimeFactory getTimeFactory,
             IDbFactory dbFactory,
-            ICommandHandler<SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>> sendJobStatus, IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> jobExistsHandler,
+            ICommandHandler<SetJobLastKnownEventCommand<DbConnection, DbTransaction>> sendJobStatus, IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> jobExistsHandler,
             IJobSchedulerMetaData jobSchedulerMetaData,
             DatabaseExists databaseExists,
             IReaderAsync readerAsync)
@@ -151,7 +152,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
                     eventTime = _jobSchedulerMetaData.GetEventTime(commandSend.MessageData);
                 }
 
-                IDbCommand commandStatus = null;
+                DbCommand commandStatus = null;
                 using (var command = SendMessage.GetMainCommand(commandSend, connection, _commandCache, _headers, _serializer, _dbFactory))
                 {
                     long id;
@@ -169,7 +170,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
                             try
                             {
                                 if (string.IsNullOrWhiteSpace(jobName) ||
-                                    _jobExistsHandler.Handle(new DoesJobExistQuery<IDbConnection, IDbTransaction>(jobName, scheduledTime, connection,
+                                    _jobExistsHandler.Handle(new DoesJobExistQuery<DbConnection, DbTransaction>(jobName, scheduledTime, connection,
                                         trans)) ==
                                     QueueStatuses.NotQueued)
                                 {
@@ -203,7 +204,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
                                         }
                                         if (!string.IsNullOrWhiteSpace(jobName))
                                         {
-                                            _sendJobStatus.Handle(new SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>(jobName, eventTime,
+                                            _sendJobStatus.Handle(new SetJobLastKnownEventCommand<DbConnection, DbTransaction>(jobName, eventTime,
                                                 scheduledTime, connection, trans));
                                         }
                                         trans.Commit();
@@ -237,7 +238,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         /// <param name="connection">The connection.</param>
         /// <param name="data">The data.</param>
         /// <returns></returns>
-        private IDbCommand CreateStatusRecord(IDbConnection connection, IAdditionalMessageData data)
+        private DbCommand CreateStatusRecord(DbConnection connection, IAdditionalMessageData data)
         {
             var command = _dbFactory.CreateCommand(connection,
                 SendMessage.BuildStatusCommandText(_tableNameHelper, data, _options.Value));

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SetJobLastKnownEventCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandHandler/SetJobLastKnownEventCommandHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using System.Globalization;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
@@ -29,7 +30,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
     /// <summary>
     /// 
     /// </summary>
-    public class SetJobLastKnownEventCommandHandler : ICommandHandler<SetJobLastKnownEventCommand<IDbConnection, IDbTransaction>>
+    public class SetJobLastKnownEventCommandHandler : ICommandHandler<SetJobLastKnownEventCommand<DbConnection, DbTransaction>>
     {
         private readonly IDbCommandStringCache _commandCache;
         /// <summary>
@@ -46,7 +47,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandHandler
         /// Handles the specified command.
         /// </summary>
         /// <param name="command">The command.</param>
-        public void Handle(SetJobLastKnownEventCommand<IDbConnection, IDbTransaction> command)
+        public void Handle(SetJobLastKnownEventCommand<DbConnection, DbTransaction> command)
         {
             using (var commandSql = command.Connection.CreateCommand())
             {

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandPrepareHandler/MoveRecordToErrorQueueCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandPrepareHandler/MoveRecordToErrorQueueCommandPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
@@ -52,7 +53,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandPrepareHandler
         /// <param name="command">The command.</param>
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
-        public void Handle(MoveRecordToErrorQueueCommand<long> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(MoveRecordToErrorQueueCommand<long> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _buildSql.Create();
             var commandSql = dbCommand;

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandPrepareHandler/ResetHeartBeatCommandPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/CommandPrepareHandler/ResetHeartBeatCommandPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
@@ -48,7 +49,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.CommandPrepareHandler
         /// <param name="command">The command.</param>
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
-        public void Handle(ResetHeartBeatCommand<long> command, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(ResetHeartBeatCommand<long> command, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(CommandStringTypes.ResetHeartbeat);
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/DbConnectionFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/DbConnectionFactory.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Validation;
 
@@ -48,7 +49,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// Creates a new connection to the database
         /// </summary>
         /// <returns></returns>
-        public IDbConnection Create()
+        public DbConnection Create()
         {
             return _dbFactory.CreateConnection(_connectionInformation.ConnectionString, false);
         }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/DbFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/DbFactory.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Data;
+using System.Data.Common;
 using System.Data.SQLite;
 using System.Threading;
 using DotNetWorkQueue.Transport.SQLite;
@@ -71,7 +72,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         }
 
         /// <inheritdoc />
-        public IDbConnection CreateConnection(string connectionString, bool forMemoryHold)
+        public DbConnection CreateConnection(string connectionString, bool forMemoryHold)
         {
             var applied = ConnectionStringPooling.Apply(connectionString, forMemoryHold);
 
@@ -87,13 +88,13 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         }
 
         /// <inheritdoc />
-        public IDbCommand CreateCommand(IDbConnection connection)
+        public DbCommand CreateCommand(DbConnection connection)
         {
             return connection.CreateCommand();
         }
 
         /// <inheritdoc />
-        public IDbCommand CreateCommand(IDbConnection connection, string commandText)
+        public DbCommand CreateCommand(DbConnection connection, string commandText)
         {
             //A pooled connection keeps the statements SQLite compiled for each of its commands;
             //anything else gets the plain behaviour of the interface default.
@@ -106,7 +107,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         }
 
         /// <inheritdoc />
-        public ISQLiteTransactionWrapper CreateTransaction(IDbConnection connection)
+        public ISQLiteTransactionWrapper CreateTransaction(DbConnection connection)
         {
             var transaction = _container.GetInstance<ISQLiteTransactionWrapper>();
             transaction.Connection = connection;

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/Message/ReceiveMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/Message/ReceiveMessage.cs
@@ -21,6 +21,7 @@ using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Validation;
 using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.SQLite.Basic.Message
 {
@@ -30,7 +31,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.Message
     internal class ReceiveMessage
     {
         private readonly QueueConsumerConfiguration _configuration;
-        private readonly IQueryHandler<ReceiveMessageQuery<IDbConnection, IDbTransaction>, IReceivedMessageInternal> _receiveMessage;
+        private readonly IQueryHandler<ReceiveMessageQuery<DbConnection, DbTransaction>, IReceivedMessageInternal> _receiveMessage;
         private readonly ICancelWork _cancelToken;
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.Message
         /// <param name="receiveMessage">The receive message.</param>
         /// <param name="cancelToken">The cancel token.</param>
         public ReceiveMessage(QueueConsumerConfiguration configuration,
-            IQueryHandler<ReceiveMessageQuery<IDbConnection, IDbTransaction>, IReceivedMessageInternal> receiveMessage,
+            IQueryHandler<ReceiveMessageQuery<DbConnection, DbTransaction>, IReceivedMessageInternal> receiveMessage,
             IQueueCancelWork cancelToken)
         {
             Guard.NotNull(configuration);
@@ -69,7 +70,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.Message
 
             //ask for the next message
             var receivedTransportMessage =
-                _receiveMessage.Handle(new ReceiveMessageQuery<IDbConnection, IDbTransaction>(null, null, _configuration.Routes, _configuration.GetUserParameters(), _configuration.GetUserClause()));
+                _receiveMessage.Handle(new ReceiveMessageQuery<DbConnection, DbTransaction>(null, null, _configuration.Routes, _configuration.GetUserParameters(), _configuration.GetUserClause()));
 
             //if no message (null) run the no message action and return
             if (receivedTransportMessage == null)

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/PooledCommand.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/PooledCommand.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Data.SQLite;
 using System.Threading;
@@ -38,7 +39,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
     /// </para>
     /// <para>
     /// Only the compiled statements are worth keeping. Callers build their own parameters through
-    /// <see cref="CreateParameter"/>, so the parameter collection is emptied on release and rebuilt
+    /// <see cref="CreateDbParameter"/>, so the parameter collection is emptied on release and rebuilt
     /// by the next caller; that measured 4,458 ns against 4,230 ns for keeping the parameters too,
     /// which is 99% of the win for none of the disruption to callers.
     /// </para>
@@ -48,7 +49,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
     /// unconditionally - which is the normal shape - therefore keep the benefit without changing.
     /// </para>
     /// </remarks>
-    internal sealed class PooledCommand : IDbCommand
+    internal sealed class PooledCommand : DbCommand
     {
         private readonly PooledConnectionEntry _owner;
         private readonly string _commandText;
@@ -80,7 +81,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                             "changing the text would leave it under a key that no longer describes it. The setter " +
                             "reads the field to accept a caller re-assigning the value it already holds - which is " +
                             "the normal shape of the callers - and refuses anything else.")]
-        public string CommandText
+        public override string CommandText
         {
             //the text this command was rented for, which is also how it is filed
             get => _commandText;
@@ -99,21 +100,25 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         }
 
         /// <inheritdoc />
-        public int CommandTimeout
+        public override int CommandTimeout
         {
             get => Inner.CommandTimeout;
             set => Inner.CommandTimeout = value;
         }
 
         /// <inheritdoc />
-        public CommandType CommandType
+        public override CommandType CommandType
         {
             get => Inner.CommandType;
             set => Inner.CommandType = value;
         }
 
         /// <inheritdoc />
-        public IDbConnection Connection
+        /// <remarks>
+        /// DbCommand exposes the public Connection, Transaction and Parameters members and routes them
+        /// through these protected ones, so they are declared here rather than as public properties.
+        /// </remarks>
+        protected override DbConnection DbConnection
         {
             get => Inner.Connection;
             set => throw new NotSupportedException(
@@ -121,56 +126,63 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         }
 
         /// <inheritdoc />
-        public IDataParameterCollection Parameters => Inner.Parameters;
+        protected override DbParameterCollection DbParameterCollection => Inner.Parameters;
 
         /// <inheritdoc />
-        public IDbTransaction Transaction
+        protected override DbTransaction DbTransaction
         {
             get => Inner.Transaction;
             set => Inner.Transaction = (SQLiteTransaction)value;
         }
 
         /// <inheritdoc />
-        public UpdateRowSource UpdatedRowSource
+        public override UpdateRowSource UpdatedRowSource
         {
             get => Inner.UpdatedRowSource;
             set => Inner.UpdatedRowSource = value;
         }
 
         /// <inheritdoc />
-        public void Cancel() => Inner.Cancel();
+        /// <remarks>Required by DbCommand for designer support; nothing here reads it.</remarks>
+        public override bool DesignTimeVisible { get; set; }
 
         /// <inheritdoc />
-        public IDbDataParameter CreateParameter() => Inner.CreateParameter();
+        public override void Cancel() => Inner.Cancel();
 
         /// <inheritdoc />
-        public int ExecuteNonQuery() => Inner.ExecuteNonQuery();
+        protected override DbParameter CreateDbParameter() => Inner.CreateParameter();
 
         /// <inheritdoc />
-        public IDataReader ExecuteReader() => Inner.ExecuteReader();
+        public override int ExecuteNonQuery() => Inner.ExecuteNonQuery();
 
         /// <inheritdoc />
-        public IDataReader ExecuteReader(CommandBehavior behavior) => Inner.ExecuteReader(behavior);
+        /// <remarks>DbCommand supplies the public ExecuteReader overloads, which route through this.</remarks>
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) =>
+            Inner.ExecuteReader(behavior);
 
         /// <inheritdoc />
-        public object ExecuteScalar() => Inner.ExecuteScalar();
+        public override object ExecuteScalar() => Inner.ExecuteScalar();
 
-        /// <summary>
-        /// No-op. The statements are compiled lazily on execution and kept on the command, which is
-        /// the point of this type.
-        /// </summary>
-        public void Prepare()
+        /// <inheritdoc />
+        public override void Prepare()
         {
             //System.Data.SQLite compiles on execution; Prepare is a no-op there as well
         }
 
-        /// <summary>
-        /// Releases the command back to the connection that owns it, which returns it to the state
-        /// a freshly created one would be in - parameters cleared, transaction detached, settings
-        /// back to their originals - except that its statements are already compiled.
-        /// </summary>
-        public void Dispose()
+        /// <inheritdoc />
+        /// <remarks>
+        /// Returns the command to its pool rather than disposing it - keeping the compiled statements
+        /// is the whole point of this type. The finalizer path does nothing, since the pool holds the
+        /// only reference that matters.
+        /// </remarks>
+        protected override void Dispose(bool disposing)
         {
+            if (!disposing)
+            {
+                base.Dispose(false);
+                return;
+            }
+
             if (Interlocked.Increment(ref _disposeCount) != 1)
                 return;
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/PooledConnection.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/PooledConnection.cs
@@ -71,7 +71,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// A command for <paramref name="commandText"/>, reusing the statements SQLite compiled for
         /// it on this connection. See <see cref="PooledCommand"/> for why that matters.
         /// </summary>
-        internal DbCommand CreateCommand(string commandText) => (DbCommand)Entry.CreateCommand(commandText);
+        internal DbCommand CreateCommand(string commandText) => Entry.CreateCommand(commandText);
 
         /// <summary>How many distinct commands this connection is holding compiled statements for.</summary>
         internal int CachedCommandCount => Entry.CachedCommandCount;

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/PooledConnection.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/PooledConnection.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Data.SQLite;
 using System.Threading;
 
@@ -47,7 +48,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
     /// constructed one was, so nothing is shared between threads and no locking is required.
     /// </para>
     /// </remarks>
-    internal sealed class PooledConnection : IDbConnection
+    internal sealed class PooledConnection : DbConnection
     {
         private readonly DbFactory _owner;
         private readonly string _connectionString;
@@ -70,7 +71,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// A command for <paramref name="commandText"/>, reusing the statements SQLite compiled for
         /// it on this connection. See <see cref="PooledCommand"/> for why that matters.
         /// </summary>
-        internal IDbCommand CreateCommand(string commandText) => Entry.CreateCommand(commandText);
+        internal DbCommand CreateCommand(string commandText) => (DbCommand)Entry.CreateCommand(commandText);
 
         /// <summary>How many distinct commands this connection is holding compiled statements for.</summary>
         internal int CachedCommandCount => Entry.CachedCommandCount;
@@ -80,7 +81,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// <c>Open()</c> because that is the contract for a freshly created connection, and
         /// calling it on an open <see cref="SQLiteConnection"/> would throw.
         /// </summary>
-        public void Open()
+        public override void Open()
         {
             if (Inner.State != ConnectionState.Open)
                 Inner.Open();
@@ -90,25 +91,27 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// No-op. The connection is returned to the pool on <see cref="Dispose"/>, and closing it
         /// here would discard the reuse this type exists to provide.
         /// </summary>
-        public void Close()
+        public override void Close()
         {
             //deliberately does nothing; see Dispose
         }
 
         /// <inheritdoc />
-        public IDbTransaction BeginTransaction() => Inner.BeginTransaction();
+        /// <remarks>
+        /// DbConnection supplies the parameterless BeginTransaction and CreateCommand, which route
+        /// through these two, so the interface versions are no longer declared here.
+        /// </remarks>
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) =>
+            Inner.BeginTransaction(isolationLevel);
 
         /// <inheritdoc />
-        public IDbTransaction BeginTransaction(IsolationLevel il) => Inner.BeginTransaction(il);
+        protected override DbCommand CreateDbCommand() => Inner.CreateCommand();
 
         /// <inheritdoc />
-        public IDbCommand CreateCommand() => Inner.CreateCommand();
+        public override void ChangeDatabase(string databaseName) => Inner.ChangeDatabase(databaseName);
 
         /// <inheritdoc />
-        public void ChangeDatabase(string databaseName) => Inner.ChangeDatabase(databaseName);
-
-        /// <inheritdoc />
-        public string ConnectionString
+        public override string ConnectionString
         {
             //the string this connection was rented for; the provider may normalise its own copy
             get => _connectionString;
@@ -117,21 +120,33 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         }
 
         /// <inheritdoc />
-        public int ConnectionTimeout => Inner.ConnectionTimeout;
+        public override int ConnectionTimeout => Inner.ConnectionTimeout;
 
         /// <inheritdoc />
-        public string Database => Inner.Database;
+        public override string Database => Inner.Database;
 
         /// <inheritdoc />
-        public ConnectionState State => _entry?.Connection.State ?? ConnectionState.Closed;
+        public override string DataSource => Inner.DataSource;
+
+        /// <inheritdoc />
+        public override string ServerVersion => Inner.ServerVersion;
+
+        /// <inheritdoc />
+        public override ConnectionState State => _entry?.Connection.State ?? ConnectionState.Closed;
 
         /// <summary>
         /// Returns the underlying connection to the pool rather than closing it. A connection that
         /// is no longer open — because the operation failed, or the provider dropped it — is
         /// disposed instead, so a broken connection cannot poison the next caller.
         /// </summary>
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
+            if (!disposing)
+            {
+                base.Dispose(false);
+                return;
+            }
+
             if (Interlocked.Increment(ref _disposeCount) != 1)
                 return;
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/PooledConnectionEntry.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/PooledConnectionEntry.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Data.SQLite;
 using System.Threading;
 
@@ -71,7 +72,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// A command for <paramref name="commandText"/>, reusing the statements compiled for it on
         /// this connection where that is possible.
         /// </summary>
-        internal IDbCommand CreateCommand(string commandText)
+        internal DbCommand CreateCommand(string commandText)
         {
             if (Volatile.Read(ref _disposeCount) != 0 || string.IsNullOrEmpty(commandText) || _inUse.Contains(commandText))
                 return Uncached(commandText);

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryHandler/BuildDequeueCommand.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryHandler/BuildDequeueCommand.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Data.SQLite;
 using System.Diagnostics.CodeAnalysis;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
@@ -36,7 +37,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.QueryHandler
 
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification =
             "Query checked")]
-        internal void BuildCommand(IDbCommand selectCommand, CommandString commandString,
+        internal void BuildCommand(DbCommand selectCommand, CommandString commandString,
             SqLiteMessageQueueTransportOptions options, List<string> routes, List<SQLiteParameter> userParameters)
         {
             selectCommand.CommandText = commandString.CommandText;

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryHandler/MessageDeQueue.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryHandler/MessageDeQueue.cs
@@ -24,6 +24,7 @@ using DotNetWorkQueue.Validation;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 
 namespace DotNetWorkQueue.Transport.SQLite.Basic.QueryHandler
@@ -52,7 +53,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.QueryHandler
         }
 
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query checked")]
-        internal IReceivedMessageInternal HandleMessage(IDbConnection connection, IDbTransaction transaction, IDataReader reader, CommandString commandString)
+        internal IReceivedMessageInternal HandleMessage(DbConnection connection, DbTransaction transaction, IDataReader reader, CommandString commandString)
         {
             if (!reader.Read())
             {

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryHandler/ReceiveMessageQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryHandler/ReceiveMessageQueryHandler.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Text;
 using System.Data.SQLite;
 using DotNetWorkQueue.Configuration;
@@ -34,7 +35,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.QueryHandler
     /// <summary>
     /// Dequeues a message.
     /// </summary>
-    internal class ReceiveMessageQueryHandler : IQueryHandler<ReceiveMessageQuery<IDbConnection, IDbTransaction>, IReceivedMessageInternal>
+    internal class ReceiveMessageQueryHandler : IQueryHandler<ReceiveMessageQuery<DbConnection, DbTransaction>, IReceivedMessageInternal>
     {
         private readonly Lazy<SqLiteMessageQueueTransportOptions> _options;
         private readonly ITableNameHelper _tableNameHelper;
@@ -104,7 +105,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.QueryHandler
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns></returns>
-        public IReceivedMessageInternal Handle(ReceiveMessageQuery<IDbConnection, IDbTransaction> query)
+        public IReceivedMessageInternal Handle(ReceiveMessageQuery<DbConnection, DbTransaction> query)
         {
             if (!_databaseExists.Exists(_connectionInformation.ConnectionString))
             {

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryPrepareHandler/FindErrorRecordsToDeleteQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryPrepareHandler/FindErrorRecordsToDeleteQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -52,7 +53,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.QueryPrepareHandler
             _getTime = timeFactory.Create();
         }
         /// <inheritdoc />
-        public void Handle(FindErrorMessagesToDeleteQuery<long> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(FindErrorMessagesToDeleteQuery<long> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryPrepareHandler/FindExpiredRecordsToDeleteQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryPrepareHandler/FindExpiredRecordsToDeleteQueryPrepareHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -53,7 +54,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.QueryPrepareHandler
         /// <param name="query">The query.</param>
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
-        public void Handle(FindExpiredMessagesToDeleteQuery<long> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(FindExpiredMessagesToDeleteQuery<long> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryPrepareHandler/FindRecordsToResetByHeartBeatQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/QueryPrepareHandler/FindRecordsToResetByHeartBeatQueryPrepareHandler.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
@@ -61,7 +62,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic.QueryPrepareHandler
         /// <param name="query">The query.</param>
         /// <param name="dbCommand">The database command.</param>
         /// <param name="commandType">Type of the command.</param>
-        public void Handle(FindMessagesToResetByHeartBeatQuery<long> query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(FindMessagesToResetByHeartBeatQuery<long> query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText =
                 _commandCache.GetCommand(commandType);

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/ReaderAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/ReaderAsync.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Data.SQLite;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.SQLite;
@@ -30,21 +31,21 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
     public class ReaderAsync : IReaderAsync
     {
         /// <inheritdoc />
-        public async Task<int> ExecuteNonQueryAsync(IDbCommand command)
+        public async Task<int> ExecuteNonQueryAsync(DbCommand command)
         {
             var sqlCommand = Provider(command);
             return await sqlCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<object> ExecuteScalarAsync(IDbCommand command)
+        public async Task<object> ExecuteScalarAsync(DbCommand command)
         {
             var sqlCommand = Provider(command);
             return await sqlCommand.ExecuteScalarAsync().ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<IDataReader> ExecuteReaderAsync(IDbCommand command)
+        public async Task<IDataReader> ExecuteReaderAsync(DbCommand command)
         {
             var sqlCommand = Provider(command);
             return await sqlCommand.ExecuteReaderAsync().ConfigureAwait(false);
@@ -56,7 +57,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// reach the concrete command - including through the wrapper a pooled connection returns,
         /// which is not itself a <see cref="SQLiteCommand"/>.
         /// </summary>
-        private static SQLiteCommand Provider(IDbCommand command)
+        private static SQLiteCommand Provider(DbCommand command)
         {
             switch (command)
             {

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SQLiteMessageQueueTransportOptions.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SQLiteMessageQueueTransportOptions.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Text;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.RelationalDatabase;
@@ -451,7 +452,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// <param name="delay">The delay.</param>
         /// <param name="expiration">The expiration.</param>
         /// <param name="currentDateTime">The current date time.</param>
-        internal void AddBuiltInColumnsParams(IDbCommand command, IAdditionalMessageData data, TimeSpan? delay, TimeSpan expiration, DateTime currentDateTime)
+        internal void AddBuiltInColumnsParams(DbCommand command, IAdditionalMessageData data, TimeSpan? delay, TimeSpan expiration, DateTime currentDateTime)
         {
             if (EnableDelayedProcessing)
             {

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SQLiteTransaction.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SQLiteTransaction.cs
@@ -17,18 +17,19 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.SQLite.Basic
 {
     internal class SqLiteTransactionWrapper : ISQLiteTransactionWrapper
     {
-        public IDbConnection Connection
+        public DbConnection Connection
         {
             get;
             set;
         }
 
-        public IDbTransaction BeginTransaction()
+        public DbTransaction BeginTransaction()
         {
             return Connection.BeginTransaction();
         }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteHoldConnection.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteHoldConnection.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.SQLite.Basic
@@ -27,7 +28,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
     {
         private readonly IGetFileNameFromConnectionString _getFileNameFromConnection;
         private readonly IDbFactory _dbFactory;
-        private readonly ConcurrentDictionary<string, IDbConnection> _connections;
+        private readonly ConcurrentDictionary<string, DbConnection> _connections;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqLiteHoldConnection"/> class.
@@ -41,7 +42,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             Guard.NotNull(dbFactory);
             _getFileNameFromConnection = getFileNameFromConnection;
             _dbFactory = dbFactory;
-            _connections = new ConcurrentDictionary<string, IDbConnection>();
+            _connections = new ConcurrentDictionary<string, DbConnection>();
         }
 
         public void AddConnectionIfNeeded(IConnectionInformation connection)

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSharedInit.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSharedInit.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Reflection;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.IoC;
@@ -114,8 +115,8 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             container.Register<SqLiteMessageQueueTransportOptions>(LifeStyles.Singleton);
 
             container
-                .Register<IConnectionHeader<IDbConnection, IDbTransaction, IDbCommand>,
-                    ConnectionHeader<IDbConnection, IDbTransaction, IDbCommand>>(LifeStyles.Singleton);
+                .Register<IConnectionHeader<DbConnection, DbTransaction, DbCommand>,
+                    ConnectionHeader<DbConnection, DbTransaction, DbCommand>>(LifeStyles.Singleton);
             container.Register<ISQLiteTransactionWrapper, SqLiteTransactionWrapper>(LifeStyles.Transient);
             //**all
 
@@ -136,19 +137,19 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
 
             //explicit registration of our job exists query
             container
-                .Register<IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>,
+                .Register<IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>,
                         QueueStatuses>,
-                    DoesJobExistQueryHandler<IDbConnection, IDbTransaction>>(LifeStyles.Singleton);
+                    DoesJobExistQueryHandler<DbConnection, DbTransaction>>(LifeStyles.Singleton);
 
             //because we have an explicit registration for job exists, we need to explicitly register the prepare statement
             container
-                .Register<IPrepareQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>,
+                .Register<IPrepareQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>,
                         QueueStatuses>,
-                    DoesJobExistQueryPrepareHandler<IDbConnection, IDbTransaction>>(LifeStyles.Singleton);
+                    DoesJobExistQueryPrepareHandler<DbConnection, DbTransaction>>(LifeStyles.Singleton);
 
             container
                 .Register<ICommandHandler<MoveRecordToErrorQueueCommand<long>>,
-                    MoveRecordToErrorQueueCommandHandler<IDbConnection, IDbTransaction, IDbCommand>>(LifeStyles
+                    MoveRecordToErrorQueueCommandHandler<DbConnection, DbTransaction, DbCommand>>(LifeStyles
                     .Singleton);
 
             //expired messages
@@ -220,7 +221,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                 typeof(GetTableExistsDecorator), LifeStyles.Singleton);
 
             container.RegisterDecorator(
-                typeof(IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses>),
+                typeof(IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses>),
                 typeof(DoesJobExistDecorator), LifeStyles.Singleton);
 
             container.RegisterDecorator(

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqliteSendToJobQueue.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqliteSendToJobQueue.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -33,7 +34,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
     /// <seealso cref="DotNetWorkQueue.ASendJobToQueue" />
     public class SqliteSendToJobQueue : ASendJobToQueue
     {
-        private readonly IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> _doesJobExist;
+        private readonly IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> _doesJobExist;
         private readonly IRemoveMessage _removeMessage;
         private readonly IQueryHandler<GetJobIdQuery<long>, long> _getJobId;
         private readonly CreateJobMetaData _createJobMetaData;
@@ -45,7 +46,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// <param name="getJobId">The get job identifier.</param>
         /// <param name="createJobMetaData">The create job meta data.</param>
         /// <param name="getTimeFactory">The get time factory.</param>
-        public SqliteSendToJobQueue(IProducerMethodQueue queue, IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> doesJobExist,
+        public SqliteSendToJobQueue(IProducerMethodQueue queue, IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> doesJobExist,
             IRemoveMessage removeMessage,
             IQueryHandler<GetJobIdQuery<long>, long> getJobId, CreateJobMetaData createJobMetaData,
             IGetTimeFactory getTimeFactory) : base(queue, getTimeFactory)
@@ -64,7 +65,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// <returns></returns>
         protected override QueueStatuses DoesJobExist(string name, DateTimeOffset scheduledTime)
         {
-            return _doesJobExist.Handle(new DoesJobExistQuery<IDbConnection, IDbTransaction>(name, scheduledTime));
+            return _doesJobExist.Handle(new DoesJobExistQuery<DbConnection, DbTransaction>(name, scheduledTime));
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/TransactionFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/TransactionFactory.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Validation;
 
@@ -44,7 +45,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         /// </summary>
         /// <param name="connection"></param>
         /// <returns></returns>
-        public ITransactionWrapper Create(IDbConnection connection)
+        public ITransactionWrapper Create(DbConnection connection)
         {
             return _factory.CreateTransaction(connection);
         }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/BeginTransactionRetryDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/BeginTransactionRetryDecorator.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Validation;
 using Polly;
@@ -47,14 +48,14 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         }
 
         /// <inheritdoc />
-        public IDbConnection Connection
+        public DbConnection Connection
         {
             get => _decorated.Connection;
             set => _decorated.Connection = value;
         }
 
         /// <inheritdoc />
-        public IDbTransaction BeginTransaction()
+        public DbTransaction BeginTransaction()
         {
             if (_pipeline == null)
             {

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/DoesJobExistDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/DoesJobExistDecorator.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Transport.Shared;
@@ -28,10 +29,10 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
     /// <summary>
     /// 
     /// </summary>
-    public class DoesJobExistDecorator : IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses>
+    public class DoesJobExistDecorator : IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses>
     {
         private readonly IConnectionInformation _connectionInformation;
-        private readonly IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> _decorated;
+        private readonly IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> _decorated;
         private readonly DatabaseExists _databaseExists;
 
         /// <summary>
@@ -41,7 +42,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         /// <param name="decorated">The decorated.</param>
         /// <param name="databaseExists">The database exists.</param>
         public DoesJobExistDecorator(IConnectionInformation connectionInformation,
-            IQueryHandler<DoesJobExistQuery<IDbConnection, IDbTransaction>, QueueStatuses> decorated,
+            IQueryHandler<DoesJobExistQuery<DbConnection, DbTransaction>, QueueStatuses> decorated,
             DatabaseExists databaseExists)
         {
             Guard.NotNull(decorated);
@@ -57,7 +58,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns></returns>
-        public QueueStatuses Handle(DoesJobExistQuery<IDbConnection, IDbTransaction> query)
+        public QueueStatuses Handle(DoesJobExistQuery<DbConnection, DbTransaction> query)
         {
             return !_databaseExists.Exists(_connectionInformation.ConnectionString) ? QueueStatuses.NotQueued : _decorated.Handle(query);
         }

--- a/Source/DotNetWorkQueue.Transport.SQLite/IDbFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/IDbFactory.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 
 namespace DotNetWorkQueue.Transport.SQLite
 {
@@ -31,14 +32,14 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// <param name="connectionString">The connection string.</param>
         /// <param name="forMemoryHold">if set to <c>true</c> [this connection is our master in-memory connection. This connection keeps the in-memory database alive].</param>
         /// <returns></returns>
-        IDbConnection CreateConnection(string connectionString, bool forMemoryHold);
+        DbConnection CreateConnection(string connectionString, bool forMemoryHold);
 
         /// <summary>
         /// Creates the command.
         /// </summary>
         /// <param name="connection">The connection.</param>
         /// <returns></returns>
-        IDbCommand CreateCommand(IDbConnection connection);
+        DbCommand CreateCommand(DbConnection connection);
 
         /// <summary>
         /// Creates a command for the supplied text, reusing the statements SQLite compiled for it
@@ -55,7 +56,7 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// <param name="connection">The connection.</param>
         /// <param name="commandText">The command text.</param>
         /// <returns></returns>
-        IDbCommand CreateCommand(IDbConnection connection, string commandText)
+        DbCommand CreateCommand(DbConnection connection, string commandText)
         {
             var command = CreateCommand(connection);
             command.CommandText = commandText;
@@ -67,6 +68,6 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// </summary>
         /// <param name="connection"></param>
         /// <returns></returns>
-        ISQLiteTransactionWrapper CreateTransaction(IDbConnection connection);
+        ISQLiteTransactionWrapper CreateTransaction(DbConnection connection);
     }
 }

--- a/Source/DotNetWorkQueue.Transport.SQLite/IReaderAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/IReaderAsync.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.SQLite
@@ -31,18 +32,18 @@ namespace DotNetWorkQueue.Transport.SQLite
         /// </summary>
         /// <param name="command">The command.</param>
         /// <returns></returns>
-        Task<int> ExecuteNonQueryAsync(IDbCommand command);
+        Task<int> ExecuteNonQueryAsync(DbCommand command);
         /// <summary>
         /// Executes a scalar method asynchronous.
         /// </summary>
         /// <param name="command">The command.</param>
         /// <returns></returns>
-        Task<object> ExecuteScalarAsync(IDbCommand command);
+        Task<object> ExecuteScalarAsync(DbCommand command);
         /// <summary>
         /// Executes the reader asynchronous.
         /// </summary>
         /// <param name="command">The command.</param>
         /// <returns></returns>
-        Task<IDataReader> ExecuteReaderAsync(IDbCommand command);
+        Task<IDataReader> ExecuteReaderAsync(DbCommand command);
     }
 }

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/CommandHandler/SetJobLastKnownEventCommandHandlerTests.cs
@@ -29,6 +29,8 @@ using Microsoft.Data.SqlClient;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
+using System.Data.Common;
+
 namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic.CommandHandler
 {
     [TestClass]
@@ -102,7 +104,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic.CommandHandler
 
             handler.Handle(command);
 
-            parameters.Received(3).Add(Arg.Any<IDbDataParameter>());
+            parameters.Received(3).Add(Arg.Any<DbParameter>());
             dbCommand.Received(3).CreateParameter();
         }
 
@@ -111,14 +113,14 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic.CommandHandler
         {
             var commandCache = CreateCommandCache();
 
-            var connection = Substitute.For<IDbConnection>();
-            var dbCommand = Substitute.For<IDbCommand>();
-            var parameters = Substitute.For<IDataParameterCollection>();
+            var connection = Substitute.For<DbConnection>();
+            var dbCommand = Substitute.For<DbCommand>();
+            var parameters = Substitute.For<DbParameterCollection>();
             dbCommand.Parameters.Returns(parameters);
 
-            var paramJobName = Substitute.For<IDbDataParameter>();
-            var paramEventTime = Substitute.For<IDbDataParameter>();
-            var paramScheduledTime = Substitute.For<IDbDataParameter>();
+            var paramJobName = Substitute.For<DbParameter>();
+            var paramEventTime = Substitute.For<DbParameter>();
+            var paramScheduledTime = Substitute.For<DbParameter>();
             dbCommand.CreateParameter().Returns(paramJobName, paramEventTime, paramScheduledTime);
 
             connection.CreateCommand().Returns(dbCommand);
@@ -147,16 +149,16 @@ namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic.CommandHandler
             paramScheduledTime.Received(1).Value = scheduledTime;
         }
 
-        private static (IDbConnectionFactory factory, IDbConnection connection, IDbCommand command, IDataParameterCollection parameters) CreateMockedFactory()
+        private static (IDbConnectionFactory factory, DbConnection connection, DbCommand command, DbParameterCollection parameters) CreateMockedFactory()
         {
-            var connection = Substitute.For<IDbConnection>();
-            var dbCommand = Substitute.For<IDbCommand>();
-            var parameters = Substitute.For<IDataParameterCollection>();
+            var connection = Substitute.For<DbConnection>();
+            var dbCommand = Substitute.For<DbCommand>();
+            var parameters = Substitute.For<DbParameterCollection>();
             dbCommand.Parameters.Returns(parameters);
             dbCommand.CreateParameter().Returns(
-                _ => Substitute.For<IDbDataParameter>(),
-                _ => Substitute.For<IDbDataParameter>(),
-                _ => Substitute.For<IDbDataParameter>());
+                _ => Substitute.For<DbParameter>(),
+                _ => Substitute.For<DbParameter>(),
+                _ => Substitute.For<DbParameter>());
             connection.CreateCommand().Returns(dbCommand);
 
             var factory = Substitute.For<IDbConnectionFactory>();

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/DbConnectionFactory.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/DbConnectionFactory.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Validation;
@@ -43,7 +44,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         /// Creates a new connection to the database
         /// </summary>
         /// <returns></returns>
-        public IDbConnection Create()
+        public DbConnection Create()
         {
             return new SqlConnection(_connectionInformation.ConnectionString);
         }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/QueryPrepareHandler/GetTableExistsQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/QueryPrepareHandler/GetTableExistsQueryPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -46,7 +47,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetTableExistsQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetTableExistsQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
             var tableName = query.TableName;

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/QueryPrepareHandler/GetTableExistsTransactionQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/QueryPrepareHandler/GetTableExistsTransactionQueryPrepareHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data;
+using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -48,7 +49,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic.QueryPrepareHandler
         }
 
         /// <inheritdoc />
-        public void Handle(GetTableExistsTransactionQuery query, IDbCommand dbCommand, CommandStringTypes commandType)
+        public void Handle(GetTableExistsTransactionQuery query, DbCommand dbCommand, CommandStringTypes commandType)
         {
             dbCommand.CommandText = _commandCache.GetCommand(commandType);
             var tableName = query.TableName;


### PR DESCRIPTION
Closes #286. Unblocks the relational half of #284.

**Nothing becomes asynchronous here.** This is the enabling change only, so it reads as the mechanical refactor it is.

## Why

`IDbConnection` and `IDbCommand` are .NET 1.x-era interfaces with **no asynchronous members at all** — `OpenAsync`, `ExecuteNonQueryAsync` and `CommitAsync` live on the `DbConnection`, `DbCommand` and `DbTransaction` base classes. While `IDbConnectionFactory.Create()` returned `IDbConnection`, no relational command handler could be made genuinely asynchronous.

That is what #284 needs for commit, rollback, remove, history and the poison-message path on SQL Server, PostgreSQL and SQLite. Redis was never affected — it goes through Lua on `BaseLua`, which already has `TryExecuteAsync`.

Every provider already derives from the right base types (`SqlConnection`, `NpgsqlConnection`, `SQLiteConnection`), which is what makes this tractable.

## What to look at

**The two SQLite pooling types are the only places with real behaviour to preserve.** `PooledConnection` and `PooledCommand` *implemented* the interfaces; deriving from the abstract bases means implementing their full surface — `ExecuteDbDataReader`, `CreateDbParameter`, `BeginDbTransaction`, `DesignTimeVisible`, `Dispose(bool)` — and letting the base route the public members through them.

Their behaviour is unchanged and worth confirming in review: the command still refuses a *different* `CommandText` while accepting a re-assignment of the same one, still keeps the statements SQLite compiled for it, and still returns itself to the pool on dispose rather than disposing the inner command. That caching is what #217–#222 measured, so a regression here would be a performance regression rather than a visible failure.

**The test doubles had to move too**, which is not obvious. Substituting an interface and substituting an abstract class are not equivalent to NSubstitute: `DbCommand.ExecuteReader` is non-virtual and routes through the protected `ExecuteDbDataReader`, so readers became `DbDataReader`, parameters `DbParameter`, and the hand-written `DataParameterCollection` fake now derives from `DbParameterCollection`.

**One name collision.** `System.Data.Common` gained its own `DbDataSource` in .NET 7, which clashes with this transport's type of the same name. Aliased at the single call site rather than renaming ours.

## Breaking

Yes, for anyone implementing `IDbConnectionFactory`, `ITransactionFactory` or `ITransactionWrapper` outside this repository. Taken deliberately — the alternatives were to cast at every call site and degrade silently for providers that do not derive from `DbConnection`, or to leave three transports permanently unable to offer an async path.

## Validation

- Full solution builds; `NoTests.sln -c Release -p:CI=true` clean
- Unit suites, 2,370 passed / 0 failed: core 1118, RelationalDatabase 247, SQLite 224, SqlServer 197, PostgreSQL 182, Redis 192, LiteDb 179, Memory 31
- **SQLite integration: 200 passed / 0 failed** — the suite that actually exercises the rewritten pooling, end to end against real database files

SQL Server and PostgreSQL integration were not run locally; their unit suites pass and Jenkins covers the rest. Given the breadth here, Jenkins is the verdict that counts — every relational path goes through this abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
