### PR TITLE
feat: record the processing-start history row without blocking (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Async consumers keep working under thread-pool pressure when a message turns out to be poison; moving it to the error queue used to occupy a pool thread for the whole round trip (GitHub #284)
 - Redis async consumers no longer hold a thread while removing an expired message during a de-queue (GitHub #284)
 - Fix: SQL Server and PostgreSQL left a message's error-history rows behind when it was removed with `EnableHoldTransactionUntilMessageCommitted` on (GitHub #284)
-- Async consumers with history tracking on no longer hold a thread while recording that a message started processing (GitHub #284)
+- SQL Server, PostgreSQL and Redis async consumers no longer hold a thread recording that a message started processing, when history tracking is on (GitHub #284)
 - ⚠️ Custom transports and consumers must add async members: `IReceivePoisonMessage.HandleAsync`, `IRemoveMessage.RemoveAsync`, `IWriteMessageHistory.RecordProcessingStartAsync`, and `ITransactionWrapper.BeginTransactionAsync` for relational transports. Built-in transports are unaffected (GitHub #284)
 - ⚠️ Custom relational transports: `IDbConnectionFactory`, `ITransactionFactory` and `ITransactionWrapper` now use `System.Data.Common` types (`DbConnection`, `DbTransaction`) rather than the `System.Data` interfaces, which have no async members. Built-in transports are unaffected (GitHub #286)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Async consumers keep working under thread-pool pressure when a message turns out to be poison; moving it to the error queue used to occupy a pool thread for the whole round trip (GitHub #284)
 - Redis async consumers no longer hold a thread while removing an expired message during a de-queue (GitHub #284)
 - Fix: SQL Server and PostgreSQL left a message's error-history rows behind when it was removed with `EnableHoldTransactionUntilMessageCommitted` on (GitHub #284)
-- ⚠️ Custom transports and consumers must add async members: `IReceivePoisonMessage.HandleAsync`, `IRemoveMessage.RemoveAsync`, and `ITransactionWrapper.BeginTransactionAsync` for relational transports. Built-in transports are unaffected (GitHub #284)
+- Async consumers with history tracking on no longer hold a thread while recording that a message started processing (GitHub #284)
+- ⚠️ Custom transports and consumers must add async members: `IReceivePoisonMessage.HandleAsync`, `IRemoveMessage.RemoveAsync`, `IWriteMessageHistory.RecordProcessingStartAsync`, and `ITransactionWrapper.BeginTransactionAsync` for relational transports. Built-in transports are unaffected (GitHub #284)
 - ⚠️ Custom relational transports: `IDbConnectionFactory`, `ITransactionFactory` and `ITransactionWrapper` now use `System.Data.Common` types (`DbConnection`, `DbTransaction`) rather than the `System.Data` interfaces, which have no async members. Built-in transports are unaffected (GitHub #286)
 
 ### 0.11.0 — 2026-09-06

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/SimpleHistoryAsyncTest.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/SimpleHistoryAsyncTest.cs
@@ -133,8 +133,14 @@ namespace DotNetWorkQueue.IntegrationTests.Shared.History.Implementation
                 }
                 finally
                 {
-                    oCreation?.RemoveQueue();
-                    oCreation?.Dispose();
+                    //The creation object was disposed above, on purpose, to release its connections
+                    //before the verification container reads the history. Nulling it there used to
+                    //mean this block found nothing and the queue was never removed - so a run left
+                    //its queue and history behind, which matters most on the shared instances
+                    //(Redis, SQL Server, PostgreSQL) where nothing else cleans up after it.
+                    oCreation ??= queueCreator.GetQueueCreation<TTransportCreate>(queueConnection);
+                    oCreation.RemoveQueue();
+                    oCreation.Dispose();
                     scope?.Dispose();
                 }
             }

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/SimpleHistoryAsyncTest.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/SimpleHistoryAsyncTest.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Linq;
+using System.Threading;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.Messages;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.IntegrationTests.Shared.History.Implementation
+{
+    /// <summary>
+    /// The asynchronous twin of <see cref="SimpleHistoryTest"/>.
+    ///
+    /// History was only ever exercised through the synchronous consumer, on every transport. The
+    /// asynchronous consumer records the processing-start row from its own receive path, so that write
+    /// reached no test - which is how it stayed synchronous unnoticed until #284.
+    ///
+    /// Reaching Complete is the assertion that proves the start row was written at all: RecordComplete
+    /// only matches a record whose status is already Processing, so a record that never started cannot
+    /// finish. StartedUtc and DurationMs are asserted on top of that because nothing else asserts them
+    /// anywhere, and DurationMs is derived from StartedUtc - it silently becomes zero when the start
+    /// row is missing.
+    /// </summary>
+    public class SimpleHistoryAsyncTest
+    {
+        public void Run<TTransportInit, TMessage, TTransportCreate>(
+            QueueConnection queueConnection,
+            int messageCount,
+            Action<TTransportCreate> setOptions,
+            Func<QueueProducerConfiguration, AdditionalMessageData> generateData,
+            Action<QueueConnection, QueueProducerConfiguration, long, ICreationScope> verify)
+            where TTransportInit : ITransportInit, new()
+            where TMessage : class, new()
+            where TTransportCreate : class, IQueueCreation
+        {
+            var logProvider = LoggerShared.Create(queueConnection.Queue, GetType().Name);
+            using (var queueCreator =
+                new QueueCreationContainer<TTransportInit>(
+                    serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+            {
+                ICreationScope scope = null;
+                var oCreation = queueCreator.GetQueueCreation<TTransportCreate>(queueConnection);
+                try
+                {
+                    setOptions(oCreation);
+                    var result = oCreation.CreateQueue();
+                    Assert.IsTrue(result.Success, result.ErrorMessage);
+                    scope = oCreation.Scope;
+
+                    var processedCount = 0;
+                    using (var queueContainer = new QueueContainer<TTransportInit>(serviceRegister =>
+                    {
+                        serviceRegister.Register(() => logProvider, LifeStyles.Singleton);
+                        serviceRegister.RegisterNonScopedSingleton(scope);
+                    }))
+                    {
+                        using (var producer = queueContainer.CreateProducer<TMessage>(queueConnection))
+                        {
+                            for (var i = 0; i < messageCount; i++)
+                            {
+                                var sendResult = producer.Send(new TMessage());
+                                Assert.IsFalse(sendResult.HasError, $"Send failed: {sendResult.SendingException?.Message}");
+                            }
+                        }
+
+                        var waitHandle = new ManualResetEventSlim(false);
+
+                        //The asynchronous consumer, which is the whole point: it records the
+                        //processing-start row from a continuation rather than from the worker's thread.
+                        using (var schedulerCreator = new SchedulerContainer())
+                        {
+                            using (var taskScheduler = schedulerCreator.CreateTaskScheduler())
+                            {
+                                taskScheduler.Configuration.MaximumThreads = 1;
+                                taskScheduler.Start();
+                                var taskFactory = schedulerCreator.CreateTaskFactory(taskScheduler);
+
+                                using (var consumer =
+                                    queueContainer.CreateConsumerQueueScheduler(queueConnection, taskFactory))
+                                {
+                                    consumer.Start<TMessage>((message, workerNotification) =>
+                                    {
+                                        Interlocked.Increment(ref processedCount);
+                                        if (processedCount >= messageCount)
+                                            waitHandle.Set();
+                                    }, null);
+
+                                    waitHandle.Wait(TimeSpan.FromSeconds(30));
+                                }
+                            }
+                        }
+                    }
+
+                    Assert.AreEqual(messageCount, processedCount, "Not all messages were processed");
+
+                    oCreation?.Dispose();
+                    oCreation = null;
+
+                    using (var verifyContainer = new QueueContainer<TTransportInit>(serviceRegister =>
+                    {
+                        serviceRegister.Register(() => logProvider, LifeStyles.Singleton);
+                        serviceRegister.RegisterNonScopedSingleton(scope);
+                    }))
+                    {
+                        using (var adminContainer = verifyContainer.CreateAdminContainer(queueConnection))
+                        {
+                            var historyQuery = adminContainer.GetInstance<IQueryMessageHistory>();
+
+                            var completeCount = historyQuery.GetCount(MessageHistoryStatus.Complete);
+                            Assert.IsGreaterThanOrEqualTo(messageCount, completeCount,
+                                $"Expected at least {messageCount} completed records, got {completeCount}. " +
+                                "Complete is only reachable from Processing, so a shortfall here means the " +
+                                "asynchronous consumer never recorded that processing started.");
+
+                            var records = historyQuery.Get(0, 100, null);
+                            Assert.IsNotNull(records);
+                            Assert.IsGreaterThanOrEqualTo(messageCount, records.Count);
+
+                            foreach (var record in records)
+                            {
+                                Assert.IsNotNull(record.QueueId);
+                                Assert.AreEqual(MessageHistoryStatus.Complete, record.Status);
+                                Assert.IsNotNull(record.StartedUtc,
+                                    $"Record {record.QueueId} has no StartedUtc, so the processing-start row " +
+                                    "was never written; DurationMs is meaningless without it.");
+                                Assert.IsNotNull(record.CompletedUtc);
+                            }
+
+                            //Derived from StartedUtc, and silently zero when it is missing.
+                            Assert.IsTrue(records.All(r => r.DurationMs.HasValue),
+                                "A completed record carried no DurationMs.");
+                        }
+                    }
+                }
+                finally
+                {
+                    oCreation?.RemoveQueue();
+                    oCreation?.Dispose();
+                    scope?.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/SimpleHistoryTest.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/SimpleHistoryTest.cs
@@ -132,8 +132,14 @@ namespace DotNetWorkQueue.IntegrationTests.Shared.History.Implementation
                 }
                 finally
                 {
-                    oCreation?.RemoveQueue();
-                    oCreation?.Dispose();
+                    //The creation object was disposed above, on purpose, to release its connections
+                    //before the verification container reads the history. Nulling it there used to
+                    //mean this block found nothing and the queue was never removed - so a run left
+                    //its queue and history behind, which matters most on the shared instances
+                    //(Redis, SQL Server, PostgreSQL) where nothing else cleans up after it.
+                    oCreation ??= queueCreator.GetQueueCreation<TTransportCreate>(queueConnection);
+                    oCreation.RemoveQueue();
+                    oCreation.Dispose();
                     scope?.Dispose();
                 }
             }

--- a/Source/DotNetWorkQueue.Tests/History/Decorator/ReceiveMessagesHistoryDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/History/Decorator/ReceiveMessagesHistoryDecoratorTests.cs
@@ -102,7 +102,10 @@ namespace DotNetWorkQueue.Tests.History.Decorator
 
             await decorator.ReceiveMessageAsync(context, CancellationToken.None);
 
-            history.Received(1).RecordProcessingStart(Arg.Any<string>());
+            await history.Received(1).RecordProcessingStartAsync(Arg.Any<string>()).ConfigureAwait(false);
+            //Calling the blocking member here would satisfy every other assertion in this class while
+            //holding a thread-pool thread for the write - the defect #284 exists to remove.
+            history.DidNotReceive().RecordProcessingStart(Arg.Any<string>());
         }
 
         [TestMethod]
@@ -115,7 +118,7 @@ namespace DotNetWorkQueue.Tests.History.Decorator
 
             await decorator.ReceiveMessageAsync(context, CancellationToken.None);
 
-            history.DidNotReceive().RecordProcessingStart(Arg.Any<string>());
+            await history.DidNotReceive().RecordProcessingStartAsync(Arg.Any<string>()).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -127,7 +130,7 @@ namespace DotNetWorkQueue.Tests.History.Decorator
 
             await decorator.ReceiveMessageAsync(context, CancellationToken.None);
 
-            history.DidNotReceive().RecordProcessingStart(Arg.Any<string>());
+            await history.DidNotReceive().RecordProcessingStartAsync(Arg.Any<string>()).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -137,12 +140,36 @@ namespace DotNetWorkQueue.Tests.History.Decorator
             var context = CreateContext();
             var receivedMessage = Substitute.For<IReceivedMessageInternal>();
             SetupAsyncReceive(inner, context, receivedMessage);
-            history.When(h => h.RecordProcessingStart(Arg.Any<string>()))
-                .Do(_ => throw new InvalidOperationException("history write failed"));
+            history.RecordProcessingStartAsync(Arg.Any<string>())
+                .Returns(Task.FromException(new InvalidOperationException("history write failed")));
 
             var result = await decorator.ReceiveMessageAsync(context, CancellationToken.None);
 
             Assert.AreSame(receivedMessage, result);
+        }
+
+        [TestMethod]
+        public async Task ReceiveMessageAsync_WaitsForTheHistoryWrite()
+        {
+            var (decorator, inner, history, _, _) = CreateDecorator(enabled: true, trackProcessing: true);
+            var context = CreateContext();
+            var receivedMessage = Substitute.For<IReceivedMessageInternal>();
+            SetupAsyncReceive(inner, context, receivedMessage);
+
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            history.RecordProcessingStartAsync(Arg.Any<string>()).Returns(gate.Task);
+
+            var receiving = decorator.ReceiveMessageAsync(context, CancellationToken.None).AsTask();
+
+            var completedEarly = await Task.WhenAny(receiving, Task.Delay(TimeSpan.FromMilliseconds(250)))
+                .ConfigureAwait(false) == receiving;
+
+            Assert.IsFalse(completedEarly,
+                "The receive handed the message on before its history row said processing had started. " +
+                "Discarding that task lets the consumer record the start after the work finishes, or not at all.");
+
+            gate.TrySetResult(true);
+            await receiving.ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/History/SimpleHistoryAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/History/SimpleHistoryAsyncTests.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.IntegrationTests.Shared.History.Implementation;
+using DotNetWorkQueue.Transport.LiteDb.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.LiteDb.IntegrationTests.History
+{
+    [TestClass]
+    public class SimpleHistoryAsyncTests
+    {
+        [TestMethod]
+        [DataRow(5, IntegrationConnectionInfo.ConnectionTypes.Direct)]
+        [DataRow(5, IntegrationConnectionInfo.ConnectionTypes.Memory)]
+        [DataRow(5, IntegrationConnectionInfo.ConnectionTypes.Shared)]
+        public void Run(int messageCount, IntegrationConnectionInfo.ConnectionTypes connectionType)
+        {
+            using (var connectionInfo = new IntegrationConnectionInfo(connectionType))
+            {
+                var queueName = GenerateQueueName.Create();
+                var test = new SimpleHistoryAsyncTest();
+                test.Run<LiteDbMessageQueueInit, FakeMessage, LiteDbMessageQueueCreation>(
+                    new QueueConnection(queueName, connectionInfo.ConnectionString),
+                    messageCount,
+                    x => { x.Options.EnableHistory = true; },
+                    Helpers.GenerateData, Helpers.Verify);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.LiteDb.Schema;
 
@@ -63,6 +64,19 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
                     Headers = _options.HistoryOptions.StoreBody ? headers : null
                 });
             }
+        }
+
+        /// <inheritdoc />
+        /// <inheritdoc />
+        /// <remarks>
+        /// LiteDB has no asynchronous API, so this runs the synchronous member on the thread pool -
+        /// the same hack the send path uses. It keeps the caller's thread free, which is what the
+        /// asynchronous consumer needs; it does not make the work asynchronous. Issue #283 tracks
+        /// replacing this once LiteDB v6 ships real async methods.
+        /// </remarks>
+        public async Task RecordProcessingStartAsync(string queueId)
+        {
+            await Task.Run(() => RecordProcessingStart(queueId)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/History/SimpleHistoryAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/History/SimpleHistoryAsyncTests.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.IntegrationTests.Shared.History.Implementation;
+using DotNetWorkQueue.Transport.Memory.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.History
+{
+    [TestClass]
+    public class SimpleHistoryAsyncTests
+    {
+        [TestMethod]
+        [DataRow(5)]
+        public void Run(int messageCount)
+        {
+            using (var connectionInfo = new IntegrationConnectionInfo())
+            {
+                var queueName = GenerateQueueName.Create();
+                var test = new SimpleHistoryAsyncTest();
+                test.Run<MemoryMessageQueueInit, FakeMessage, MessageQueueCreation>(
+                    new QueueConnection(queueName, connectionInfo.ConnectionString),
+                    messageCount,
+                    x => { x.Options.EnableHistory = true; },
+                    Helpers.GenerateData, Helpers.Verify);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/History/SimpleHistoryAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/History/SimpleHistoryAsyncTests.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.IntegrationTests.Shared.History.Implementation;
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.History
+{
+    [TestClass]
+    public class SimpleHistoryAsyncTests
+    {
+        [TestMethod]
+        [DataRow(5)]
+        public void Run(int messageCount)
+        {
+            var queueName = GenerateQueueName.Create();
+            var test = new SimpleHistoryAsyncTest();
+            test.Run<PostgreSqlMessageQueueInit, FakeMessage, PostgreSqlMessageQueueCreation>(
+                new QueueConnection(queueName, ConnectionInfo.ConnectionString),
+                messageCount,
+                x =>
+                {
+                    Helpers.SetOptions(x,
+                        false, false, false,
+                        false, false, false, true, false);
+                    x.Options.EnableHistory = true;
+                },
+                Helpers.GenerateData, Helpers.Verify);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/History/SimpleHistoryAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/History/SimpleHistoryAsyncTests.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.IntegrationTests.Shared.History.Implementation;
+using DotNetWorkQueue.Transport.Redis.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.History
+{
+    [TestClass]
+    public class SimpleHistoryAsyncTests
+    {
+        [TestMethod]
+        [DataRow(5)]
+        public void Run(int messageCount)
+        {
+            var queueName = GenerateQueueName.Create();
+            var connectionString = ConnectionInfo.ConnectionString;
+            var test = new SimpleHistoryAsyncTest();
+            test.Run<RedisQueueInit, FakeMessage, RedisQueueCreation>(
+                new QueueConnection(queueName, connectionString),
+                messageCount,
+                x => { x.Options.EnableHistory = true; },
+                Helpers.GenerateData, Helpers.Verify);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 using StackExchange.Redis;
 
@@ -72,6 +73,16 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             var rawStatus = db.HashGet(HistoryHashKey(queueId), FieldStatus);
             if (!rawStatus.HasValue || (int)rawStatus != (int)MessageHistoryStatus.Enqueued) return;
             db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Processing), new HashEntry(FieldStartedUtc, DateTime.UtcNow.Ticks) });
+        }
+
+        /// <inheritdoc />
+        public async Task RecordProcessingStartAsync(string queueId)
+        {
+            if (!_options.EnableHistory) return;
+            var db = GetDb();
+            var rawStatus = await db.HashGetAsync(HistoryHashKey(queueId), FieldStatus).ConfigureAwait(false);
+            if (!rawStatus.HasValue || (int)rawStatus != (int)MessageHistoryStatus.Enqueued) return;
+            await db.HashSetAsync(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Processing), new HashEntry(FieldStartedUtc, DateTime.UtcNow.Ticks) }).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
@@ -100,6 +100,13 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// Genuinely asynchronous on SQL Server and PostgreSQL. not on SQLite:
+        /// System.Data.SQLite does not override the inherited asynchronous members, so the base class
+        /// runs them on the calling thread and this buys that transport nothing. It is written this way
+        /// regardless, because the three share this implementation and a per-provider split here would
+        /// be worse than a member that is merely no faster on one of them.
+        /// </remarks>
         public async Task RecordProcessingStartAsync(string queueId)
         {
             if (!_options.EnableHistory) return;

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
@@ -94,6 +95,29 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     AddParameter(command, "@PrevStatus", DbType.Int32, (int)MessageHistoryStatus.Enqueued);
 
                     command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task RecordProcessingStartAsync(string queueId)
+        {
+            if (!_options.EnableHistory) return;
+            using (var connection = _connectionFactory.Create())
+            {
+                await connection.OpenAsync().ConfigureAwait(false);
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $@"UPDATE {_tableNameHelper.HistoryName}
+                        SET Status = @Status, StartedUtc = @StartedUtc
+                        WHERE QueueID = @QueueID AND Status = @PrevStatus";
+
+                    AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Processing);
+                    AddParameter(command, "@StartedUtc", DbType.DateTime, DateTime.UtcNow);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
+                    AddParameter(command, "@PrevStatus", DbType.Int32, (int)MessageHistoryStatus.Enqueued);
+
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
             }
         }

--- a/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/History/SimpleHistoryAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/History/SimpleHistoryAsyncTests.cs
@@ -1,0 +1,51 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.IntegrationTests.Shared.History.Implementation;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.History
+{
+    [TestClass]
+    public class SimpleHistoryAsyncTests
+    {
+        [TestMethod]
+        [DataRow(5, true)]
+        [DataRow(5, false)]
+        public void Run(int messageCount, bool inMemoryDb)
+        {
+            using (var connectionInfo = new IntegrationConnectionInfo(inMemoryDb))
+            {
+                var queueName = GenerateQueueName.Create();
+                var test = new SimpleHistoryAsyncTest();
+                test.Run<SqLiteMessageQueueInit, FakeMessage, SqLiteMessageQueueCreation>(
+                    new QueueConnection(queueName, connectionInfo.ConnectionString),
+                    messageCount,
+                    x =>
+                    {
+                        Helpers.SetOptions(x, true, false, false, false, false, false, false);
+                        x.Options.EnableHistory = true;
+                    },
+                    Helpers.GenerateData, Helpers.Verify);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/History/SimpleHistoryAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/History/SimpleHistoryAsyncTests.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.IntegrationTests.Shared.History.Implementation;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.History
+{
+    [TestClass]
+    public class SimpleHistoryAsyncTests
+    {
+        [TestMethod]
+        [DataRow(5)]
+        public void Run(int messageCount)
+        {
+            var queueName = GenerateQueueName.Create();
+            var test = new SimpleHistoryAsyncTest();
+            test.Run<SqlServerMessageQueueInit, FakeMessage, SqlServerMessageQueueCreation>(
+                new QueueConnection(queueName, ConnectionInfo.ConnectionString),
+                messageCount,
+                x =>
+                {
+                    Helpers.SetOptions(x,
+                        false, false, false,
+                        false, false, false, true, false);
+                    x.Options.EnableHistory = true;
+                },
+                Helpers.GenerateData, Helpers.Verify);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue/History/Decorator/ReceiveMessagesHistoryDecorator.cs
+++ b/Source/DotNetWorkQueue/History/Decorator/ReceiveMessagesHistoryDecorator.cs
@@ -66,7 +66,8 @@ namespace DotNetWorkQueue.History.Decorator
             {
                 try
                 {
-                    _history.RecordProcessingStart(context.MessageId.Id.Value.ToString());
+                    await _history.RecordProcessingStartAsync(context.MessageId.Id.Value.ToString())
+                        .ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/Source/DotNetWorkQueue/IWriteMessageHistory.cs
+++ b/Source/DotNetWorkQueue/IWriteMessageHistory.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 
 namespace DotNetWorkQueue
@@ -43,6 +44,16 @@ namespace DotNetWorkQueue
         /// </summary>
         /// <param name="queueId">The message's queue ID.</param>
         void RecordProcessingStart(string queueId);
+
+        /// <summary>
+        /// Updates a history record when a message begins processing, without blocking a thread.
+        /// </summary>
+        /// <param name="queueId">The message's queue ID.</param>
+        /// <remarks>
+        /// The asynchronous consumer records this inline on its receive path, in a continuation on a
+        /// thread-pool thread, so the synchronous member would hold one of those for the write.
+        /// </remarks>
+        Task RecordProcessingStartAsync(string queueId);
 
         /// <summary>
         /// Updates a history record when a message is committed successfully.

--- a/Source/DotNetWorkQueue/Queue/WriteMessageHistoryNoOp.cs
+++ b/Source/DotNetWorkQueue/Queue/WriteMessageHistoryNoOp.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 
+using System.Threading.Tasks;
 namespace DotNetWorkQueue.Queue
 {
     /// <summary>
@@ -30,6 +31,9 @@ namespace DotNetWorkQueue.Queue
 
         /// <inheritdoc />
         public void RecordProcessingStart(string queueId) { }
+
+        /// <inheritdoc />
+        public Task RecordProcessingStartAsync(string queueId) => Task.CompletedTask;
 
         /// <inheritdoc />
         public void RecordComplete(string queueId) { }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic
@@ -58,6 +59,17 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         {
             if (!_options.EnableHistory) return;
             if (GetRecords().TryGetValue(queueId, out var r) && r.Status == MessageHistoryStatus.Enqueued) { r.Status = MessageHistoryStatus.Processing; r.StartedUtc = DateTime.UtcNow; }
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Correct as written rather than unfinished: the history lives in process, so there is no
+        /// I/O to release the thread for.
+        /// </remarks>
+        public Task RecordProcessingStartAsync(string queueId)
+        {
+            RecordProcessingStart(queueId);
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fourth of the calls #284 tracks. Small and self-contained: one interface member, five implementations, one call site.

## What blocks

`ReceiveMessagesHistoryDecorator` writes the processing-start row inline on the receive path. On the asynchronous consumer that write lands in a continuation on a thread-pool thread — once per message, whenever `EnableHistory` and `TrackProcessing` are on.

`IWriteMessageHistory` gains `RecordProcessingStartAsync`. Genuinely asynchronous on the relational transports (`OpenAsync`, `ExecuteNonQueryAsync`) and on Redis (`HashGetAsync`, `HashSetAsync`). Memory returns a completed task — the history lives in process, so there is nothing to release a thread for. LiteDB delegates to the thread pool, having no asynchronous API until v6 (#283): that frees the caller's thread without making the work asynchronous.

## Only one of the seven members

The other six are reached from the commit, rollback, error and send paths, none of which is awaitable yet. An async twin for each would be code nothing calls, and #291 showed what that does to a coverage report — its patch was capped near 54% by exactly that. They come with their callers.

## What to look at

**The tests in this class were asserting the wrong member.** The existing asynchronous tests checked `RecordProcessingStart` — the blocking one — so after this change they were verifying the wrong thing rather than failing. They now assert the asynchronous member *and* that the blocking one is not used, which is the assertion that would otherwise pass either way. One test is new: the receive must not hand the message on before the history row says processing started.

**A sibling check, not a change.** The six history decorators gate on `EnableHistory` plus a per-event `Track*` flag — except rollback, which has only `EnableHistory`. That one is correct: there is no `TrackRollback` option for it to check. Noted because it looks like an omission next to the others.

## Breaking

`IWriteMessageHistory` gains `RecordProcessingStartAsync`. Only affects code implementing that interface outside this repository; in the changelog.

## Two things this PR deliberately does not do

**HeartBeat is not a mirror job.** `ISendHeartBeat.Send` runs inside `lock (_runningLocker)` and `await` is illegal in a lock; `IHeartBeatScheduler.AddUpdateJob` takes `Expression<Action<...>>`, which cannot contain `await` either; and `Stop()` relies on that same lock to block until an in-flight beat finishes. Converting it means replacing the concurrency guard and re-proving the shutdown protocol — its own change, not a ride along here.

**A seventh synchronous call, absent from the issue's table.** `ProcessMessageAsync.cs:89` calls `MessageExceptionHandler.Handle` synchronously on the async continuation, reaching `IReceiveMessagesError.MessageFailedProcessing` and from there `RecordError` and the transport's error write. It runs through the same handler as rollback, so it belongs with that work.

## Validation

- `NoTests.sln -c Release -p:CI=true` clean
- 2,426 unit tests / 0 failed
- **SQLite integration 203 / 0 failed**
- Both new assertions checked by reverting the decorator to the blocking call

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added asynchronous processing-start history recording across supported transports.
  - Asynchronous consumers now record processing history without blocking the receiving caller thread where supported.
  - Message delivery waits for processing history to complete before continuing.

- **Breaking Changes**
  - Custom relational transports implementing message history must support `RecordProcessingStartAsync`.

- **Bug Fixes**
  - Improved asynchronous history error propagation and processing-status reliability.
  - Corrected cleanup behavior to ensure test queues and history records are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->