### PR TITLE
feat: move a poison message to the error queue without blocking (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 - ⚠️ Custom transports and consumers must add async members: `IReceiveMessages.ReceiveMessageAsync`, `IQueueWait.WaitAsync`, and `IRedisQueueWorkSub.WaitAsync` for Redis. Built-in transports are unaffected (GitHub #256)
 - ⚠️ `IMessageProcessing.Handle()` is now `HandleAsync()` and returns a task. Only affects code implementing that interface directly (GitHub #256)
 - Tracing: the async consumer emits its receive span as `ReceiveMessageAsync` rather than `ReceiveMessage`. Dashboards filtering on the old name will not match it. Metric names are unchanged (GitHub #256)
-- The async consumer moves a poison message to the error queue without holding a thread while it waits on the transport (GitHub #284)
-- ⚠️ `IReceivePoisonMessage` gains `HandleAsync`. Only affects code implementing that interface directly (GitHub #284)
+- Async consumers keep working under thread-pool pressure when a message turns out to be poison; moving it to the error queue used to occupy a pool thread for the whole round trip (GitHub #284)
+- ⚠️ `IReceivePoisonMessage` gains `HandleAsync` and `ITransactionWrapper` gains `BeginTransactionAsync`. Only affects code implementing those interfaces directly (GitHub #284)
 - ⚠️ Custom relational transports: `IDbConnectionFactory`, `ITransactionFactory` and `ITransactionWrapper` now use `System.Data.Common` types (`DbConnection`, `DbTransaction`) rather than the `System.Data` interfaces, which have no async members. Built-in transports are unaffected (GitHub #286)
 
 ### 0.11.0 — 2026-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - ⚠️ Custom transports and consumers must add async members: `IReceiveMessages.ReceiveMessageAsync`, `IQueueWait.WaitAsync`, and `IRedisQueueWorkSub.WaitAsync` for Redis. Built-in transports are unaffected (GitHub #256)
 - ⚠️ `IMessageProcessing.Handle()` is now `HandleAsync()` and returns a task. Only affects code implementing that interface directly (GitHub #256)
 - Tracing: the async consumer emits its receive span as `ReceiveMessageAsync` rather than `ReceiveMessage`. Dashboards filtering on the old name will not match it. Metric names are unchanged (GitHub #256)
+- The async consumer moves a poison message to the error queue without holding a thread while it waits on the transport (GitHub #284)
+- ⚠️ `IReceivePoisonMessage` gains `HandleAsync`. Only affects code implementing that interface directly (GitHub #284)
+- ⚠️ Custom relational transports: `IDbConnectionFactory`, `ITransactionFactory` and `ITransactionWrapper` now use `System.Data.Common` types (`DbConnection`, `DbTransaction`) rather than the `System.Data` interfaces, which have no async members. Built-in transports are unaffected (GitHub #286)
 
 ### 0.11.0 — 2026-09-06
 - SQL Server and PostgreSQL: an ordinary send is one round trip instead of four, on `Send` and `SendAsync`. A SQL Server send allocates 16% less — 29,298 B down to 24,648 B — and the time saved grows with distance to the server (GitHub #231, #232)

--- a/Source/DotNetWorkQueue.Tests/IoC/CreateContainerTest.cs
+++ b/Source/DotNetWorkQueue.Tests/IoC/CreateContainerTest.cs
@@ -264,6 +264,11 @@ namespace DotNetWorkQueue.Tests.IoC
             {
 
             }
+
+            public Task HandleAsync(IMessageContext context, PoisonMessageException exception)
+            {
+                return Task.CompletedTask;
+            }
         }
         internal class ReceiveMessagesErrorNoOp : IReceiveMessagesError
         {

--- a/Source/DotNetWorkQueue.Tests/Queue/MessageProcessingAsyncPoisonTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/MessageProcessingAsyncPoisonTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Notifications;
+using DotNetWorkQueue.Queue;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace DotNetWorkQueue.Tests.Queue
+{
+    /// <summary>
+    /// The poison-message path on the asynchronous consumer.
+    ///
+    /// Moving a message to the error queue is transport I/O. Before #284 the asynchronous consumer
+    /// called the synchronous <see cref="IReceivePoisonMessage.Handle"/> for it, which was free while
+    /// the receive was a blocking call on the worker's own dedicated thread. Once the receive became
+    /// awaitable this catch block runs in a continuation on a thread-pool thread, where that same
+    /// call blocks one of the threads the consumer needs.
+    ///
+    /// Two things are asserted, because only the pair of them rules out a half-conversion: that the
+    /// asynchronous member is the one called, and that its task is actually awaited. Calling
+    /// <c>HandleAsync</c> and discarding the task would satisfy the first on its own while quietly
+    /// letting the queue carry on before the message had been moved.
+    /// </summary>
+    [TestClass]
+    public class MessageProcessingAsyncPoisonTests
+    {
+        private static readonly TimeSpan SettleTime = TimeSpan.FromMilliseconds(250);
+
+        [TestMethod]
+        public async Task PoisonMessage_MovesThroughTheAsynchronousHandler()
+        {
+            var harness = new Harness();
+
+            var readyForNext = harness.Processor.HandleAsync();
+            harness.CompleteTheMove();
+            await readyForNext.ConfigureAwait(false);
+
+            await harness.PoisonHandler.Received(1)
+                .HandleAsync(Arg.Any<IMessageContext>(), Arg.Any<PoisonMessageException>())
+                .ConfigureAwait(false);
+            harness.PoisonHandler.DidNotReceive()
+                .Handle(Arg.Any<IMessageContext>(), Arg.Any<PoisonMessageException>());
+        }
+
+        [TestMethod]
+        public async Task PoisonMessage_TheWorkerLoopWaitsForTheMoveToFinish()
+        {
+            var harness = new Harness();
+
+            var readyForNext = harness.Processor.HandleAsync();
+
+            var completedEarly = await Task.WhenAny(readyForNext, Task.Delay(SettleTime))
+                .ConfigureAwait(false) == readyForNext;
+
+            Assert.IsFalse(completedEarly,
+                "The worker loop was released while the message was still being moved to the error " +
+                "queue. Discarding that task lets the consumer de-queue again - and shut down - " +
+                "before the move has happened.");
+
+            harness.CompleteTheMove();
+            await readyForNext.ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task PoisonMessage_NotifiesOnlyAfterTheMoveHasFinished()
+        {
+            var harness = new Harness();
+
+            var readyForNext = harness.Processor.HandleAsync();
+            await Task.Delay(SettleTime).ConfigureAwait(false);
+
+            harness.ErrorNotification.DidNotReceive()
+                .InvokePoisonMessageError(Arg.Any<PoisonMessageNotification>());
+
+            harness.CompleteTheMove();
+            await readyForNext.ConfigureAwait(false);
+
+            harness.ErrorNotification.Received(1)
+                .InvokePoisonMessageError(Arg.Any<PoisonMessageNotification>());
+        }
+
+        private sealed class Harness
+        {
+            private readonly TaskCompletionSource<bool> _move =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public MessageProcessingAsync Processor { get; }
+            public IReceivePoisonMessage PoisonHandler { get; }
+            public IConsumerQueueErrorNotification ErrorNotification { get; }
+
+            public Harness()
+            {
+                var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
+
+                var receiveMessages = Substitute.For<IReceiveMessages>();
+                SetupPoisonReceive(receiveMessages);
+
+                var receiveFactory = Substitute.For<IReceiveMessagesFactory>();
+                receiveFactory.Create().Returns(receiveMessages);
+
+                PoisonHandler = Substitute.For<IReceivePoisonMessage>();
+                PoisonHandler.HandleAsync(Arg.Any<IMessageContext>(), Arg.Any<PoisonMessageException>())
+                    .Returns(_ => _move.Task);
+
+                ErrorNotification = Substitute.For<IConsumerQueueErrorNotification>();
+
+                fixture.Inject(receiveFactory);
+                fixture.Inject(PoisonHandler);
+                fixture.Inject(ErrorNotification);
+
+                Processor = fixture.Create<MessageProcessingAsync>();
+            }
+
+            public void CompleteTheMove() => _move.TrySetResult(true);
+
+            private static void SetupPoisonReceive(IReceiveMessages receiveMessages)
+            {
+                //See MessageProcessingAsyncPacingTests: configuring the substitute is the one place
+                //the returned ValueTask is not meant to be consumed, and CA2012 is an error repo-wide.
+#pragma warning disable CA2012
+                receiveMessages.ReceiveMessageAsync(Arg.Any<IMessageContext>(), Arg.Any<CancellationToken>())
+                    .Throws(new PoisonMessageException());
+#pragma warning restore CA2012
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Tests/Trace/Decorator/ReceivePoisonMessageDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Trace/Decorator/ReceivePoisonMessageDecoratorTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Trace.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Tests.Trace.Decorator
+{
+    /// <summary>
+    /// The tracing decorator over the poison-message handler.
+    ///
+    /// It is the only one of the three decorators on <see cref="IReceivePoisonMessage"/> that is
+    /// public; the logging and metrics ones are internal and are covered where the container builds
+    /// the whole chain. What matters here is that the asynchronous member is a decorator rather than
+    /// a bypass: it must reach the decorated handler, and it must not close the activity until the
+    /// move to the error queue has finished, or the span records a duration that excludes the work
+    /// it is meant to measure.
+    /// </summary>
+    [TestClass]
+    public class ReceivePoisonMessageDecoratorTests
+    {
+        [TestMethod]
+        public async Task HandleAsync_ReachesTheDecoratedHandler_WithNoTraceHeader()
+        {
+            var harness = new Harness(header: null);
+
+            await harness.Decorator.HandleAsync(harness.Context, harness.Exception).ConfigureAwait(false);
+
+            await harness.Decorated.Received(1).HandleAsync(harness.Context, harness.Exception)
+                .ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_ReachesTheDecoratedHandler_WithATraceHeader()
+        {
+            var harness = new Harness(header: new Dictionary<string, object>());
+
+            await harness.Decorator.HandleAsync(harness.Context, harness.Exception).ConfigureAwait(false);
+
+            await harness.Decorated.Received(1).HandleAsync(harness.Context, harness.Exception)
+                .ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_DoesNotCallTheBlockingHandler()
+        {
+            var harness = new Harness(header: null);
+
+            await harness.Decorator.HandleAsync(harness.Context, harness.Exception).ConfigureAwait(false);
+
+            harness.Decorated.DidNotReceive().Handle(Arg.Any<IMessageContext>(), Arg.Any<PoisonMessageException>());
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WaitsForTheDecoratedHandler()
+        {
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var harness = new Harness(header: null);
+            harness.Decorated.HandleAsync(Arg.Any<IMessageContext>(), Arg.Any<PoisonMessageException>())
+                .Returns(_ => gate.Task);
+
+            var handling = harness.Decorator.HandleAsync(harness.Context, harness.Exception);
+
+            var completedEarly = await Task.WhenAny(handling, Task.Delay(TimeSpan.FromMilliseconds(250)))
+                .ConfigureAwait(false) == handling;
+
+            Assert.IsFalse(completedEarly,
+                "The decorator returned before the handler it decorates had finished. The activity " +
+                "would close over none of the work it is timing.");
+
+            gate.TrySetResult(true);
+            await handling.ConfigureAwait(false);
+        }
+
+        private sealed class Harness
+        {
+            public ReceivePoisonMessageDecorator Decorator { get; }
+            public IReceivePoisonMessage Decorated { get; }
+            public IMessageContext Context { get; }
+            public PoisonMessageException Exception { get; }
+
+            public Harness(IDictionary<string, object> header)
+            {
+                Decorated = Substitute.For<IReceivePoisonMessage>();
+                Context = Substitute.For<IMessageContext>();
+                Exception = new PoisonMessageException();
+
+                var getHeader = Substitute.For<IGetHeader>();
+                getHeader.GetHeaders(Arg.Any<IMessageId>()).Returns(header);
+
+                Decorator = new ReceivePoisonMessageDecorator(Decorated,
+                    new ActivitySource("DotNetWorkQueue.Tests.PoisonMessage"),
+                    Substitute.For<IStandardHeaders>(),
+                    getHeader);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
@@ -1,0 +1,55 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
+{
+    /// <summary>
+    /// Moves a record from the meta table to the error table
+    /// </summary>
+    /// <remarks>
+    /// LiteDB has no asynchronous API, so this runs the synchronous handler on the thread pool -
+    /// the same hack <see cref="SendMessageCommandHandlerAsync"/> uses. It keeps the caller's thread
+    /// free, which is what the asynchronous consumer needs; it does not make the work asynchronous.
+    /// Issue #283 tracks replacing this once LiteDB v6 ships real async methods.
+    /// </remarks>
+    public class MoveRecordToErrorQueueCommandHandlerAsync : ICommandHandlerAsync<MoveRecordToErrorQueueCommand<int>>
+    {
+        private readonly ICommandHandler<MoveRecordToErrorQueueCommand<int>> _handler;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MoveRecordToErrorQueueCommandHandlerAsync"/> class.
+        /// </summary>
+        /// <param name="handler">The synchronous handler that does the work.</param>
+        public MoveRecordToErrorQueueCommandHandlerAsync(ICommandHandler<MoveRecordToErrorQueueCommand<int>> handler)
+        {
+            Guard.NotNull(handler);
+            _handler = handler;
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(MoveRecordToErrorQueueCommand<int> command)
+        {
+            await Task.Run(() => _handler.Handle(command)).ConfigureAwait(false);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbMessageQueueInit.cs
@@ -135,6 +135,9 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
             container.Register(typeof(ICommandHandler<>), LifeStyles.Singleton,
                 target);
 
+            container.Register(typeof(ICommandHandlerAsync<>), LifeStyles.Singleton,
+                target);
+
             container.Register(typeof(IQueryHandler<,>), LifeStyles.Singleton,
                 target);
 

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.Transport.LiteDb.Basic;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
+{
+    /// <summary>
+    /// Container registration for the asynchronous poison-message path (#284).
+    ///
+    /// LiteDB gains nothing from this in itself - it has no asynchronous API until v6 (#283) - but
+    /// the shared <c>ReceivePoisonMessage</c> every transport resolves now takes both handlers, so a
+    /// missing registration here fails at run time in the consumer rather than at compile time.
+    /// </summary>
+    [TestClass]
+    public class PoisonMessageAsyncRegistrationTests
+    {
+        private static readonly string FakeConnection =
+            Path.Combine(Path.GetTempPath(), "dnwq-poison-registration.db");
+
+        [TestMethod]
+        public void MoveRecordToErrorQueue_ResolvesForTheAsynchronousPath()
+        {
+            ICommandHandlerAsync<MoveRecordToErrorQueueCommand<int>> handler = null;
+            IReceivePoisonMessage poisonMessage = null;
+
+            using (var qc = new QueueContainer<LiteDbMessageQueueInit>(
+                registerService: _ => { },
+                setOptions: container =>
+                {
+                    handler = container.GetInstance<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<int>>>();
+                    poisonMessage = container.GetInstance<IReceivePoisonMessage>();
+                }))
+            {
+                try { qc.CreateConsumer(new QueueConnection("poison_registration", FakeConnection)); }
+                catch { /* the database does not exist; the resolutions above are the point */ }
+            }
+
+            Assert.IsNotNull(handler, "The asynchronous move-to-error-queue handler did not resolve.");
+            Assert.IsNotNull(poisonMessage, "IReceivePoisonMessage did not resolve.");
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
@@ -17,8 +18,22 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
     [TestClass]
     public class PoisonMessageAsyncRegistrationTests
     {
-        private static readonly string FakeConnection =
-            Path.Combine(Path.GetTempPath(), "dnwq-poison-registration.db");
+        private string _database;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            //A path of its own per run: the container reaches the file, and a shared name would make
+            //this test depend on whatever a previous run left behind.
+            _database = Path.Combine(Path.GetTempPath(),
+                $"dnwq-poison-registration-{Guid.NewGuid():N}.db");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            try { File.Delete(_database); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+        }
 
         [TestMethod]
         public void MoveRecordToErrorQueue_ResolvesForTheAsynchronousPath()
@@ -34,7 +49,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                     poisonMessage = container.GetInstance<IReceivePoisonMessage>();
                 }))
             {
-                try { qc.CreateConsumer(new QueueConnection("poison_registration", FakeConnection)); }
+                try { qc.CreateConsumer(new QueueConnection("poison_registration", _database)); }
                 catch { /* the database does not exist; the resolutions above are the point */ }
             }
 

--- a/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/ReceivePoisonMessageTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Tests/Basic/ReceivePoisonMessageTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Transport.Memory;
+using DotNetWorkQueue.Transport.Memory.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Transport.Memory.Tests.Basic
+{
+    /// <summary>
+    /// The memory transport's poison-message handler.
+    ///
+    /// Its asynchronous member is deliberately a completed task around the synchronous work - there
+    /// is no I/O here to release a thread for - so what is worth pinning is that it still does the
+    /// work rather than becoming a silent no-op, and that it still declines a context with no
+    /// message id.
+    /// </summary>
+    [TestClass]
+    public class ReceivePoisonMessageTests
+    {
+        [TestMethod]
+        public async Task HandleAsync_MovesTheMessageToTheErrorQueue()
+        {
+            var storage = Substitute.For<IDataStorage>();
+            var id = Guid.NewGuid();
+            var context = ContextWith(id);
+            var exception = new PoisonMessageException();
+
+            await new ReceivePoisonMessage(storage).HandleAsync(context, exception).ConfigureAwait(false);
+
+            storage.Received(1).MoveToErrorQueue(exception, id, context);
+            context.Received(1).SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WithNoMessageId_DoesNothing()
+        {
+            var storage = Substitute.For<IDataStorage>();
+            var context = Substitute.For<IMessageContext>();
+            var messageId = Substitute.For<IMessageId>();
+            messageId.HasValue.Returns(false);
+            context.MessageId.Returns(messageId);
+
+            await new ReceivePoisonMessage(storage).HandleAsync(context, new PoisonMessageException())
+                .ConfigureAwait(false);
+
+            storage.DidNotReceiveWithAnyArgs().MoveToErrorQueue(null, Guid.Empty, null);
+        }
+
+        private static IMessageContext ContextWith(Guid id)
+        {
+            var setting = Substitute.For<ISetting>();
+            setting.Value.Returns(id);
+
+            var messageId = Substitute.For<IMessageId>();
+            messageId.HasValue.Returns(true);
+            messageId.Id.Returns(setting);
+
+            var context = Substitute.For<IMessageContext>();
+            context.MessageId.Returns(messageId);
+            return context;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
@@ -1,0 +1,59 @@
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IoC;
+using DotNetWorkQueue.Transport.RelationalDatabase;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using DotNetWorkQueue.Transport.PostgreSQL.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Transport.PostgreSQL.Tests.Basic
+{
+    /// <summary>
+    /// Container registration for the asynchronous poison-message path (#284).
+    ///
+    /// The handler is only half of the change: an <see cref="ICommandHandlerAsync{TCommand}"/> that
+    /// resolves without its retry decorator would move a message to the error queue on the first
+    /// transient failure instead of retrying, and nothing else in the suite would notice - the
+    /// synchronous twin beside it retries either way.
+    /// </summary>
+    [TestClass]
+    public class PoisonMessageAsyncRegistrationTests
+    {
+        private const string FakeConnection =
+            "Server=localhost;Application Name=Test;Database=db;User ID=sa;Password=password";
+
+        [TestMethod]
+        public void MoveRecordToErrorQueue_ResolvesWrappedInTheRetryDecorator()
+        {
+            ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>> handler = null;
+            IReceivePoisonMessage poisonMessage = null;
+
+            using (var qc = new QueueContainer<PostgreSqlMessageQueueInit>(
+                registerService: container =>
+                {
+                    //Without this the container reaches the database for its defaults before the
+                    //callback below ever runs.
+                    var stubFactory = Substitute.For<ITransportOptionsFactory>();
+                    stubFactory.Create().Returns(new PostgreSqlMessageQueueTransportOptions());
+                    container.Register<ITransportOptionsFactory>(() => stubFactory, LifeStyles.Singleton);
+                },
+                setOptions: container =>
+                {
+                    handler = container.GetInstance<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>>();
+                    poisonMessage = container.GetInstance<IReceivePoisonMessage>();
+                }))
+            {
+                try { qc.CreateConsumer(new QueueConnection("ADMIN", FakeConnection)); }
+                catch { /* the fake connection fails further down; the resolutions above are the point */ }
+            }
+
+            Assert.IsNotNull(handler, "The asynchronous move-to-error-queue handler did not resolve.");
+            Assert.IsInstanceOfType<RetryCommandHandlerDecoratorAsync<MoveRecordToErrorQueueCommand<long>>>(handler,
+                "The asynchronous handler resolved without its retry decorator, so a transient failure " +
+                "would move the message to the error queue instead of being retried.");
+            Assert.IsNotNull(poisonMessage, "IReceivePoisonMessage did not resolve.");
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueInit.cs
@@ -206,6 +206,9 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             container
                 .Register<ICommandHandler<MoveRecordToErrorQueueCommand<long>>,
                     MoveRecordToErrorQueueCommandHandler<NpgsqlConnection, NpgsqlTransaction, NpgsqlCommand>>(LifeStyles.Singleton);
+            container
+                .Register<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>,
+                    MoveRecordToErrorQueueCommandHandlerAsync<NpgsqlConnection, NpgsqlTransaction, NpgsqlCommand>>(LifeStyles.Singleton);
 
             //explicit registration of options
             container

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
@@ -1,0 +1,52 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.Redis.Basic.Command;
+using DotNetWorkQueue.Transport.Redis.Basic.Lua;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Transport.Redis.Basic.CommandHandler
+{
+    /// <inheritdoc />
+    internal class MoveRecordToErrorQueueCommandHandlerAsync : ICommandHandlerAsync<MoveRecordToErrorQueueCommand<string>>
+    {
+        private readonly ErrorLua _errorLua;
+        private readonly IUnixTime _unixTime;
+
+        /// <summary>Initializes a new instance of the <see cref="DeleteMessageCommandHandler"/> class.</summary>
+        /// <param name="errorLua">The error lua.</param>
+        /// <param name="timeFactory">Time factory</param>
+        public MoveRecordToErrorQueueCommandHandlerAsync(ErrorLua errorLua, IUnixTimeFactory timeFactory)
+        {
+            Guard.NotNull(errorLua);
+            Guard.NotNull(timeFactory);
+            _errorLua = errorLua;
+            _unixTime = timeFactory.Create();
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(MoveRecordToErrorQueueCommand<string> command)
+        {
+            await _errorLua.ExecuteAsync(command.QueueId, _unixTime.GetCurrentUnixTimestampMilliseconds())
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Lua/ErrorLua.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Lua/ErrorLua.cs
@@ -56,10 +56,6 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Lua
                 return null;
             return (int)result;
         }
-        /// <summary>Gets the parameters.</summary>
-        /// <param name="messageId">The message identifier.</param>
-        /// <param name="unixTime">current time</param>
-        /// <returns></returns>
         /// <summary>
         /// Moves a message to the error queue without blocking a thread across the call.
         /// </summary>
@@ -76,7 +72,10 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Lua
                 return null;
             return (int)result;
         }
-
+        /// <summary>Gets the parameters.</summary>
+        /// <param name="messageId">The message identifier.</param>
+        /// <param name="unixTime">current time</param>
+        /// <returns></returns>
         private object GetParameters(string messageId, long unixTime)
         {
             return new

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/Lua/ErrorLua.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/Lua/ErrorLua.cs
@@ -18,6 +18,8 @@
 // ---------------------------------------------------------------------
 using StackExchange.Redis;
 
+using System.Threading.Tasks;
+
 namespace DotNetWorkQueue.Transport.Redis.Basic.Lua
 {
     /// <inheritdoc />
@@ -58,6 +60,23 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.Lua
         /// <param name="messageId">The message identifier.</param>
         /// <param name="unixTime">current time</param>
         /// <returns></returns>
+        /// <summary>
+        /// Moves a message to the error queue without blocking a thread across the call.
+        /// </summary>
+        /// <remarks>
+        /// A line-for-line twin of <see cref="Execute"/>, differing only in awaiting the script. It
+        /// deliberately omits the <c>Connection.IsDisposed</c> guard that <c>DequeueLua.ExecuteAsync</c>
+        /// opens with, because the synchronous method here does not have one either - matching its own
+        /// twin matters more than matching the other script.
+        /// </remarks>
+        public async Task<int?> ExecuteAsync(string messageId, long unixTime)
+        {
+            var result = await TryExecuteAsync(GetParameters(messageId, unixTime)).ConfigureAwait(false);
+            if (result.IsNull)
+                return null;
+            return (int)result;
+        }
+
         private object GetParameters(string messageId, long unixTime)
         {
             return new

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueInit.cs
@@ -144,6 +144,9 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             container.Register(typeof(ICommandHandler<>), LifeStyles.Singleton,
                 target);
 
+            container.Register(typeof(ICommandHandlerAsync<>), LifeStyles.Singleton,
+                target);
+
             container.Register(typeof(IQueryHandler<,>), LifeStyles.Singleton,
                 target);
 

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceivePoisonMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceivePoisonMessage.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading.Tasks;
 using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
@@ -28,13 +29,17 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
     internal class RedisQueueReceivePoisonMessage : IReceivePoisonMessage
     {
         private readonly ICommandHandler<MoveRecordToErrorQueueCommand<string>> _commandMoveRecord;
+        private readonly ICommandHandlerAsync<MoveRecordToErrorQueueCommand<string>> _commandMoveRecordAsync;
         /// <summary>
         /// Initializes a new instance of the <see cref="RedisQueueReceivePoisonMessage"/> class.
         /// </summary>
         /// <param name="commandMoveRecord">The command move record.</param>
-        public RedisQueueReceivePoisonMessage(ICommandHandler<MoveRecordToErrorQueueCommand<string>> commandMoveRecord)
+        /// <param name="commandMoveRecordAsync">The command move record, for the asynchronous consumer.</param>
+        public RedisQueueReceivePoisonMessage(ICommandHandler<MoveRecordToErrorQueueCommand<string>> commandMoveRecord,
+            ICommandHandlerAsync<MoveRecordToErrorQueueCommand<string>> commandMoveRecordAsync)
         {
             _commandMoveRecord = commandMoveRecord;
+            _commandMoveRecordAsync = commandMoveRecordAsync;
         }
 
         /// <summary>
@@ -47,6 +52,18 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             if (context.MessageId != null && context.MessageId.HasValue)
             {
                 _commandMoveRecord.Handle(new MoveRecordToErrorQueueCommand<string>(exception, context.MessageId.Id.Value.ToString(), context));
+            }
+            context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(IMessageContext context, PoisonMessageException exception)
+        {
+            if (context.MessageId != null && context.MessageId.HasValue)
+            {
+                await _commandMoveRecordAsync.HandleAsync(
+                    new MoveRecordToErrorQueueCommand<string>(exception, context.MessageId.Id.Value.ToString(), context))
+                    .ConfigureAwait(false);
             }
             context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/ReceivePoisonMessageTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/ReceivePoisonMessageTests.cs
@@ -1,0 +1,98 @@
+using System.Threading.Tasks;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
+{
+    /// <summary>
+    /// The shared poison-message handler every relational transport resolves.
+    ///
+    /// It holds both the synchronous and the asynchronous command handler, and the two paths must
+    /// stay separate: the asynchronous consumer calling the synchronous handler is the defect #284
+    /// exists to remove, and it would be invisible - the message still reaches the error queue
+    /// either way - so it is asserted directly.
+    /// </summary>
+    [TestClass]
+    public class ReceivePoisonMessageTests
+    {
+        [TestMethod]
+        public async Task HandleAsync_UsesTheAsynchronousCommandHandler()
+        {
+            var harness = new Harness();
+
+            await harness.Sut.HandleAsync(harness.Context, harness.Exception).ConfigureAwait(false);
+
+            await harness.Async.Received(1).HandleAsync(Arg.Any<MoveRecordToErrorQueueCommand<long>>())
+                .ConfigureAwait(false);
+            harness.Sync.DidNotReceiveWithAnyArgs().Handle(null);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_CarriesTheMessageIdAndException()
+        {
+            var harness = new Harness();
+
+            await harness.Sut.HandleAsync(harness.Context, harness.Exception).ConfigureAwait(false);
+
+            await harness.Async.Received(1).HandleAsync(Arg.Is<MoveRecordToErrorQueueCommand<long>>(
+                    c => c.QueueId == Harness.MessageId && ReferenceEquals(c.Exception, harness.Exception)))
+                .ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_ClearsTheMessageOnceTheMoveHasFinished()
+        {
+            var harness = new Harness();
+
+            await harness.Sut.HandleAsync(harness.Context, harness.Exception).ConfigureAwait(false);
+
+            harness.Context.Received(1)
+                .SetMessageAndHeaders(null, harness.Context.CorrelationId, harness.Context.Headers);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WithNoMessageId_DoesNothing()
+        {
+            var harness = new Harness(hasMessageId: false);
+
+            await harness.Sut.HandleAsync(harness.Context, harness.Exception).ConfigureAwait(false);
+
+            await harness.Async.DidNotReceiveWithAnyArgs().HandleAsync(null).ConfigureAwait(false);
+            harness.Context.DidNotReceiveWithAnyArgs().SetMessageAndHeaders(null, null, null);
+        }
+
+        private sealed class Harness
+        {
+            public const long MessageId = 42L;
+
+            public ReceivePoisonMessage<long> Sut { get; }
+            public ICommandHandler<MoveRecordToErrorQueueCommand<long>> Sync { get; }
+            public ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>> Async { get; }
+            public IMessageContext Context { get; }
+            public PoisonMessageException Exception { get; }
+
+            public Harness(bool hasMessageId = true)
+            {
+                Sync = Substitute.For<ICommandHandler<MoveRecordToErrorQueueCommand<long>>>();
+                Async = Substitute.For<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>>();
+                Exception = new PoisonMessageException();
+
+                var setting = Substitute.For<ISetting>();
+                setting.Value.Returns(MessageId);
+
+                var messageId = Substitute.For<IMessageId>();
+                messageId.HasValue.Returns(hasMessageId);
+                messageId.Id.Returns(setting);
+
+                Context = Substitute.For<IMessageContext>();
+                Context.MessageId.Returns(messageId);
+
+                Sut = new ReceivePoisonMessage<long>(Sync, Async);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/DeleteMetaDataCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/DeleteMetaDataCommandHandlerAsync.cs
@@ -1,0 +1,58 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Deletes the meta data for a message
+    /// </summary>
+    public class DeleteMetaDataCommandHandlerAsync : ICommandHandlerAsync<DeleteMetaDataCommand>
+    {
+        private readonly IPrepareCommandHandler<DeleteMetaDataCommand> _prepareCommand;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteMetaDataCommandHandlerAsync" /> class.
+        /// </summary>
+        /// <param name="prepareCommand">The prepare command.</param>
+        public DeleteMetaDataCommandHandlerAsync(
+            IPrepareCommandHandler<DeleteMetaDataCommand> prepareCommand)
+        {
+            Guard.NotNull(prepareCommand);
+
+            _prepareCommand = prepareCommand;
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(DeleteMetaDataCommand command)
+        {
+            using (
+                var commandSqlDeleteMetaData = command.Connection.CreateCommand())
+            {
+                _prepareCommand.Handle(command, commandSqlDeleteMetaData, CommandStringTypes.DeleteFromMetaData);
+                commandSqlDeleteMetaData.Transaction = command.Transaction;
+                await commandSqlDeleteMetaData.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
@@ -95,7 +95,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
                 using (var conn = _dbConnectionFactory.Create())
                 {
                     await conn.OpenAsync().ConfigureAwait(false);
-                    using (var trans = _transactionFactory.Create(conn).BeginTransaction())
+                    using (var trans = await _transactionFactory.Create(conn).BeginTransactionAsync().ConfigureAwait(false))
                     {
                         using (var commandSql = conn.CreateCommand())
                         {

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
@@ -1,0 +1,153 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Moves a record from the meta table to the error table
+    /// </summary>
+    public class MoveRecordToErrorQueueCommandHandlerAsync<TConnection, TTransaction, TCommand> : ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>
+        where TConnection : DbConnection
+        where TTransaction : DbTransaction
+        where TCommand : DbCommand
+    {
+        private readonly ICommandHandlerAsync<DeleteMetaDataCommand> _deleteMetaCommandHandler;
+        private readonly ICommandHandlerAsync<SetStatusTableStatusTransactionCommand> _setStatusCommandHandler;
+        private readonly ICommandHandlerAsync<SetStatusTableStatusCommand<long>> _setStatusNoTransactionCommandHandler;
+        private readonly IDbConnectionFactory _dbConnectionFactory;
+        private readonly ITransactionFactory _transactionFactory;
+        private readonly IPrepareCommandHandler<MoveRecordToErrorQueueCommand<long>> _prepareCommand;
+        private readonly Lazy<ITransportOptions> _options;
+        private readonly IConnectionHeader<TConnection, TTransaction, TCommand> _headers;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MoveRecordToErrorQueueCommandHandlerAsync{TConnection, TTransaction, TCommand}" /> class.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <param name="deleteMetaCommandHandler">The delete meta command handler.</param>
+        /// <param name="setStatusCommandHandler">The set status command handler.</param>
+        /// <param name="dbConnectionFactory">The database connection factory.</param>
+        /// <param name="transactionFactory">The transaction factory.</param>
+        /// <param name="prepareCommand">The prepare command.</param>
+        /// <param name="headers">The headers.</param>
+        /// <param name="setCommandHandler">The set command handler.</param>
+        public MoveRecordToErrorQueueCommandHandlerAsync(
+            ITransportOptionsFactory options,
+            ICommandHandlerAsync<DeleteMetaDataCommand> deleteMetaCommandHandler,
+            ICommandHandlerAsync<SetStatusTableStatusTransactionCommand> setStatusCommandHandler,
+            IDbConnectionFactory dbConnectionFactory,
+            ITransactionFactory transactionFactory,
+            IPrepareCommandHandler<MoveRecordToErrorQueueCommand<long>> prepareCommand,
+            IConnectionHeader<TConnection, TTransaction, TCommand> headers,
+            ICommandHandlerAsync<SetStatusTableStatusCommand<long>> setCommandHandler)
+        {
+            Guard.NotNull(options);
+            Guard.NotNull(transactionFactory);
+            Guard.NotNull(headers);
+            Guard.NotNull(prepareCommand);
+            Guard.NotNull(dbConnectionFactory);
+            Guard.NotNull(deleteMetaCommandHandler);
+            Guard.NotNull(setStatusCommandHandler);
+            Guard.NotNull(setCommandHandler);
+
+            _options = new Lazy<ITransportOptions>(options.Create);
+            _deleteMetaCommandHandler = deleteMetaCommandHandler;
+            _setStatusCommandHandler = setStatusCommandHandler;
+            _dbConnectionFactory = dbConnectionFactory;
+            _transactionFactory = transactionFactory;
+            _prepareCommand = prepareCommand;
+            _headers = headers;
+            _setStatusNoTransactionCommandHandler = setCommandHandler;
+        }
+        /// <inheritdoc />
+        public async Task HandleAsync(MoveRecordToErrorQueueCommand<long> command)
+        {
+            if (_options.Value.EnableHoldTransactionUntilMessageCommitted)
+            {
+                await HandleForTransactionAsync(command).ConfigureAwait(false);
+            }
+            else
+            {
+                using (var conn = _dbConnectionFactory.Create())
+                {
+                    await conn.OpenAsync().ConfigureAwait(false);
+                    using (var trans = _transactionFactory.Create(conn).BeginTransaction())
+                    {
+                        using (var commandSql = conn.CreateCommand())
+                        {
+                            commandSql.Transaction = trans;
+                            _prepareCommand.Handle(command, commandSql, CommandStringTypes.MoveToErrorQueue);
+                            var iCount = await commandSql.ExecuteNonQueryAsync().ConfigureAwait(false);
+                            if (iCount != 1) return;
+
+                            //the record is now in the error queue, remove it from the main queue
+                            await _deleteMetaCommandHandler.HandleAsync(new DeleteMetaDataCommand(command.QueueId, conn, trans)).ConfigureAwait(false);
+
+                            if (!_options.Value.EnableStatusTable)
+                            {
+                                await trans.CommitAsync().ConfigureAwait(false);
+                                return;
+                            }
+
+                            //update the status record
+                            await _setStatusCommandHandler.HandleAsync(new SetStatusTableStatusTransactionCommand(command.QueueId, conn, QueueStatuses.Error, trans)).ConfigureAwait(false);
+                        }
+                        await trans.CommitAsync().ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+
+        private async Task HandleForTransactionAsync(MoveRecordToErrorQueueCommand<long> command)
+        {
+            var connHolder = command.MessageContext.Get(_headers.Connection);
+            using (var conn = _dbConnectionFactory.Create())
+            {
+                await conn.OpenAsync().ConfigureAwait(false);
+                using (var commandSql = conn.CreateCommand())
+                {
+                    _prepareCommand.Handle(command, commandSql, CommandStringTypes.MoveToErrorQueue);
+                    var iCount = await commandSql.ExecuteNonQueryAsync().ConfigureAwait(false);
+                    if (iCount != 1) return;
+
+                    //the record is now in the error queue, remove it from the main queue
+                    await _deleteMetaCommandHandler.HandleAsync(new DeleteMetaDataCommand(command.QueueId, connHolder.Connection, connHolder.Transaction)).ConfigureAwait(false);
+
+                    //commit the original transaction
+                    await connHolder.Transaction.CommitAsync().ConfigureAwait(false);
+                    connHolder.Transaction.Dispose();
+                    connHolder.Transaction = null;
+
+                    if (_options.Value.EnableStatusTable)
+                    {
+                        await _setStatusNoTransactionCommandHandler.HandleAsync(new SetStatusTableStatusCommand<long>(command.QueueId, QueueStatuses.Error)).ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetStatusTableStatusCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetStatusTableStatusCommandHandlerAsync.cs
@@ -1,0 +1,66 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Updates the status of a status record in the status table
+    /// </summary>
+    internal class SetStatusTableStatusCommandHandlerAsync : ICommandHandlerAsync<SetStatusTableStatusCommand<long>>
+    {
+        private readonly IDbConnectionFactory _dbConnectionFactory;
+        private readonly IPrepareCommandHandler<SetStatusTableStatusCommand<long>> _prepareCommand;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SetStatusTableStatusCommandHandlerAsync" /> class.
+        /// </summary>
+        /// <param name="dbConnectionFactory">The database connection factory.</param>
+        /// <param name="prepareCommand">The prepare command.</param>
+        public SetStatusTableStatusCommandHandlerAsync(IDbConnectionFactory dbConnectionFactory,
+                IPrepareCommandHandler<SetStatusTableStatusCommand<long>> prepareCommand)
+        {
+            Guard.NotNull(prepareCommand);
+            Guard.NotNull(dbConnectionFactory);
+
+            _dbConnectionFactory = dbConnectionFactory;
+            _prepareCommand = prepareCommand;
+        }
+
+        /// <inheritdoc />
+        [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query checked")]
+        public async Task HandleAsync(SetStatusTableStatusCommand<long> command)
+        {
+            using (var connection = _dbConnectionFactory.Create())
+            {
+                await connection.OpenAsync().ConfigureAwait(false);
+                using (var commandSql = connection.CreateCommand())
+                {
+                    _prepareCommand.Handle(command, commandSql, CommandStringTypes.UpdateStatusRecord);
+                    await commandSql.ExecuteNonQueryAsync().ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetStatusTableStatusTransactionCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetStatusTableStatusTransactionCommandHandlerAsync.cs
@@ -1,0 +1,56 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Command;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Sets the status on the status table
+    /// </summary>
+    public class SetStatusTableStatusTransactionCommandHandlerAsync : ICommandHandlerAsync<SetStatusTableStatusTransactionCommand>
+    {
+        private readonly IPrepareCommandHandler<SetStatusTableStatusTransactionCommand> _prepareCommand;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SetStatusTableStatusTransactionCommandHandlerAsync"/> class.
+        /// </summary>
+        /// <param name="prepareCommand">The prepare command.</param>
+        public SetStatusTableStatusTransactionCommandHandlerAsync(
+            IPrepareCommandHandler<SetStatusTableStatusTransactionCommand> prepareCommand)
+        {
+            Guard.NotNull(prepareCommand);
+            _prepareCommand = prepareCommand;
+        }
+        /// <inheritdoc />
+        public async Task HandleAsync(SetStatusTableStatusTransactionCommand command)
+        {
+            using (
+                var commandSqlUpdateStatusRecord = command.Connection.CreateCommand())
+            {
+                commandSqlUpdateStatusRecord.Transaction = command.Transaction;
+                _prepareCommand.Handle(command, commandSqlUpdateStatusRecord, CommandStringTypes.UpdateStatusRecord);
+                await commandSqlUpdateStatusRecord.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/RelationalDatabaseMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/RelationalDatabaseMessageQueueInit.cs
@@ -440,6 +440,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
             container.Register(typeof(ICommandHandler<>), LifeStyles.Singleton,
                 target);
 
+            container.Register(typeof(ICommandHandlerAsync<>), LifeStyles.Singleton,
+                target);
+
             // Go look in all assemblies and register all implementations
             // of IQueryHandler<T> by their closed interface:
             container.Register(typeof(IQueryHandler<,>), LifeStyles.Singleton,

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/TransactionWrapper.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/TransactionWrapper.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data.Common;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
@@ -39,6 +40,11 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         public DbTransaction BeginTransaction()
         {
             return Connection.BeginTransaction();
+        }
+        /// <inheritdoc />
+        public async Task<DbTransaction> BeginTransactionAsync()
+        {
+            return await Connection.BeginTransactionAsync().ConfigureAwait(false);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/ITransactionWrapper.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/ITransactionWrapper.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase
 {
@@ -38,5 +39,17 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase
         /// </summary>
         /// <returns></returns>
         DbTransaction BeginTransaction();
+        /// <summary>
+        /// Begins the transaction without blocking a thread across the call.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// On SQL Server and PostgreSQL beginning a transaction is a round trip, so the asynchronous
+        /// consumer needs this rather than the synchronous member; the send path already awaits
+        /// <see cref="DbConnection.BeginTransactionAsync(System.Threading.CancellationToken)"/> directly.
+        /// A provider that does not override it runs the synchronous version on the calling thread,
+        /// which is what SQLite does.
+        /// </remarks>
+        Task<DbTransaction> BeginTransactionAsync();
     }
 }

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
@@ -1,0 +1,59 @@
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IoC;
+using DotNetWorkQueue.Transport.RelationalDatabase;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Transport.SQLite.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
+{
+    /// <summary>
+    /// Container registration for the asynchronous poison-message path (#284).
+    ///
+    /// The handler is only half of the change: an <see cref="ICommandHandlerAsync{TCommand}"/> that
+    /// resolves without its retry decorator would move a message to the error queue on the first
+    /// transient failure instead of retrying, and nothing else in the suite would notice - the
+    /// synchronous twin beside it retries either way.
+    /// </summary>
+    [TestClass]
+    public class PoisonMessageAsyncRegistrationTests
+    {
+        private static readonly string FakeConnection =
+            $@"Data Source={System.IO.Path.GetTempPath()}poison-registration.db;Version=3;";
+
+        [TestMethod]
+        public void MoveRecordToErrorQueue_ResolvesWrappedInTheRetryDecorator()
+        {
+            ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>> handler = null;
+            IReceivePoisonMessage poisonMessage = null;
+
+            using (var qc = new QueueContainer<SqLiteMessageQueueInit>(
+                registerService: container =>
+                {
+                    //Without this the container reaches the database for its defaults before the
+                    //callback below ever runs.
+                    var stubFactory = Substitute.For<ITransportOptionsFactory>();
+                    stubFactory.Create().Returns(new SqLiteMessageQueueTransportOptions());
+                    container.Register<ITransportOptionsFactory>(() => stubFactory, LifeStyles.Singleton);
+                },
+                setOptions: container =>
+                {
+                    handler = container.GetInstance<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>>();
+                    poisonMessage = container.GetInstance<IReceivePoisonMessage>();
+                }))
+            {
+                try { qc.CreateConsumer(new QueueConnection("ADMIN", FakeConnection)); }
+                catch { /* the fake connection fails further down; the resolutions above are the point */ }
+            }
+
+            Assert.IsNotNull(handler, "The asynchronous move-to-error-queue handler did not resolve.");
+            Assert.IsInstanceOfType<RetryCommandHandlerDecoratorAsync<MoveRecordToErrorQueueCommand<long>>>(handler,
+                "The asynchronous handler resolved without its retry decorator, so a transient failure " +
+                "would move the message to the error queue instead of being retried.");
+            Assert.IsNotNull(poisonMessage, "IReceivePoisonMessage did not resolve.");
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/BeginTransactionRetryDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/BeginTransactionRetryDecoratorTests.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Data;
 using System.Data.Common;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Transport.SQLite.Decorator;
@@ -85,6 +86,64 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
 
             Assert.AreSame(decoratedTxn, result);
             decorated.Received(1).BeginTransaction();
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public async Task BeginTransactionAsync_WhenRegistryDisposed_FallsThroughToDecorated()
+        {
+            var decoratedTxn = Substitute.For<DbTransaction>();
+            var decorated = Substitute.For<ISQLiteTransactionWrapper>();
+            decorated.BeginTransactionAsync().Returns(Task.FromResult(decoratedTxn));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.Dispose();
+            policies.Registry.Returns(registry);
+
+            var sut = new BeginTransactionRetryDecorator(decorated, policies);
+
+            var result = await sut.BeginTransactionAsync().ConfigureAwait(false);
+
+            Assert.AreSame(decoratedTxn, result);
+            await decorated.Received(1).BeginTransactionAsync().ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task BeginTransactionAsync_WhenPipelineRegistered_ExecutesThroughPipeline()
+        {
+            var decoratedTxn = Substitute.For<DbTransaction>();
+            var decorated = Substitute.For<ISQLiteTransactionWrapper>();
+            decorated.BeginTransactionAsync().Returns(Task.FromResult(decoratedTxn));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            registry.TryAddBuilder(TransportPolicyDefinitions.BeginTransaction, (_, _) => { });
+            policies.Registry.Returns(registry);
+
+            var sut = new BeginTransactionRetryDecorator(decorated, policies);
+
+            var result = await sut.BeginTransactionAsync().ConfigureAwait(false);
+
+            Assert.AreSame(decoratedTxn, result);
+            await decorated.Received(1).BeginTransactionAsync().ConfigureAwait(false);
+            registry.Dispose();
+        }
+
+        [TestMethod]
+        public async Task BeginTransactionAsync_WhenNoPipelineRegistered_CallsDecoratedDirectly()
+        {
+            var decoratedTxn = Substitute.For<DbTransaction>();
+            var decorated = Substitute.For<ISQLiteTransactionWrapper>();
+            decorated.BeginTransactionAsync().Returns(Task.FromResult(decoratedTxn));
+            var policies = Substitute.For<IPolicies>();
+            var registry = new ResiliencePipelineRegistry<string>();
+            policies.Registry.Returns(registry);
+
+            var sut = new BeginTransactionRetryDecorator(decorated, policies);
+
+            var result = await sut.BeginTransactionAsync().ConfigureAwait(false);
+
+            Assert.AreSame(decoratedTxn, result);
+            await decorated.Received(1).BeginTransactionAsync().ConfigureAwait(false);
             registry.Dispose();
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/MoveRecordToErrorQueueCommandDecoratorAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Decorator/MoveRecordToErrorQueueCommandDecoratorAsyncTests.cs
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Transport.SQLite.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Transport.SQLite.Tests.Decorator
+{
+    /// <summary>
+    /// The database-existence guard on the asynchronous poison-message path.
+    ///
+    /// SQLite is the one transport whose store can simply disappear - someone deletes the file - and
+    /// the synchronous consumer declines the move rather than failing on it. The asynchronous
+    /// consumer must do the same, or a deleted queue turns a poison message into a command failure
+    /// and a retry cycle.
+    /// </summary>
+    [TestClass]
+    public class MoveRecordToErrorQueueCommandDecoratorAsyncTests
+    {
+        [TestMethod]
+        public async Task HandleAsync_WhenTheDatabaseIsGone_DeclinesTheMove()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>>();
+            var sut = Create(decorated, Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.db"));
+
+            await sut.HandleAsync(null).ConfigureAwait(false);
+
+            await decorated.DidNotReceiveWithAnyArgs().HandleAsync(null).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenTheDatabaseExists_PassesTheCommandThrough()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>>();
+            var file = Path.Combine(Path.GetTempPath(), $"present-{Guid.NewGuid():N}.db");
+            File.WriteAllText(file, string.Empty);
+            try
+            {
+                var sut = Create(decorated, file);
+
+                await sut.HandleAsync(null).ConfigureAwait(false);
+
+                await decorated.Received(1).HandleAsync(null).ConfigureAwait(false);
+            }
+            finally
+            {
+                try { File.Delete(file); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+            }
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenTheDatabaseIsInMemory_PassesTheCommandThrough()
+        {
+            var decorated = Substitute.For<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>>();
+            //An in-memory database has no file to find, so the guard must not read it as missing.
+            var sut = Create(decorated, fileName: null, inMemory: true);
+
+            await sut.HandleAsync(null).ConfigureAwait(false);
+
+            await decorated.Received(1).HandleAsync(null).ConfigureAwait(false);
+        }
+
+        private static MoveRecordToErrorQueueCommandDecoratorAsync Create(
+            ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>> decorated,
+            string fileName,
+            bool inMemory = false)
+        {
+            var getFileName = Substitute.For<IGetFileNameFromConnectionString>();
+            getFileName.GetFileName(Arg.Any<string>()).Returns(new ConnectionStringInfo(inMemory, fileName));
+
+            var connectionInformation = Substitute.For<IConnectionInformation>();
+            connectionInformation.ConnectionString.Returns("Data Source=whatever;Version=3;");
+
+            return new MoveRecordToErrorQueueCommandDecoratorAsync(connectionInformation, decorated,
+                new DatabaseExists(getFileName));
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SQLiteTransaction.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SQLiteTransaction.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System.Data;
 using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.SQLite.Basic
 {
@@ -32,6 +33,11 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         public DbTransaction BeginTransaction()
         {
             return Connection.BeginTransaction();
+        }
+
+        public async Task<DbTransaction> BeginTransactionAsync()
+        {
+            return await Connection.BeginTransactionAsync().ConfigureAwait(false);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSharedInit.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSharedInit.cs
@@ -205,6 +205,10 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                 typeof(MoveRecordToErrorQueueCommandDecorator), LifeStyles.Singleton);
 
             container.RegisterDecorator(
+                typeof(ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>),
+                typeof(MoveRecordToErrorQueueCommandDecoratorAsync), LifeStyles.Singleton);
+
+            container.RegisterDecorator(
                 typeof(IQueryHandler<GetErrorRecordExistsQuery<long>, bool>),
                 typeof(GetErrorRecordExistsQueryDecorator), LifeStyles.Singleton);
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSharedInit.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSharedInit.cs
@@ -151,6 +151,10 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                 .Register<ICommandHandler<MoveRecordToErrorQueueCommand<long>>,
                     MoveRecordToErrorQueueCommandHandler<DbConnection, DbTransaction, DbCommand>>(LifeStyles
                     .Singleton);
+            container
+                .Register<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>,
+                    MoveRecordToErrorQueueCommandHandlerAsync<DbConnection, DbTransaction, DbCommand>>(LifeStyles
+                    .Singleton);
 
             //expired messages
             container

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/BeginTransactionRetryDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/BeginTransactionRetryDecorator.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.SQLite.Basic;
 using DotNetWorkQueue.Validation;
 using Polly;
@@ -57,20 +58,33 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         /// <inheritdoc />
         public DbTransaction BeginTransaction()
         {
-            if (_pipeline == null)
+            var pipeline = Pipeline();
+            if (pipeline == null) return _decorated.BeginTransaction();
+            return pipeline.Execute(_ => _decorated.BeginTransaction());
+        }
+
+        /// <inheritdoc />
+        public async Task<DbTransaction> BeginTransactionAsync()
+        {
+            var pipeline = Pipeline();
+            if (pipeline == null) return await _decorated.BeginTransactionAsync().ConfigureAwait(false);
+            return await pipeline.ExecuteAsync(async _ =>
+                await _decorated.BeginTransactionAsync().ConfigureAwait(false)).ConfigureAwait(false);
+        }
+
+        private ResiliencePipeline Pipeline()
+        {
+            if (_pipeline != null) return _pipeline;
+            try
             {
-                try
-                {
-                    _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.BeginTransaction, out _pipeline);
-                }
-                catch (ObjectDisposedException)
-                {
-                    // Shutdown race: registry disposed before first invocation.
-                    // Fall through to direct handler — same semantics as the "no pipeline" path.
-                }
+                _policies.Registry.TryGetPipeline(TransportPolicyDefinitions.BeginTransaction, out _pipeline);
             }
-            if (_pipeline == null) return _decorated.BeginTransaction();
-            return _pipeline.Execute(_ => _decorated.BeginTransaction());
+            catch (ObjectDisposedException)
+            {
+                // Shutdown race: registry disposed before first invocation.
+                // Fall through to the direct handler - same semantics as the "no pipeline" path.
+            }
+            return _pipeline;
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/MoveRecordToErrorQueueCommandDecoratorAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/MoveRecordToErrorQueueCommandDecoratorAsync.cs
@@ -1,0 +1,68 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Threading.Tasks;
+using DotNetWorkQueue.Transport.RelationalDatabase;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Transport.SQLite.Decorator
+{
+    /// <summary>
+    /// Declines the move when the database file is gone, rather than failing on it.
+    /// </summary>
+    /// <remarks>
+    /// The twin of <see cref="MoveRecordToErrorQueueCommandDecorator"/> for the asynchronous consumer.
+    /// SQLite is the one transport whose store can simply disappear - a deleted file - and without this
+    /// the asynchronous poison path would run its commands against a missing database and retry, where
+    /// the synchronous one declines.
+    /// </remarks>
+    public class MoveRecordToErrorQueueCommandDecoratorAsync : ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>
+    {
+        private readonly IConnectionInformation _connectionInformation;
+        private readonly ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>> _decorated;
+        private readonly DatabaseExists _databaseExists;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MoveRecordToErrorQueueCommandDecoratorAsync" /> class.
+        /// </summary>
+        /// <param name="connectionInformation">The connection information.</param>
+        /// <param name="decorated">The decorated.</param>
+        /// <param name="databaseExists">The database exists.</param>
+        public MoveRecordToErrorQueueCommandDecoratorAsync(IConnectionInformation connectionInformation,
+            ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>> decorated,
+            DatabaseExists databaseExists)
+        {
+            Guard.NotNull(decorated);
+            Guard.NotNull(connectionInformation);
+            Guard.NotNull(databaseExists);
+            _connectionInformation = connectionInformation;
+            _decorated = decorated;
+            _databaseExists = databaseExists;
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(MoveRecordToErrorQueueCommand<long> command)
+        {
+            if (!_databaseExists.Exists(_connectionInformation.ConnectionString)) return;
+            await _decorated.HandleAsync(command).ConfigureAwait(false);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Shared/Basic/ReceivePoisonMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.Shared/Basic/ReceivePoisonMessage.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading.Tasks;
 using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using DotNetWorkQueue.Validation;
@@ -26,15 +27,20 @@ namespace DotNetWorkQueue.Transport.Shared.Basic
     public class ReceivePoisonMessage<T> : IReceivePoisonMessage
     {
         private readonly ICommandHandler<MoveRecordToErrorQueueCommand<T>> _commandMoveRecord;
+        private readonly ICommandHandlerAsync<MoveRecordToErrorQueueCommand<T>> _commandMoveRecordAsync;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReceivePoisonMessage{T}"/> class.
         /// </summary>
         /// <param name="commandMoveRecord">The command move record.</param>
-        public ReceivePoisonMessage(ICommandHandler<MoveRecordToErrorQueueCommand<T>> commandMoveRecord)
+        /// <param name="commandMoveRecordAsync">The command move record, for the asynchronous consumer.</param>
+        public ReceivePoisonMessage(ICommandHandler<MoveRecordToErrorQueueCommand<T>> commandMoveRecord,
+            ICommandHandlerAsync<MoveRecordToErrorQueueCommand<T>> commandMoveRecordAsync)
         {
             Guard.NotNull(commandMoveRecord);
+            Guard.NotNull(commandMoveRecordAsync);
             _commandMoveRecord = commandMoveRecord;
+            _commandMoveRecordAsync = commandMoveRecordAsync;
         }
         /// <inheritdoc />
         public void Handle(IMessageContext context, PoisonMessageException exception)
@@ -47,6 +53,19 @@ namespace DotNetWorkQueue.Transport.Shared.Basic
             var messageId = (T)context.MessageId.Id.Value;
             _commandMoveRecord.Handle(
                 new MoveRecordToErrorQueueCommand<T>(exception, messageId, context));
+            context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(IMessageContext context, PoisonMessageException exception)
+        {
+            Guard.NotNull(context);
+            Guard.NotNull(exception);
+
+            if (context.MessageId == null || !context.MessageId.HasValue) return;
+            var messageId = (T)context.MessageId.Id.Value;
+            await _commandMoveRecordAsync.HandleAsync(
+                new MoveRecordToErrorQueueCommand<T>(exception, messageId, context)).ConfigureAwait(false);
             context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
         }
     }

--- a/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.Tests/Basic/PoisonMessageAsyncRegistrationTests.cs
@@ -1,0 +1,59 @@
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IoC;
+using DotNetWorkQueue.Transport.RelationalDatabase;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using DotNetWorkQueue.Transport.SqlServer.Decorator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Transport.SqlServer.Tests.Basic
+{
+    /// <summary>
+    /// Container registration for the asynchronous poison-message path (#284).
+    ///
+    /// The handler is only half of the change: an <see cref="ICommandHandlerAsync{TCommand}"/> that
+    /// resolves without its retry decorator would move a message to the error queue on the first
+    /// transient failure instead of retrying, and nothing else in the suite would notice - the
+    /// synchronous twin beside it retries either way.
+    /// </summary>
+    [TestClass]
+    public class PoisonMessageAsyncRegistrationTests
+    {
+        private const string FakeConnection =
+            "Server=localhost;Application Name=Test;Database=Test;User ID=sa;Password=password";
+
+        [TestMethod]
+        public void MoveRecordToErrorQueue_ResolvesWrappedInTheRetryDecorator()
+        {
+            ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>> handler = null;
+            IReceivePoisonMessage poisonMessage = null;
+
+            using (var qc = new QueueContainer<SqlServerMessageQueueInit>(
+                registerService: container =>
+                {
+                    //Without this the container reaches the database for its defaults before the
+                    //callback below ever runs.
+                    var stubFactory = Substitute.For<ITransportOptionsFactory>();
+                    stubFactory.Create().Returns(new SqlServerMessageQueueTransportOptions());
+                    container.Register<ITransportOptionsFactory>(() => stubFactory, LifeStyles.Singleton);
+                },
+                setOptions: container =>
+                {
+                    handler = container.GetInstance<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>>();
+                    poisonMessage = container.GetInstance<IReceivePoisonMessage>();
+                }))
+            {
+                try { qc.CreateConsumer(new QueueConnection("ADMIN", FakeConnection)); }
+                catch { /* the fake connection fails further down; the resolutions above are the point */ }
+            }
+
+            Assert.IsNotNull(handler, "The asynchronous move-to-error-queue handler did not resolve.");
+            Assert.IsInstanceOfType<RetryCommandHandlerDecoratorAsync<MoveRecordToErrorQueueCommand<long>>>(handler,
+                "The asynchronous handler resolved without its retry decorator, so a transient failure " +
+                "would move the message to the error queue instead of being retried.");
+            Assert.IsNotNull(poisonMessage, "IReceivePoisonMessage did not resolve.");
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueInit.cs
@@ -187,6 +187,9 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             container
                 .Register<ICommandHandler<MoveRecordToErrorQueueCommand<long>>,
                     MoveRecordToErrorQueueCommandHandler<SqlConnection, SqlTransaction, SqlCommand>>(LifeStyles.Singleton);
+            container
+                .Register<ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>,
+                    MoveRecordToErrorQueueCommandHandlerAsync<SqlConnection, SqlTransaction, SqlCommand>>(LifeStyles.Singleton);
 
             //explicit registration of options
             container

--- a/Source/DotNetWorkQueue/IReceivePoisonMessage.cs
+++ b/Source/DotNetWorkQueue/IReceivePoisonMessage.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading.Tasks;
 using DotNetWorkQueue.Exceptions;
 
 namespace DotNetWorkQueue
@@ -32,5 +33,17 @@ namespace DotNetWorkQueue
         /// <param name="context">The context.</param>
         /// <param name="exception">The exception.</param>
         void Handle(IMessageContext context, PoisonMessageException exception);
+
+        /// <summary>
+        /// Moves a message that cannot be processed to the error queue, without blocking a thread.
+        /// </summary>
+        /// <param name="context">The message context.</param>
+        /// <param name="exception">The exception that made the message poison.</param>
+        /// <remarks>
+        /// Called from the asynchronous consumer, where the synchronous twin would block a thread-pool
+        /// thread: after the receive became awaitable this runs in a continuation rather than on the
+        /// worker's own dedicated thread.
+        /// </remarks>
+        Task HandleAsync(IMessageContext context, PoisonMessageException exception);
     }
 }

--- a/Source/DotNetWorkQueue/Logging/Decorator/IReceivePoisonMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Logging/Decorator/IReceivePoisonMessageDecorator.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading.Tasks;
 using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Validation;
 using Microsoft.Extensions.Logging;
@@ -59,6 +60,22 @@ namespace DotNetWorkQueue.Logging.Decorator
             else
             {
                 _handler.Handle(context, exception);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(IMessageContext context, PoisonMessageException exception)
+        {
+            if (context.MessageId != null && context.MessageId.HasValue)
+            {
+                var messageId = context.MessageId.Id.Value.ToString();
+                await _handler.HandleAsync(context, exception).ConfigureAwait(false);
+                _log.LogError(exception,
+                    "Message with ID {MessageId} has failed after de-queue, but before finishing loading. This message is considered a poison message, and has been moved to the error queue", messageId);
+            }
+            else
+            {
+                await _handler.HandleAsync(context, exception).ConfigureAwait(false);
             }
         }
     }

--- a/Source/DotNetWorkQueue/Metrics/Decorator/IReceivePoisonMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Metrics/Decorator/IReceivePoisonMessageDecorator.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading.Tasks;
 using DotNetWorkQueue.Exceptions;
 
 namespace DotNetWorkQueue.Metrics.Decorator
@@ -48,6 +49,13 @@ namespace DotNetWorkQueue.Metrics.Decorator
         public void Handle(IMessageContext context, PoisonMessageException exception)
         {
             _handler.Handle(context, exception);
+            _meterError.Mark();
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(IMessageContext context, PoisonMessageException exception)
+        {
+            await _handler.HandleAsync(context, exception).ConfigureAwait(false);
             _meterError.Mark();
         }
     }

--- a/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
+++ b/Source/DotNetWorkQueue/Queue/MessageProcessingAsync.cs
@@ -195,7 +195,7 @@ namespace DotNetWorkQueue.Queue
                 }
                 catch (PoisonMessageException exception)
                 {
-                    _receivePoisonMessage.Handle(context, exception);
+                    await _receivePoisonMessage.HandleAsync(context, exception).ConfigureAwait(false);
                     _consumerQueueErrorNotification.InvokePoisonMessageError(new PoisonMessageNotification(exception));
                 }
                 catch (ReceiveMessageException e)

--- a/Source/DotNetWorkQueue/Trace/Decorator/ReceivePoisonMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Trace/Decorator/ReceivePoisonMessageDecorator.cs
@@ -21,6 +21,7 @@ using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Messages;
 using OpenTelemetry.Trace;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Trace.Decorator
 {
@@ -72,6 +73,32 @@ namespace DotNetWorkQueue.Trace.Decorator
                     scope?.AddMessageIdTag(context);
                     scope?.AddException(exception);
                     _handler.Handle(context, exception);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(IMessageContext context, PoisonMessageException exception)
+        {
+            var header = _getHeader.GetHeaders(context.MessageId);
+            if (header != null)
+            {
+                var activityContext = header.Extract(_tracer, _headers);
+                using (var scope = _tracer.StartActivity("PoisonMessage", ActivityKind.Internal, activityContext))
+                {
+                    scope?.AddMessageIdTag(context);
+                    scope?.AddException(exception);
+                    scope?.SetStatus(ActivityStatusCode.Error);
+                    await _handler.HandleAsync(context, exception).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                using (var scope = _tracer.StartActivity("PoisonMessage"))
+                {
+                    scope?.AddMessageIdTag(context);
+                    scope?.AddException(exception);
+                    await _handler.HandleAsync(context, exception).ConfigureAwait(false);
                 }
             }
         }

--- a/Source/DotNetWorkQueue/Trace/Decorator/ReceivePoisonMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Trace/Decorator/ReceivePoisonMessageDecorator.cs
@@ -72,6 +72,7 @@ namespace DotNetWorkQueue.Trace.Decorator
                 {
                     scope?.AddMessageIdTag(context);
                     scope?.AddException(exception);
+                    scope?.SetStatus(ActivityStatusCode.Error);
                     _handler.Handle(context, exception);
                 }
             }
@@ -98,6 +99,7 @@ namespace DotNetWorkQueue.Trace.Decorator
                 {
                     scope?.AddMessageIdTag(context);
                     scope?.AddException(exception);
+                    scope?.SetStatus(ActivityStatusCode.Error);
                     await _handler.HandleAsync(context, exception).ConfigureAwait(false);
                 }
             }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/ReceivePoisonMessage.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/ReceivePoisonMessage.cs
@@ -19,6 +19,7 @@
 using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Validation;
 using System;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic
 {
@@ -52,6 +53,18 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
 
             _dataStorage.MoveToErrorQueue(exception, (Guid)context.MessageId.Id.Value, context);
             context.SetMessageAndHeaders(null, context.CorrelationId, context.Headers);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Correct as written rather than unfinished. The memory transport keeps its messages in
+        /// process, so there is no I/O to release the thread for. Deliberately not Task.Run, which
+        /// would only move the work to another pool thread.
+        /// </remarks>
+        public Task HandleAsync(IMessageContext context, PoisonMessageException exception)
+        {
+            Handle(context, exception);
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Second of the six synchronous calls #284 tracks on the asynchronous receive path. Moving a poison message to the error queue is transport I/O, and the async consumer was calling the blocking member for it.

## Why now

Before #282 this cost nothing. `MessageProcessingAsync` ran under `async void Handle()` on a worker whose thread is dedicated (`TaskCreationOptions.LongRunning`), so blocking there never touched the pool. Once the receive became awaitable, everything after the first `await` runs in a continuation **on a thread-pool thread** — and this catch block is downstream of it. On Redis it is also a sync-over-async completion, which is #161's contention.

It is also the first of the six that the relational transports can answer at all: `IDbConnection` has no `OpenAsync`, so this needed #287 first, and `MoveRecordToErrorQueueCommand` has no output, so it needed #285's `ICommandHandlerAsync<T>`.

## What to look at

**`IReceivePoisonMessage` gains `HandleAsync`** — implemented by all four handlers and the three decorators over it. `MessageProcessingAsync` awaits it; `MessageProcessing` (the synchronous consumer) is unchanged.

**Two transports gain nothing and say so.** The shared `ReceivePoisonMessage<T>` now takes both handlers, so every transport needs the async one:

- **Memory** returns a completed task around the synchronous work. Nothing to release a thread for, and `Task.Run` would only move it to another pool thread.
- **LiteDB** has no async API until v6 (#283), so it runs the synchronous handler on the pool — the hack `SendMessageCommandHandlerAsync` already uses. It frees the caller's thread; it does not make the work asynchronous.

**The relational handler is genuinely async** — `OpenAsync`, `ExecuteNonQueryAsync`, `CommitAsync`, and the three delegated handlers it awaits (`DeleteMetaData`, `SetStatusTableStatus`, `SetStatusTableStatusTransaction`) are async twins rather than wrappers. Both branches of the sync handler are mirrored, including the held-transaction one.

**`ErrorLua.ExecuteAsync` deliberately omits the `Connection.IsDisposed` guard** that `DequeueLua` has, matching its own synchronous twin rather than a different script.

**The registration tests are the ones worth reading.** An `ICommandHandlerAsync` that resolved *without* its retry decorator would move a message to the error queue on the first transient failure instead of retrying — and nothing else in the suite would notice, because the synchronous twin beside it retries either way.

## Breaking

Yes, for anyone implementing `IReceivePoisonMessage` outside this repository. Noted in the changelog. The changelog also picks up the `System.Data.Common` break from #286/#287, which merged without an entry.

## Validation

- `NoTests.sln -c Release -p:CI=true` clean
- Unit suites, 2,398 passed / 0 failed: core 1125, RelationalDatabase 251, SQLite 236, SqlServer 198, Redis 192, PostgreSQL 183, LiteDb 180, Memory 33
- **SQLite integration: 200 passed / 0 failed** — the transport that exercises the new relational handler end to end locally
- New tests fail as expected when the change is reverted — the pacing assertions, and the registration tests with the closed-generic registration removed

Redis, SQL Server and PostgreSQL integration are Jenkins' to confirm; `ConsumerAsyncPoisonMessage` already covers this path on every transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Poison messages are now handled asynchronously, allowing processing to await error-queue transfers without blocking threads.
  * Error handling, logging, tracing, and metrics support the asynchronous poison-message workflow.
  * LiteDB, Redis, relational database, SQLite, and SQL Server transports support asynchronous error-queue transfers.
  * Database transactions can now begin asynchronously.
  * Custom relational transports now use modern database connection and transaction abstractions.

* **Tests**
  * Added coverage for asynchronous poison-message processing, transaction handling, completion ordering, notifications, and transport registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->