### PR TITLE
feat: commit a message without blocking on the async consumer (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fix: SQL Server and PostgreSQL left a message's error-history rows behind when it was removed with `EnableHoldTransactionUntilMessageCommitted` on (GitHub #284)
 - SQL Server, PostgreSQL and Redis async consumers no longer hold a thread recording that a message started processing, when history tracking is on (GitHub #284)
 - Async consumers no longer hold a thread committing a message. This is the per-message path, so it is the change consumers under thread-pool pressure will notice most (GitHub #284)
-- ⚠️ Custom transports and consumers must add async members: `IReceivePoisonMessage.HandleAsync`, `IRemoveMessage.RemoveAsync`, `IWriteMessageHistory.RecordProcessingStartAsync` and `RecordCompleteAsync`, `ICommitMessage.CommitAsync`, `ITransportCommitMessage.CommitAsync`, and `ITransactionWrapper.BeginTransactionAsync` for relational transports. Built-in transports are unaffected (GitHub #284)
+- ⚠️ Custom transports and consumers must add async members to `IReceivePoisonMessage`, `IRemoveMessage`, `IWriteMessageHistory`, `ICommitMessage`, `ITransportCommitMessage`, and `ITransactionWrapper`. GitHub #284 lists them; built-in transports are unaffected (GitHub #284)
 - ⚠️ `IMessageContext` gains a `CommitAsync` event and `RaiseCommitAsync`. Only affects code implementing that interface directly; the existing `Commit` event is unchanged and still used by the synchronous consumer (GitHub #284)
 - ⚠️ Custom relational transports: `IDbConnectionFactory`, `ITransactionFactory` and `ITransactionWrapper` now use `System.Data.Common` types (`DbConnection`, `DbTransaction`) rather than the `System.Data` interfaces, which have no async members. Built-in transports are unaffected (GitHub #286)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Redis async consumers no longer hold a thread while removing an expired message during a de-queue (GitHub #284)
 - Fix: SQL Server and PostgreSQL left a message's error-history rows behind when it was removed with `EnableHoldTransactionUntilMessageCommitted` on (GitHub #284)
 - SQL Server, PostgreSQL and Redis async consumers no longer hold a thread recording that a message started processing, when history tracking is on (GitHub #284)
-- ⚠️ Custom transports and consumers must add async members: `IReceivePoisonMessage.HandleAsync`, `IRemoveMessage.RemoveAsync`, `IWriteMessageHistory.RecordProcessingStartAsync`, and `ITransactionWrapper.BeginTransactionAsync` for relational transports. Built-in transports are unaffected (GitHub #284)
+- Async consumers no longer hold a thread committing a message. This is the per-message path, so it is the change consumers under thread-pool pressure will notice most (GitHub #284)
+- ⚠️ Custom transports and consumers must add async members: `IReceivePoisonMessage.HandleAsync`, `IRemoveMessage.RemoveAsync`, `IWriteMessageHistory.RecordProcessingStartAsync` and `RecordCompleteAsync`, `ICommitMessage.CommitAsync`, `ITransportCommitMessage.CommitAsync`, and `ITransactionWrapper.BeginTransactionAsync` for relational transports. Built-in transports are unaffected (GitHub #284)
+- ⚠️ `IMessageContext` gains a `CommitAsync` event and `RaiseCommitAsync`. Only affects code implementing that interface directly; the existing `Commit` event is unchanged and still used by the synchronous consumer (GitHub #284)
 - ⚠️ Custom relational transports: `IDbConnectionFactory`, `ITransactionFactory` and `ITransactionWrapper` now use `System.Data.Common` types (`DbConnection`, `DbTransaction`) rather than the `System.Data` interfaces, which have no async members. Built-in transports are unaffected (GitHub #286)
 
 ### 0.11.0 — 2026-09-06

--- a/Source/DotNetWorkQueue.Tests/History/Decorator/CommitMessageHistoryDecoratorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/History/Decorator/CommitMessageHistoryDecoratorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using DotNetWorkQueue.History.Decorator;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -72,6 +73,51 @@ namespace DotNetWorkQueue.Tests.History.Decorator
                 .Do(_ => throw new InvalidOperationException("history write failed"));
 
             var result = decorator.Commit(context);
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public async Task CommitAsync_When_Enabled_Records_History_Without_Blocking()
+        {
+            var (decorator, inner, history, _, _) = CreateDecorator(enabled: true, trackComplete: true);
+            var context = CreateContext();
+            inner.CommitAsync(context).Returns(Task.FromResult(true));
+
+            var result = await decorator.CommitAsync(context).ConfigureAwait(false);
+
+            Assert.IsTrue(result);
+            await history.Received(1).RecordCompleteAsync(Arg.Any<string>()).ConfigureAwait(false);
+            //Calling the blocking member here would satisfy every other assertion while holding a
+            //thread-pool thread for the write.
+            history.DidNotReceive().RecordComplete(Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public async Task CommitAsync_When_Inner_Returns_False_Does_Not_Record_History()
+        {
+            var (decorator, inner, history, _, _) = CreateDecorator(enabled: true, trackComplete: true);
+            var context = CreateContext();
+            inner.CommitAsync(context).Returns(Task.FromResult(false));
+
+            var result = await decorator.CommitAsync(context).ConfigureAwait(false);
+
+            Assert.IsFalse(result);
+            await history.DidNotReceive().RecordCompleteAsync(Arg.Any<string>()).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task CommitAsync_When_History_Throws_The_Commit_Still_Succeeds()
+        {
+            var (decorator, inner, history, _, _) = CreateDecorator(enabled: true, trackComplete: true);
+            var context = CreateContext();
+            inner.CommitAsync(context).Returns(Task.FromResult(true));
+            history.RecordCompleteAsync(Arg.Any<string>())
+                .Returns(Task.FromException(new InvalidOperationException("history write failed")));
+
+            //History is bookkeeping. Failing to write it must not turn a committed message into a
+            //failed one, which would roll back work that has already been done.
+            var result = await decorator.CommitAsync(context).ConfigureAwait(false);
 
             Assert.IsTrue(result);
         }

--- a/Source/DotNetWorkQueue.Tests/Messages/MessageContextAsyncEventTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Messages/MessageContextAsyncEventTests.cs
@@ -22,6 +22,8 @@ namespace DotNetWorkQueue.Tests.Messages
     [TestClass]
     public class MessageContextAsyncEventTests
     {
+        private static readonly string[] SequentialOrder = { "first-start", "first-end", "second-start" };
+
         [TestMethod]
         public async Task RaiseCommitAsync_WithNoSubscribers_DoesNothing()
         {
@@ -72,7 +74,7 @@ namespace DotNetWorkQueue.Tests.Messages
 
             //Not WhenAll: the second handler must not start until the first has finished, because the
             //transports commit against a shared connection and transaction.
-            CollectionAssert.AreEqual(new[] { "first-start", "first-end", "second-start" }, order);
+            CollectionAssert.AreEqual(SequentialOrder, order);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Tests/Messages/MessageContextAsyncEventTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Messages/MessageContextAsyncEventTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Messages;
+using NSubstitute;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Tests.Messages
+{
+    /// <summary>
+    /// The awaitable commit event on the message context.
+    ///
+    /// <see cref="EventHandler"/> returns void, so a subscriber doing transport I/O had to block the
+    /// thread that raised the event - and on the asynchronous consumer that raise happens in a
+    /// continuation on a thread-pool thread, once per message. The awaitable event is what lets the
+    /// transports commit without holding it.
+    ///
+    /// Handlers run one after another rather than concurrently, which is what the synchronous event
+    /// already did. That ordering is load-bearing: the transports commit against a shared connection
+    /// and transaction, which cannot take concurrent work.
+    /// </summary>
+    [TestClass]
+    public class MessageContextAsyncEventTests
+    {
+        [TestMethod]
+        public async Task RaiseCommitAsync_WithNoSubscribers_DoesNothing()
+        {
+            using var context = NewContext();
+
+            await context.RaiseCommitAsync().ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task RaiseCommitAsync_AwaitsTheSubscriber()
+        {
+            using var context = NewContext();
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            context.CommitAsync += (_, _) => gate.Task;
+
+            var raising = context.RaiseCommitAsync();
+
+            var completedEarly = await Task.WhenAny(raising, Task.Delay(TimeSpan.FromMilliseconds(250)))
+                .ConfigureAwait(false) == raising;
+
+            Assert.IsFalse(completedEarly,
+                "The raise completed while the subscriber was still working. Discarding that task lets " +
+                "the consumer carry on before the message has actually been committed.");
+
+            gate.TrySetResult(true);
+            await raising.ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task RaiseCommitAsync_RunsSubscribersOneAfterAnother()
+        {
+            using var context = NewContext();
+            var order = new List<string>();
+
+            context.CommitAsync += async (_, _) =>
+            {
+                order.Add("first-start");
+                await Task.Delay(30).ConfigureAwait(false);
+                order.Add("first-end");
+            };
+            context.CommitAsync += (_, _) =>
+            {
+                order.Add("second-start");
+                return Task.CompletedTask;
+            };
+
+            await context.RaiseCommitAsync().ConfigureAwait(false);
+
+            //Not WhenAll: the second handler must not start until the first has finished, because the
+            //transports commit against a shared connection and transaction.
+            CollectionAssert.AreEqual(new[] { "first-start", "first-end", "second-start" }, order);
+        }
+
+        [TestMethod]
+        public async Task RaiseCommitAsync_PropagatesTheSubscribersFailure()
+        {
+            using var context = NewContext();
+            context.CommitAsync += (_, _) => Task.FromException(new InvalidOperationException("commit failed"));
+
+            //A failed commit must not be swallowed here - CommitMessage turns it into a CommitException,
+            //which is what the queue's error handling is written against.
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => context.RaiseCommitAsync()).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task RaiseCommitAsync_AfterDispose_Throws()
+        {
+            var context = NewContext();
+            context.Dispose();
+
+            await Assert.ThrowsExactlyAsync<ObjectDisposedException>(
+                () => context.RaiseCommitAsync()).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task RaiseCommitAsync_DoesNotRaiseTheSynchronousEvent()
+        {
+            using var context = NewContext();
+            var syncCalled = false;
+            var asyncCalled = false;
+            context.Commit += (_, _) => syncCalled = true;
+            context.CommitAsync += (_, _) => { asyncCalled = true; return Task.CompletedTask; };
+
+            await context.RaiseCommitAsync().ConfigureAwait(false);
+
+            Assert.IsTrue(asyncCalled);
+            Assert.IsFalse(syncCalled,
+                "A context raises one event or the other. Raising both would commit the message twice.");
+        }
+
+        [TestMethod]
+        public void RaiseCommit_DoesNotRaiseTheAwaitableEvent()
+        {
+            using var context = NewContext();
+            var syncCalled = false;
+            var asyncCalled = false;
+            context.Commit += (_, _) => syncCalled = true;
+            context.CommitAsync += (_, _) => { asyncCalled = true; return Task.CompletedTask; };
+
+            context.RaiseCommit();
+
+            Assert.IsTrue(syncCalled);
+            Assert.IsFalse(asyncCalled);
+        }
+
+        private static MessageContext NewContext() =>
+            new MessageContext(Substitute.For<IWorkerNotificationFactory>());
+    }
+}

--- a/Source/DotNetWorkQueue.Tests/Queue/CommitMessageAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/CommitMessageAsyncTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Queue;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Tests.Queue
+{
+    /// <summary>
+    /// <see cref="CommitMessage"/>'s awaitable member.
+    ///
+    /// Its job is to raise the event and to turn any failure underneath into a
+    /// <see cref="CommitException"/> carrying the message's identity - which is what the queue's
+    /// error handling is written against. `MessageProcessingAsync` catches `MessageException` to roll
+    /// a message back, and `CommitException` is how a failed commit reaches that.
+    /// </summary>
+    [TestClass]
+    public class CommitMessageAsyncTests
+    {
+        [TestMethod]
+        public async Task CommitAsync_RaisesTheAwaitableEvent()
+        {
+            var context = Substitute.For<IMessageContext>();
+            context.RaiseCommitAsync().Returns(Task.CompletedTask);
+
+            var result = await new CommitMessage().CommitAsync(context).ConfigureAwait(false);
+
+            Assert.IsTrue(result);
+            await context.Received(1).RaiseCommitAsync().ConfigureAwait(false);
+            context.DidNotReceive().RaiseCommit();
+        }
+
+        [TestMethod]
+        public async Task CommitAsync_WrapsAFailureAsCommitException()
+        {
+            var context = ContextWithIdentity();
+            context.RaiseCommitAsync()
+                .Returns(Task.FromException(new InvalidOperationException("transport refused the delete")));
+
+            var thrown = await Assert.ThrowsExactlyAsync<CommitException>(
+                () => new CommitMessage().CommitAsync(context)).ConfigureAwait(false);
+
+            Assert.IsInstanceOfType<InvalidOperationException>(thrown.InnerException);
+        }
+
+        [TestMethod]
+        public async Task CommitAsync_TheExceptionCarriesTheMessageIdentity()
+        {
+            var context = ContextWithIdentity();
+            context.RaiseCommitAsync().Returns(Task.FromException(new InvalidOperationException("boom")));
+
+            var thrown = await Assert.ThrowsExactlyAsync<CommitException>(
+                () => new CommitMessage().CommitAsync(context)).ConfigureAwait(false);
+
+            //Without these the notification raised for a failed commit cannot say which message failed.
+            Assert.AreSame(context.MessageId, thrown.MessageId);
+            Assert.AreSame(context.CorrelationId, thrown.CorrelationId);
+            Assert.AreSame(context.Headers, thrown.Headers);
+        }
+
+        [TestMethod]
+        public async Task CommitAsync_WithNoContext_Throws()
+        {
+            await Assert.ThrowsExactlyAsync<ArgumentNullException>(
+                () => new CommitMessage().CommitAsync(null)).ConfigureAwait(false);
+        }
+
+        private static IMessageContext ContextWithIdentity()
+        {
+            var messageId = Substitute.For<IMessageId>();
+            var correlationId = Substitute.For<ICorrelationId>();
+            var context = Substitute.For<IMessageContext>();
+            context.MessageId.Returns(messageId);
+            context.CorrelationId.Returns(correlationId);
+            return context;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Tests/Queue/ProcessMessageAsyncCommitTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/ProcessMessageAsyncCommitTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using DotNetWorkQueue.Exceptions;
+using DotNetWorkQueue.Queue;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Tests.Queue
+{
+    /// <summary>
+    /// Committing on the asynchronous consumer.
+    ///
+    /// The commit is the busiest of the calls #284 tracks: it runs on every message, on the happy
+    /// path, in a continuation on a thread-pool thread. Both the assertion that the awaitable member
+    /// is used and the assertion that the blocking one is not are needed - the message is committed
+    /// either way, so nothing else would notice the wrong one.
+    /// </summary>
+    [TestClass]
+    public class ProcessMessageAsyncCommitTests
+    {
+        [TestMethod]
+        public async Task HandleAsync_CommitsWithoutBlocking()
+        {
+            var harness = new Harness();
+
+            await harness.Processor.HandleAsync(harness.Context, harness.Message).ConfigureAwait(false);
+
+            await harness.CommitMessage.Received(1).CommitAsync(harness.Context).ConfigureAwait(false);
+            harness.CommitMessage.DidNotReceive().Commit(Arg.Any<IMessageContext>());
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WaitsForTheCommit()
+        {
+            var harness = new Harness();
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            harness.CommitMessage.CommitAsync(Arg.Any<IMessageContext>()).Returns(gate.Task);
+
+            var handling = harness.Processor.HandleAsync(harness.Context, harness.Message);
+
+            var completedEarly = await Task.WhenAny(handling, Task.Delay(TimeSpan.FromMilliseconds(250)))
+                .ConfigureAwait(false) == handling;
+
+            Assert.IsFalse(completedEarly,
+                "Processing reported done while the commit was still in flight. The consumer would " +
+                "release the message - and could shut down - before the transport had committed it.");
+
+            gate.TrySetResult(true);
+            await handling.ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_WhenTheCommitFails_TheExceptionHandlerSeesIt()
+        {
+            var harness = new Harness();
+            harness.CommitMessage.CommitAsync(Arg.Any<IMessageContext>())
+                .Returns(Task.FromException<bool>(new InvalidOperationException("commit failed")));
+
+            //A failed commit goes through the message exception handler, which wraps and rethrows -
+            //so it surfaces as MessageException, which is what MessageProcessingAsync catches to roll
+            //the message back. The awaited commit must not change that contract.
+            var thrown = await Assert.ThrowsExactlyAsync<MessageException>(
+                () => harness.Processor.HandleAsync(harness.Context, harness.Message)).ConfigureAwait(false);
+            Assert.IsInstanceOfType<InvalidOperationException>(thrown.InnerException);
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_DoesNotCommitWhenTheHandlerThrows()
+        {
+            var harness = new Harness();
+            harness.Handler
+                .HandleAsync(Arg.Any<IReceivedMessageInternal>(), Arg.Any<IWorkerNotification>())
+                .Returns(Task.FromException(new InvalidOperationException("handler failed")));
+
+            await Assert.ThrowsExactlyAsync<MessageException>(
+                () => harness.Processor.HandleAsync(harness.Context, harness.Message)).ConfigureAwait(false);
+
+            await harness.CommitMessage.DidNotReceiveWithAnyArgs().CommitAsync(null).ConfigureAwait(false);
+        }
+
+        private sealed class Harness
+        {
+            public ProcessMessageAsync Processor { get; }
+            public ICommitMessage CommitMessage { get; }
+            public IHandleMessage Handler { get; }
+            public IMessageContext Context { get; }
+            public IReceivedMessageInternal Message { get; }
+
+            public Harness()
+            {
+                var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
+
+                CommitMessage = Substitute.For<ICommitMessage>();
+                CommitMessage.CommitAsync(Arg.Any<IMessageContext>()).Returns(Task.FromResult(true));
+
+                Handler = Substitute.For<IHandleMessage>();
+                Handler.HandleAsync(Arg.Any<IReceivedMessageInternal>(), Arg.Any<IWorkerNotification>())
+                    .Returns(Task.CompletedTask);
+
+                fixture.Inject(CommitMessage);
+                fixture.Inject(Handler);
+
+                Context = Substitute.For<IMessageContext>();
+                Message = Substitute.For<IReceivedMessageInternal>();
+                Processor = fixture.Create<ProcessMessageAsync>();
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Tests/Queue/WriteMessageHistoryNoOpTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/WriteMessageHistoryNoOpTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoNSubstitute;
 using DotNetWorkQueue.Queue;
@@ -55,6 +56,20 @@ namespace DotNetWorkQueue.Tests.Queue
         {
             var test = Create();
             test.RecordExpire("1");
+        }
+
+        [TestMethod]
+        public async Task RecordProcessingStartAsync_DoesNotThrow()
+        {
+            var test = Create();
+            await test.RecordProcessingStartAsync("1").ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task RecordCompleteAsync_DoesNotThrow()
+        {
+            var test = Create();
+            await test.RecordCompleteAsync("1").ConfigureAwait(false);
         }
 
         private IWriteMessageHistory Create()

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
@@ -242,6 +242,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         private void ContextCleanup(IMessageContext context)
         {
             context.Commit -= _cachedCommit;
+            context.CommitAsync -= _cachedCommitAsync;
             context.Rollback -= _cachedRollback;
             context.Cleanup -= _cachedCleanup;
         }

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/LiteDbQueueReceiveMessages.cs
@@ -175,6 +175,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         //delegate that unsubscribes just as well, since removal compares target and method rather
         //than reference.
         private EventHandler _cachedCommit;
+        private AsyncEventHandler _cachedCommitAsync;
         private EventHandler _cachedRollback;
         private EventHandler _cachedCleanup;
 
@@ -188,6 +189,9 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         {
             //wire up the context commit/rollback/dispose delegates
             context.Commit += _cachedCommit ??= ContextOnCommit;
+            //Both are subscribed: the synchronous consumer raises Commit, the asynchronous one
+            //raises CommitAsync. A context only ever raises one of them.
+            context.CommitAsync += _cachedCommitAsync ??= ContextOnCommitAsync;
             context.Rollback += _cachedRollback ??= ContextOnRollback;
             context.Cleanup += _cachedCleanup ??= Context_Cleanup;
         }
@@ -221,6 +225,14 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         private void ContextOnCommit(object sender, EventArgs eventArgs)
         {
             _handleMessage.CommitMessage.Commit((IMessageContext)sender);
+        }
+
+        /// <summary>
+        /// On Commit, awaited
+        /// </summary>
+        private async Task ContextOnCommitAsync(object sender, EventArgs eventArgs)
+        {
+            await _handleMessage.CommitMessage.CommitAsync((IMessageContext)sender).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
@@ -80,6 +80,13 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         }
 
         /// <inheritdoc />
+        /// <remarks>See <see cref="RecordProcessingStartAsync"/>: LiteDB has no async API (#283).</remarks>
+        public async Task RecordCompleteAsync(string queueId)
+        {
+            await Task.Run(() => RecordComplete(queueId)).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
         public void RecordProcessingStart(string queueId)
         {
             using (var db = _connectionManager.GetDatabase())

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueReceive.cs
@@ -161,6 +161,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
         //delegate that unsubscribes just as well, since removal compares target and method rather
         //than reference.
         private EventHandler _cachedCommit;
+        private AsyncEventHandler _cachedCommitAsync;
         private EventHandler _cachedCommitTransaction;
         private EventHandler _cachedRollback;
         private EventHandler _cachedRollbackTransaction;
@@ -180,6 +181,9 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             if (!_configuration.Options().EnableHoldTransactionUntilMessageCommitted)
             {
                 context.Commit += _cachedCommit ??= ContextOnCommit;
+                //Both are subscribed: the synchronous consumer raises Commit, the asynchronous one
+                //raises CommitAsync. A context only ever raises one of them.
+                context.CommitAsync += _cachedCommitAsync ??= ContextOnCommitAsync;
                 context.Rollback += _cachedRollback ??= ContextOnRollback;
             }
             else
@@ -263,6 +267,14 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
         private void ContextOnCommit(object sender, EventArgs eventArgs)
         {
             _handleMessage.CommitMessage.Commit((IMessageContext)sender);
+        }
+
+        /// <summary>
+        /// On Commit, awaited
+        /// </summary>
+        private async Task ContextOnCommitAsync(object sender, EventArgs eventArgs)
+        {
+            await _handleMessage.CommitMessage.CommitAsync((IMessageContext)sender).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueReceive.cs
@@ -189,6 +189,11 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             else
             {
                 context.Commit += _cachedCommitTransaction ??= ContextOnCommitTransaction;
+                //The same awaited handler serves both branches: the held-transaction commit delegate
+                //also ends at CommitMessage.Commit, and RemoveAsync handles the held transaction
+                //itself. Missing this is what left the asynchronous consumer unable to commit with
+                //EnableHoldTransactionUntilMessageCommitted on.
+                context.CommitAsync += _cachedCommitAsync ??= ContextOnCommitAsync;
                 context.Rollback += _cachedRollbackTransaction ??= ContextOnRollbackTransaction;
             }
             context.Cleanup += _cachedCleanup ??= Context_Cleanup;
@@ -294,6 +299,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
                 context.Commit -= _cachedCommitTransaction;
                 context.Rollback -= _cachedRollbackTransaction;
             }
+            context.CommitAsync -= _cachedCommitAsync;
             context.Cleanup -= _cachedCleanup;
             _disposeConnection(connectionHolder);
         }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
@@ -68,6 +68,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         //delegate that unsubscribes just as well, since removal compares target and method rather
         //than reference.
         private EventHandler _cachedCommit;
+        private AsyncEventHandler _cachedCommitAsync;
         private EventHandler _cachedRollback;
         private EventHandler _cachedCleanup;
 
@@ -80,6 +81,9 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         public IReceivedMessageInternal ReceiveMessage(IMessageContext context)
         {
             context.Commit += _cachedCommit ??= ContextOnCommit;
+            //Both are subscribed: the synchronous consumer raises Commit, the asynchronous one
+            //raises CommitAsync. A context only ever raises one of them.
+            context.CommitAsync += _cachedCommitAsync ??= ContextOnCommitAsync;
             context.Rollback += _cachedRollback ??= ContextOnRollback;
             context.Cleanup += _cachedCleanup ??= Context_Cleanup;
 
@@ -236,6 +240,14 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         private void ContextOnCommit(object sender, EventArgs eventArgs)
         {
             _handleMessage.CommitMessage.Commit((IMessageContext)sender);
+        }
+
+        /// <summary>
+        /// On Commit, awaited
+        /// </summary>
+        private async Task ContextOnCommitAsync(object sender, EventArgs eventArgs)
+        {
+            await _handleMessage.CommitMessage.CommitAsync((IMessageContext)sender).ConfigureAwait(false);
         }
         /// <summary>
         /// Handles the Cleanup event of the context control.

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisQueueReceiveMessages.cs
@@ -141,9 +141,11 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// </remarks>
         public async ValueTask<IReceivedMessageInternal> ReceiveMessageAsync(IMessageContext context, CancellationToken cancellation)
         {
-            //These three are not optional. Without them the method still compiles and still returns
-            //messages, and commit and rollback silently stop working.
+            //These are not optional. Without them the method still compiles and still returns
+            //messages, and commit and rollback silently stop working. CommitAsync is the one this
+            //path actually needs: the asynchronous consumer raises that event, not Commit.
             context.Commit += _cachedCommit ??= ContextOnCommit;
+            context.CommitAsync += _cachedCommitAsync ??= ContextOnCommitAsync;
             context.Rollback += _cachedRollback ??= ContextOnRollback;
             context.Cleanup += _cachedCleanup ??= Context_Cleanup;
 
@@ -266,6 +268,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         private void ContextCleanup(IMessageContext context)
         {
             context.Commit -= _cachedCommit;
+            context.CommitAsync -= _cachedCommitAsync;
             context.Rollback -= _cachedRollback;
             context.Cleanup -= _cachedCleanup;
         }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
@@ -86,6 +86,18 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         }
 
         /// <inheritdoc />
+        public async Task RecordCompleteAsync(string queueId)
+        {
+            if (!_options.EnableHistory) return;
+            var db = GetDb();
+            var now = DateTime.UtcNow;
+            var rawStarted = await db.HashGetAsync(HistoryHashKey(queueId), FieldStartedUtc).ConfigureAwait(false);
+            var startedTicks = rawStarted.HasValue ? (long)rawStarted : 0L;
+            var durationMs = startedTicks > 0 ? (long)(now - new DateTime(startedTicks, DateTimeKind.Utc)).TotalMilliseconds : 0L;
+            await db.HashSetAsync(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Complete), new HashEntry(FieldCompletedUtc, now.Ticks), new HashEntry(FieldDurationMs, durationMs) }).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
         public void RecordComplete(string queueId)
         {
             if (!_options.EnableHistory) return;

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
@@ -130,6 +130,48 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         }
 
         /// <inheritdoc />
+        /// <remarks>See <see cref="RecordProcessingStartAsync"/> on what SQLite does and does not gain.</remarks>
+        public async Task RecordCompleteAsync(string queueId)
+        {
+            if (!_options.EnableHistory) return;
+            var now = DateTime.UtcNow;
+            using (var connection = _connectionFactory.Create())
+            {
+                await connection.OpenAsync().ConfigureAwait(false);
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $@"UPDATE {_tableNameHelper.HistoryName}
+                        SET Status = @Status, CompletedUtc = @CompletedUtc
+                        WHERE QueueID = @QueueID AND Status = @PrevStatus";
+
+                    AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Complete);
+                    AddParameter(command, CompletedUtcParameter, DbType.DateTime, now);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
+                    AddParameter(command, "@PrevStatus", DbType.Int32, (int)MessageHistoryStatus.Processing);
+
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+                }
+
+                // Update duration separately
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $@"UPDATE {_tableNameHelper.HistoryName}
+                        SET DurationMs = @DurationMs
+                        WHERE QueueID = @QueueID AND CompletedUtc IS NOT NULL AND DurationMs IS NULL";
+
+                    // Read start time to calculate duration
+                    var startTime = await GetStartedUtcAsync(connection, queueId).ConfigureAwait(false);
+                    var durationMs = startTime.HasValue ? (long)(now - startTime.Value).TotalMilliseconds : 0L;
+
+                    AddParameter(command, "@DurationMs", DbType.Int64, durationMs);
+                    AddParameter(command, QueueIdParameter, DbType.String, queueId);
+
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <inheritdoc />
         public void RecordComplete(string queueId)
         {
             if (!_options.EnableHistory) return;
@@ -264,6 +306,35 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     command.ExecuteNonQuery();
                 }
             }
+        }
+
+        private async Task<DateTime?> GetStartedUtcAsync(DbConnection connection, string queueId)
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = $"SELECT StartedUtc FROM {_tableNameHelper.HistoryName} WHERE QueueID = @QueueID";
+                AddParameter(command, QueueIdParameter, DbType.String, queueId);
+
+                var result = await command.ExecuteScalarAsync().ConfigureAwait(false);
+                return ReadStartedUtc(result);
+            }
+        }
+
+        /// <summary>
+        /// SQLite stores DateTime as INTEGER (ticks) or TEXT; other transports return DateTime directly.
+        /// Shared so the two readers cannot drift on that.
+        /// </summary>
+        private static DateTime? ReadStartedUtc(object result)
+        {
+            if (result == null || result == DBNull.Value)
+                return null;
+
+            if (result is DateTime dt)
+                return dt;
+            if (result is long ticks && ticks > 0)
+                return new DateTime(ticks, DateTimeKind.Utc);
+
+            return null;
         }
 
         private DateTime? GetStartedUtc(DbConnection connection, string queueId)

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
@@ -32,6 +32,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         private const string QueueIdParameter = "@QueueID";
         private const string StatusParameter = "@Status";
         private const string CompletedUtcParameter = "@CompletedUtc";
+        private const string PrevStatusParameter = "@PrevStatus";
         private readonly IDbConnectionFactory _connectionFactory;
         private readonly ITableNameHelper _tableNameHelper;
         private readonly IBaseTransportOptions _options;
@@ -92,7 +93,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Processing);
                     AddParameter(command, "@StartedUtc", DbType.DateTime, DateTime.UtcNow);
                     AddParameter(command, QueueIdParameter, DbType.String, queueId);
-                    AddParameter(command, "@PrevStatus", DbType.Int32, (int)MessageHistoryStatus.Enqueued);
+                    AddParameter(command, PrevStatusParameter, DbType.Int32, (int)MessageHistoryStatus.Enqueued);
 
                     command.ExecuteNonQuery();
                 }
@@ -122,7 +123,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Processing);
                     AddParameter(command, "@StartedUtc", DbType.DateTime, DateTime.UtcNow);
                     AddParameter(command, QueueIdParameter, DbType.String, queueId);
-                    AddParameter(command, "@PrevStatus", DbType.Int32, (int)MessageHistoryStatus.Enqueued);
+                    AddParameter(command, PrevStatusParameter, DbType.Int32, (int)MessageHistoryStatus.Enqueued);
 
                     await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
@@ -147,7 +148,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Complete);
                     AddParameter(command, CompletedUtcParameter, DbType.DateTime, now);
                     AddParameter(command, QueueIdParameter, DbType.String, queueId);
-                    AddParameter(command, "@PrevStatus", DbType.Int32, (int)MessageHistoryStatus.Processing);
+                    AddParameter(command, PrevStatusParameter, DbType.Int32, (int)MessageHistoryStatus.Processing);
 
                     await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
@@ -188,7 +189,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Complete);
                     AddParameter(command, CompletedUtcParameter, DbType.DateTime, now);
                     AddParameter(command, QueueIdParameter, DbType.String, queueId);
-                    AddParameter(command, "@PrevStatus", DbType.Int32, (int)MessageHistoryStatus.Processing);
+                    AddParameter(command, PrevStatusParameter, DbType.Int32, (int)MessageHistoryStatus.Processing);
 
                     command.ExecuteNonQuery();
                 }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
@@ -178,6 +178,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         //delegate that unsubscribes just as well, since removal compares target and method rather
         //than reference.
         private EventHandler _cachedCommit;
+        private AsyncEventHandler _cachedCommitAsync;
         private EventHandler _cachedRollback;
         private EventHandler _cachedCleanup;
 
@@ -191,6 +192,9 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         {
             //wire up the context commit/rollback/dispose delegates
             context.Commit += _cachedCommit ??= ContextOnCommit;
+            //Both are subscribed: the synchronous consumer raises Commit, the asynchronous one
+            //raises CommitAsync. A context only ever raises one of them.
+            context.CommitAsync += _cachedCommitAsync ??= ContextOnCommitAsync;
             context.Rollback += _cachedRollback ??= ContextOnRollback;
             context.Cleanup += _cachedCleanup ??= Context_Cleanup;
         }
@@ -224,6 +228,14 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         private void ContextOnCommit(object sender, EventArgs eventArgs)
         {
             _handleMessage.CommitMessage.Commit((IMessageContext)sender);
+        }
+
+        /// <summary>
+        /// On Commit, awaited
+        /// </summary>
+        private async Task ContextOnCommitAsync(object sender, EventArgs eventArgs)
+        {
+            await _handleMessage.CommitMessage.CommitAsync((IMessageContext)sender).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueReceive.cs
@@ -245,6 +245,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
         private void ContextCleanup(IMessageContext context)
         {
             context.Commit -= _cachedCommit;
+            context.CommitAsync -= _cachedCommitAsync;
             context.Rollback -= _cachedRollback;
             context.Cleanup -= _cachedCleanup;
         }

--- a/Source/DotNetWorkQueue.Transport.Shared/Message/TransportCommitMessage.cs
+++ b/Source/DotNetWorkQueue.Transport.Shared/Message/TransportCommitMessage.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading.Tasks;
 using DotNetWorkQueue.Validation;
 namespace DotNetWorkQueue.Transport.Shared.Message
 {
@@ -41,6 +42,19 @@ namespace DotNetWorkQueue.Transport.Shared.Message
         public void Commit(IMessageContext context)
         {
             _removeMessage.Remove(context, RemoveMessageReason.Complete);
+        }
+
+        /// <summary>
+        /// Commits the processed message, by deleting the message, without blocking a thread.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <remarks>
+        /// This is the caller #291 built <see cref="IRemoveMessage.RemoveAsync(IMessageContext, RemoveMessageReason)"/> for: the commit path
+        /// bottoms out in a delete, on every message.
+        /// </remarks>
+        public async Task CommitAsync(IMessageContext context)
+        {
+            await _removeMessage.RemoveAsync(context, RemoveMessageReason.Complete).ConfigureAwait(false);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueReceive.cs
@@ -198,6 +198,11 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             else
             {
                 context.Commit += _cachedCommitTransaction ??= ContextOnCommitTransaction;
+                //The same awaited handler serves both branches: the held-transaction commit delegate
+                //also ends at CommitMessage.Commit, and RemoveAsync handles the held transaction
+                //itself. Missing this is what left the asynchronous consumer unable to commit with
+                //EnableHoldTransactionUntilMessageCommitted on.
+                context.CommitAsync += _cachedCommitAsync ??= ContextOnCommitAsync;
                 context.Rollback += _cachedRollbackTransaction ??= ContextOnRollbackTransaction;
             }
             context.Cleanup += _cachedCleanup ??= Context_Cleanup;
@@ -303,6 +308,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
                 context.Commit -= _cachedCommitTransaction;
                 context.Rollback -= _cachedRollbackTransaction;
             }
+            context.CommitAsync -= _cachedCommitAsync;
             context.Cleanup -= _cachedCleanup;
             _disposeConnection(connectionHolder);
         }

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueReceive.cs
@@ -170,6 +170,7 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         //delegate that unsubscribes just as well, since removal compares target and method rather
         //than reference.
         private EventHandler _cachedCommit;
+        private AsyncEventHandler _cachedCommitAsync;
         private EventHandler _cachedCommitTransaction;
         private EventHandler _cachedRollback;
         private EventHandler _cachedRollbackTransaction;
@@ -189,6 +190,9 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             if (!_configuration.Options().EnableHoldTransactionUntilMessageCommitted)
             {
                 context.Commit += _cachedCommit ??= ContextOnCommit;
+                //Both are subscribed: the synchronous consumer raises Commit, the asynchronous one
+                //raises CommitAsync. A context only ever raises one of them.
+                context.CommitAsync += _cachedCommitAsync ??= ContextOnCommitAsync;
                 context.Rollback += _cachedRollback ??= ContextOnRollback;
             }
             else
@@ -272,6 +276,14 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
         private void ContextOnCommit(object sender, EventArgs eventArgs)
         {
             _handleMessage.CommitMessage.Commit((IMessageContext)sender);
+        }
+
+        /// <summary>
+        /// On Commit, awaited
+        /// </summary>
+        private async Task ContextOnCommitAsync(object sender, EventArgs eventArgs)
+        {
+            await _handleMessage.CommitMessage.CommitAsync((IMessageContext)sender).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue/AsyncEventHandler.cs
+++ b/Source/DotNetWorkQueue/AsyncEventHandler.cs
@@ -16,25 +16,24 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using System.Threading.Tasks;
 
-namespace DotNetWorkQueue.Transport.Shared
+namespace DotNetWorkQueue
 {
     /// <summary>
-    /// Transport commit message action
+    /// An event handler that can be awaited.
     /// </summary>
-    public interface ITransportCommitMessage
-    {
-        /// <summary>
-        /// Commits the processed message, by deleting the message
-        /// </summary>
-        /// <param name="context">The context.</param>
-        void Commit(IMessageContext context);
-
-        /// <summary>
-        /// Commits the processed message, by deleting the message, without blocking a thread.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        Task CommitAsync(IMessageContext context);
-    }
+    /// <param name="sender">The sender.</param>
+    /// <param name="e">The event data.</param>
+    /// <returns>A task that completes when the handler has finished.</returns>
+    /// <remarks>
+    /// <see cref="EventHandler"/> returns void, so a subscriber doing I/O has to block the thread that
+    /// raised the event. That is what the commit and rollback events did on the asynchronous consumer,
+    /// where the raise happens in a continuation on a thread-pool thread.
+    ///
+    /// Handlers are awaited one after another, in subscription order, which is how the synchronous
+    /// events already behaved - the next handler does not start until the previous one has finished.
+    /// </remarks>
+    public delegate Task AsyncEventHandler(object sender, EventArgs e);
 }

--- a/Source/DotNetWorkQueue/History/Decorator/CommitMessageHistoryDecorator.cs
+++ b/Source/DotNetWorkQueue/History/Decorator/CommitMessageHistoryDecorator.cs
@@ -17,6 +17,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace DotNetWorkQueue.History.Decorator
@@ -47,6 +48,24 @@ namespace DotNetWorkQueue.History.Decorator
                 try
                 {
                     _history.RecordComplete(context.MessageId.Id.Value.ToString());
+                }
+                catch (Exception ex)
+                {
+                    _log.LogWarning(ex, "Failed to record history for commit of message {MessageId}", context.MessageId.Id.Value);
+                }
+            }
+            return result;
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> CommitAsync(IMessageContext context)
+        {
+            var result = await _handler.CommitAsync(context).ConfigureAwait(false);
+            if (result && _options.EnableHistory && _options.HistoryOptions.TrackComplete && context.MessageId != null && context.MessageId.HasValue)
+            {
+                try
+                {
+                    await _history.RecordCompleteAsync(context.MessageId.Id.Value.ToString()).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/Source/DotNetWorkQueue/ICommitMessage.cs
+++ b/Source/DotNetWorkQueue/ICommitMessage.cs
@@ -16,6 +16,8 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading.Tasks;
+
 namespace DotNetWorkQueue
 {
     /// <summary>
@@ -29,5 +31,16 @@ namespace DotNetWorkQueue
         /// <param name="context"></param>
         /// <returns></returns>
         bool Commit(IMessageContext context);
+
+        /// <summary>
+        /// Commits the message associated to the context, without blocking a thread.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns>true if the message was committed</returns>
+        /// <remarks>
+        /// The asynchronous consumer commits from a continuation on a thread-pool thread, and a commit
+        /// is transport I/O on every message - the busiest of the calls #284 tracks.
+        /// </remarks>
+        Task<bool> CommitAsync(IMessageContext context);
     }
 }

--- a/Source/DotNetWorkQueue/IMessageContext.cs
+++ b/Source/DotNetWorkQueue/IMessageContext.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue
 {
@@ -55,6 +56,16 @@ namespace DotNetWorkQueue
         /// Will be raised when it is time to commit the message.
         /// </summary>
         event EventHandler Commit;
+
+        /// <summary>
+        /// Occurs when the message has been committed, and lets the subscriber be awaited.
+        /// </summary>
+        /// <remarks>
+        /// The asynchronous consumer raises this instead of <see cref="Commit"/>: committing is
+        /// transport I/O, and an <see cref="EventHandler"/> subscriber would have to block the
+        /// continuation that raised it.
+        /// </remarks>
+        event AsyncEventHandler CommitAsync;
 
         /// <summary>
         /// Will be raised if the message should be rolled back.
@@ -104,6 +115,11 @@ namespace DotNetWorkQueue
         /// Explicitly fires the commit event.
         /// </summary>
         void RaiseCommit();
+
+        /// <summary>
+        /// Explicitly fires the commit event, awaiting each subscriber in turn.
+        /// </summary>
+        Task RaiseCommitAsync();
 
         /// <summary>
         /// Explicitly fires the rollback event.

--- a/Source/DotNetWorkQueue/IWriteMessageHistory.cs
+++ b/Source/DotNetWorkQueue/IWriteMessageHistory.cs
@@ -56,6 +56,12 @@ namespace DotNetWorkQueue
         Task RecordProcessingStartAsync(string queueId);
 
         /// <summary>
+        /// Updates a history record when a message completes, without blocking a thread.
+        /// </summary>
+        /// <param name="queueId">The message's queue ID.</param>
+        Task RecordCompleteAsync(string queueId);
+
+        /// <summary>
         /// Updates a history record when a message is committed successfully.
         /// </summary>
         /// <param name="queueId">The message's queue ID.</param>

--- a/Source/DotNetWorkQueue/Messages/MessageContext.cs
+++ b/Source/DotNetWorkQueue/Messages/MessageContext.cs
@@ -20,6 +20,7 @@ using DotNetWorkQueue.Validation;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Messages
 {
@@ -37,6 +38,9 @@ namespace DotNetWorkQueue.Messages
         /// Will be raised when it is time to commit the message.
         /// </summary>
         public event EventHandler Commit;
+
+        /// <inheritdoc/>
+        public event AsyncEventHandler CommitAsync;
 
         /// <summary>
         /// Will be raised if the message should be rolled back.
@@ -111,10 +115,32 @@ namespace DotNetWorkQueue.Messages
         }
 
         /// <inheritdoc/>
+        public Task RaiseCommitAsync() => RaiseAsync(CommitAsync);
+
+        /// <inheritdoc/>
         public void RaiseRollback()
         {
             ThrowIfDisposed();
             Rollback?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Awaits each subscriber in turn, in subscription order.
+        /// </summary>
+        /// <remarks>
+        /// Sequential rather than <see cref="Task.WhenAll(System.Collections.Generic.IEnumerable{Task})"/>:
+        /// the synchronous events already ran their handlers one after another, and the transports
+        /// subscribed to these commit and roll back against a shared connection and transaction, which
+        /// cannot take concurrent work.
+        /// </remarks>
+        private async Task RaiseAsync(AsyncEventHandler handlers)
+        {
+            ThrowIfDisposed();
+            if (handlers == null) return;
+            foreach (var handler in handlers.GetInvocationList())
+            {
+                await ((AsyncEventHandler)handler)(this, EventArgs.Empty).ConfigureAwait(false);
+            }
         }
 
         /// <inheritdoc/>

--- a/Source/DotNetWorkQueue/Metrics/Decorator/ICommitMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Metrics/Decorator/ICommitMessageDecorator.cs
@@ -16,6 +16,8 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading.Tasks;
+
 namespace DotNetWorkQueue.Metrics.Decorator
 {
     internal class CommitMessageDecorator : ICommitMessage
@@ -46,6 +48,17 @@ namespace DotNetWorkQueue.Metrics.Decorator
         public bool Commit(IMessageContext context)
         {
             var result = _handler.Commit(context);
+            if (result)
+            {
+                _commitCounter.Increment();
+            }
+            return result;
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> CommitAsync(IMessageContext context)
+        {
+            var result = await _handler.CommitAsync(context).ConfigureAwait(false);
             if (result)
             {
                 _commitCounter.Increment();

--- a/Source/DotNetWorkQueue/Queue/CommitMessage.cs
+++ b/Source/DotNetWorkQueue/Queue/CommitMessage.cs
@@ -19,6 +19,7 @@
 using DotNetWorkQueue.Exceptions;
 using DotNetWorkQueue.Validation;
 using System;
+using System.Threading.Tasks;
 
 namespace DotNetWorkQueue.Queue
 {
@@ -39,6 +40,23 @@ namespace DotNetWorkQueue.Queue
             try
             {
                 context.RaiseCommit();
+                return true;
+            }
+            catch (Exception commitException)
+            {
+                throw new CommitException(
+                    "An error has occurred committing a processed message",
+                    commitException, context.MessageId, context.CorrelationId, context.Headers);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> CommitAsync(IMessageContext context)
+        {
+            Guard.NotNull(context);
+            try
+            {
+                await context.RaiseCommitAsync().ConfigureAwait(false);
                 return true;
             }
             catch (Exception commitException)

--- a/Source/DotNetWorkQueue/Queue/ProcessMessageAsync.cs
+++ b/Source/DotNetWorkQueue/Queue/ProcessMessageAsync.cs
@@ -75,7 +75,7 @@ namespace DotNetWorkQueue.Queue
                 try
                 {
                     await _methodToRun.HandleAsync(transportMessage, context.WorkerNotification).ConfigureAwait(false);
-                    _commitMessage.Commit(context);
+                    await _commitMessage.CommitAsync(context).ConfigureAwait(false);
                     _consumerQueueNotification.InvokeMessageComplete(new MessageCompleteNotification(transportMessage.MessageId, transportMessage.CorrelationId, transportMessage.Headers, transportMessage.Body));
                 }
                 catch (OperationCanceledException)

--- a/Source/DotNetWorkQueue/Queue/WriteMessageHistoryNoOp.cs
+++ b/Source/DotNetWorkQueue/Queue/WriteMessageHistoryNoOp.cs
@@ -36,6 +36,9 @@ namespace DotNetWorkQueue.Queue
         public Task RecordProcessingStartAsync(string queueId) => Task.CompletedTask;
 
         /// <inheritdoc />
+        public Task RecordCompleteAsync(string queueId) => Task.CompletedTask;
+
+        /// <inheritdoc />
         public void RecordComplete(string queueId) { }
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue/Trace/Decorator/CommitMessageDecorator.cs
+++ b/Source/DotNetWorkQueue/Trace/Decorator/CommitMessageDecorator.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 
 using System.Diagnostics;
+using System.Threading.Tasks;
 using OpenTelemetry.Trace;
 
 namespace DotNetWorkQueue.Trace.Decorator
@@ -51,7 +52,22 @@ namespace DotNetWorkQueue.Trace.Decorator
             var activityContext = context.Extract(_tracer, _headers);
             using (var scope = _tracer.StartActivity("Commit", ActivityKind.Internal, activityContext))
             {
+                //Every sibling decorator tags the span with the message id - rollback, remove and the
+                //poison handler all do. This one did not, so a commit span could not be tied back to
+                //its message.
+                scope?.AddMessageIdTag(context);
                 return _handler.Commit(context);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> CommitAsync(IMessageContext context)
+        {
+            var activityContext = context.Extract(_tracer, _headers);
+            using (var scope = _tracer.StartActivity("Commit", ActivityKind.Internal, activityContext))
+            {
+                scope?.AddMessageIdTag(context);
+                return await _handler.CommitAsync(context).ConfigureAwait(false);
             }
         }
     }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/Message/CommitMessage.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/Message/CommitMessage.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System.Threading.Tasks;
 using DotNetWorkQueue.Validation;
 
 namespace DotNetWorkQueue.Transport.Memory.Basic.Message
@@ -42,6 +43,17 @@ namespace DotNetWorkQueue.Transport.Memory.Basic.Message
         {
             if (context != null)
                 _removeMessage.Remove(context.MessageId, RemoveMessageReason.Complete);
+        }
+
+        /// <summary>
+        /// Commits the processed message, without blocking a thread.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        public async Task CommitAsync(IMessageContext context)
+        {
+            if (context != null)
+                await _removeMessage.RemoveAsync(context.MessageId, RemoveMessageReason.Complete)
+                    .ConfigureAwait(false);
         }
     }
 }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/MessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/MessageQueueReceive.cs
@@ -194,6 +194,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         private void ContextCleanup(IMessageContext context)
         {
             context.Commit -= _cachedCommit;
+            context.CommitAsync -= _cachedCommitAsync;
             context.Rollback -= _cachedRollback;
             context.Cleanup -= _cachedCleanup;
         }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/MessageQueueReceive.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/MessageQueueReceive.cs
@@ -127,6 +127,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         //delegate that unsubscribes just as well, since removal compares target and method rather
         //than reference.
         private EventHandler _cachedCommit;
+        private AsyncEventHandler _cachedCommitAsync;
         private EventHandler _cachedRollback;
         private EventHandler _cachedCleanup;
 
@@ -140,6 +141,9 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         {
             //wire up the context commit/rollback/dispose delegates
             context.Commit += _cachedCommit ??= ContextOnCommit;
+            //Both are subscribed: the synchronous consumer raises Commit, the asynchronous one
+            //raises CommitAsync. A context only ever raises one of them.
+            context.CommitAsync += _cachedCommitAsync ??= ContextOnCommitAsync;
             context.Rollback += _cachedRollback ??= ContextOnRollback;
             context.Cleanup += _cachedCleanup ??= context_Cleanup;
         }
@@ -173,6 +177,14 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         private void ContextOnCommit(object sender, EventArgs eventArgs)
         {
             _handleMessage.CommitMessage.Commit((IMessageContext)sender);
+        }
+
+        /// <summary>
+        /// On Commit, awaited
+        /// </summary>
+        private async Task ContextOnCommitAsync(object sender, EventArgs eventArgs)
+        {
+            await _handleMessage.CommitMessage.CommitAsync((IMessageContext)sender).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
@@ -73,6 +73,14 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         }
 
         /// <inheritdoc />
+        /// <remarks>See <see cref="RecordProcessingStartAsync"/>: in process, nothing to release.</remarks>
+        public Task RecordCompleteAsync(string queueId)
+        {
+            RecordComplete(queueId);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
         public void RecordComplete(string queueId)
         {
             if (!_options.EnableHistory) return;


### PR DESCRIPTION
The busiest of the calls #284 tracks. Committing runs on every message, on the happy path, and on the asynchronous consumer it runs in a continuation on a thread-pool thread — so the synchronous commit held one of those for a transport round trip per message.

Rollback and the error path follow in a second pull request; see the end.

## The obstacle was the event, not the commit

`IMessageContext.Commit` is an `EventHandler`, which returns void. The transports subscribe to that event and commit from it, so a subscriber doing transport I/O had no way to be awaited.

This adds `AsyncEventHandler` — a `Task`-returning delegate — and a `CommitAsync` event beside the existing one, with `RaiseCommitAsync` awaiting each subscriber.

**Subscribers are awaited sequentially, in subscription order, not through `WhenAll`.** That matches what the synchronous event already did, and it is load-bearing rather than incidental: the transports commit against a connection and transaction held in the message context, which cannot take concurrent work. Asserted directly, because `WhenAll` would look like an obvious improvement to a later reader.

## What to look at

**Each receive class subscribes both events.** A context raises one or the other — the synchronous consumer raises `Commit`, the asynchronous one `CommitAsync` — and raising both would commit the message twice. Asserted in both directions.

**This is the caller #291 was built for.** `ITransportCommitMessage.CommitAsync` bottoms out in `IRemoveMessage.RemoveAsync`, so the ~144 lines of relational `RemoveAsync` and async delete handlers that #291 shipped as deliberately unreachable are now exercised. That was the known cost of splitting those PRs, and it is paid here.

**`IWriteMessageHistory.RecordCompleteAsync` arrives with its caller**, which is what #293 said would happen rather than adding the member early.

**Two things the tests found, not the reading.**

- A failed commit is *not* swallowed: `MessageExceptionHandler` wraps and rethrows as `MessageException`, which is what `MessageProcessingAsync` catches to roll the message back. The first version of that test asserted the opposite and failed; the contract is now pinned.
- The commit trace decorator never tagged its span with the message id, while rollback, remove and the poison handler all do — a commit span could not be tied back to its message. Fixed on both twins, the same class of gap as #289's missing `SetStatus`.

## Breaking

`IMessageContext` gains a `CommitAsync` event and `RaiseCommitAsync`; `ICommitMessage`, `ITransportCommitMessage` and `IWriteMessageHistory` gain async members. Only affects code implementing those interfaces outside this repository. The existing `Commit` event is untouched and still what the synchronous consumer raises.

## Validation

- `NoTests.sln -c Release -p:CI=true` clean
- 2,441 unit tests / 0 failed — 11 new, all failing when the commit is reverted to the blocking member
- Memory and LiteDB integration clean
- **SQLite integration 204/205.** The failure is `ConsumerHeartbeat`, which drives the *synchronous* consumer — `ProcessMessage.cs` and `MessageProcessing.cs` are untouched here — and passes 3/3 in isolation. It has now failed on two branches on two different rows, so it is filed as **#294** with both occurrences rather than re-run until green.

## Why rollback is not here

Rollback needs six transport implementations, five async command handlers with their trace decorators and DI, plus the seventh synchronous call at `ProcessMessageAsync.cs:89` that the issue's table does not list (`MessageExceptionHandler.Handle` → `IReceiveMessagesError.MessageFailedProcessing` → `RecordError`). Together with this change that is roughly 80 files, and #287 at 155 files received no LLM review at all. Splitting keeps the most intricate part of #284 reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous message commit processing for consumers and supported transports.
  * Added awaitable commit events that run sequentially and propagate failures.
  * Added asynchronous message-history completion recording across supported storage backends.
  * Added async commit support for tracing, metrics, and in-memory queue processing.
* **Documentation**
  * Updated the changelog with asynchronous commit APIs and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->