### PR TITLE
Count message errors in one statement, where the schema allows it (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ﻿### Unreleased
+- Fix: counting how many times a message has failed is now one statement on SQL Server, PostgreSQL and SQLite. Two failures arriving together could each add a row, and the retry count then read low - so a message got more attempts than configured, and a poison message could loop instead of reaching the error queue (GitHub #299)
+- New queues get a unique index on the error tracking table. Existing queues keep working unchanged: the queue is asked once whether the index is there and falls back to the previous behaviour when it is not. Re-create a queue to get the guarantee (GitHub #299)
 - Redis consumers no longer hold a thread through the de-queue. Under thread-pool pressure, where a consumer previously timed out waiting on Redis, it now keeps working (GitHub #256)
 - ⚠️ Custom transports and consumers must add async members: `IReceiveMessages.ReceiveMessageAsync`, `IQueueWait.WaitAsync`, and `IRedisQueueWorkSub.WaitAsync` for Redis. Built-in transports are unaffected (GitHub #256)
 - ⚠️ `IMessageProcessing.Handle()` is now `HandleAsync()` and returns a task. Only affects code implementing that interface directly (GitHub #256)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ﻿### Unreleased
-- Fix: counting how many times a message has failed is now one statement on SQL Server, PostgreSQL and SQLite. Two failures arriving together could each add a row, and the retry count then read low - so a message got more attempts than configured, and a poison message could loop instead of reaching the error queue (GitHub #299)
-- New queues get a unique index on the error tracking table. Existing queues keep working unchanged: the queue is asked once whether the index is there and falls back to the previous behaviour when it is not. Re-create a queue to get the guarantee (GitHub #299)
+- ⚠️ Fix: two failures arriving at once each added an error row, so a message got more retries than configured and could loop instead of reaching the error queue. Re-create an existing SQL Server, PostgreSQL or SQLite queue to pick up the fix (GitHub #299)
 - Redis consumers no longer hold a thread through the de-queue. Under thread-pool pressure, where a consumer previously timed out waiting on Redis, it now keeps working (GitHub #256)
 - ⚠️ Custom transports and consumers must add async members: `IReceiveMessages.ReceiveMessageAsync`, `IQueueWait.WaitAsync`, and `IRedisQueueWorkSub.WaitAsync` for Redis. Built-in transports are unaffected (GitHub #256)
 - ⚠️ `IMessageProcessing.Handle()` is now `HandleAsync()` and returns a task. Only affects code implementing that interface directly (GitHub #256)

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
@@ -4,10 +4,10 @@ using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using DotNetWorkQueue.Transport.SQLite.Basic;
-using System.Data.SQLite;
+using DotNetWorkQueue.Transport.PostgreSQL.Basic;
+using Npgsql;
 
-namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
+namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Basic
 {
     /// <summary>
     /// Counting errors against a real database, with and without the unique index.
@@ -28,46 +28,43 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
         [TestMethod]
         public void CountsErrors_OnANewQueueAndOnOneWithoutTheIndex()
         {
-            using (var connectionInfo = new IntegrationConnectionInfo(false))
+            var queueName = GenerateQueueName.Create();
+            var connectionString = ConnectionInfo.ConnectionString;
+            var queueConnection = new QueueConnection(queueName, connectionString);
+            var logProvider = LoggerShared.Create(queueName, GetType().Name);
+
+            using (var queueCreator = new QueueCreationContainer<PostgreSqlMessageQueueInit>(
+                serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
             {
-                var queueName = GenerateQueueName.Create();
-                var connectionString = connectionInfo.ConnectionString;
-                var queueConnection = new QueueConnection(queueName, connectionString);
-                var logProvider = LoggerShared.Create(queueName, GetType().Name);
-
-                using (var queueCreator = new QueueCreationContainer<SqLiteMessageQueueInit>(
-                    serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+                var oCreation = queueCreator.GetQueueCreation<PostgreSqlMessageQueueCreation>(queueConnection);
+                try
                 {
-                    var oCreation = queueCreator.GetQueueCreation<SqLiteMessageQueueCreation>(queueConnection);
-                    try
-                    {
-                        var result = oCreation.CreateQueue();
-                        Assert.IsTrue(result.Success, result.ErrorMessage);
+                    var result = oCreation.CreateQueue();
+                    Assert.IsTrue(result.Success, result.ErrorMessage);
 
-                        var errorTable = $"{queueName}ErrorTracking";
+                    var errorTable = $"{queueName}ErrorTracking";
 
-                        Assert.IsTrue(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
-                            "a new queue did not report the unique index, so it would keep using the racy count");
+                    Assert.IsTrue(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
+                        "a new queue did not report the unique index, so it would keep using the racy count");
 
-                        //the atomic statement, on the schema that supports it
-                        CountTwice(queueConnection, logProvider, oCreation.Scope, 1);
-                        Assert.AreEqual(2, RetryCount(connectionString, errorTable, 1));
+                    //the atomic statement, on the schema that supports it
+                    CountTwice(queueConnection, logProvider, oCreation.Scope, 1);
+                    Assert.AreEqual(2, RetryCount(connectionString, errorTable, 1));
 
-                        //now an older queue: same table, no index
-                        Execute(connectionString, $"DROP INDEX IX_QueueIDExceptionType{errorTable}");
-                        Assert.IsFalse(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
-                            "the index was still reported after it had been dropped");
+                    //now an older queue: same table, no index
+                    Execute(connectionString, $"DROP INDEX IX_QueueIDExceptionType{errorTable}");
+                    Assert.IsFalse(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
+                        "the index was still reported after it had been dropped");
 
-                        //a different message id, so this counts from zero on the fallback path
-                        CountTwice(queueConnection, logProvider, oCreation.Scope, 2);
-                        Assert.AreEqual(2, RetryCount(connectionString, errorTable, 2),
-                            "the fallback stopped counting errors on a queue without the index");
-                    }
-                    finally
-                    {
-                        oCreation.RemoveQueue();
-                        oCreation.Dispose();
-                    }
+                    //a different message id, so this counts from zero on the fallback path
+                    CountTwice(queueConnection, logProvider, oCreation.Scope, 2);
+                    Assert.AreEqual(2, RetryCount(connectionString, errorTable, 2),
+                        "the fallback stopped counting errors on a queue without the index");
+                }
+                finally
+                {
+                    oCreation.RemoveQueue();
+                    oCreation.Dispose();
                 }
             }
         }
@@ -96,10 +93,10 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
             }
         }
 
-        private static QueueContainer<SqLiteMessageQueueInit> Container(
+        private static QueueContainer<PostgreSqlMessageQueueInit> Container(
             Microsoft.Extensions.Logging.ILogger logProvider, ICreationScope scope)
         {
-            return new QueueContainer<SqLiteMessageQueueInit>(serviceRegister =>
+            return new QueueContainer<PostgreSqlMessageQueueInit>(serviceRegister =>
             {
                 serviceRegister.Register(() => logProvider, LifeStyles.Singleton);
                 serviceRegister.RegisterNonScopedSingleton(scope);
@@ -108,7 +105,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
 
         private static int RetryCount(string connectionString, string errorTable, long queueId)
         {
-            using (var conn = new SQLiteConnection(connectionString))
+            using (var conn = new NpgsqlConnection(connectionString))
             {
                 conn.Open();
                 using (var command = conn.CreateCommand())
@@ -128,7 +125,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
 
         private static void Execute(string connectionString, string sql)
         {
-            using (var conn = new SQLiteConnection(connectionString))
+            using (var conn = new NpgsqlConnection(connectionString))
             {
                 conn.Open();
                 using (var command = conn.CreateCommand())

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
@@ -156,6 +156,41 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Basic
             }
         }
 
+        [TestMethod]
+        public void DoesNotMistakeAnIncludedColumnForAKeyColumn()
+        {
+            //a unique index on QueueID alone that merely stores ExceptionType alongside it. It has the
+            //two column names and it is unique, but it guarantees one row per message rather than one
+            //per message and exception type - the single statement would break on the second exception
+            var queueName = GenerateQueueName.Create();
+            var connectionString = ConnectionInfo.ConnectionString;
+            var queueConnection = new QueueConnection(queueName, connectionString);
+            var logProvider = LoggerShared.Create(queueName, GetType().Name);
+
+            using (var queueCreator = new QueueCreationContainer<PostgreSqlMessageQueueInit>(
+                serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+            {
+                var oCreation = queueCreator.GetQueueCreation<PostgreSqlMessageQueueCreation>(queueConnection);
+                try
+                {
+                    var result = oCreation.CreateQueue();
+                    Assert.IsTrue(result.Success, result.ErrorMessage);
+
+                    var errorTable = $"{queueName}ErrorTracking";
+                    Execute(connectionString, $"DROP INDEX IX_QueueIDExceptionType{errorTable}");
+                    Execute(connectionString, $"CREATE UNIQUE INDEX IX_Included{errorTable} ON {errorTable} (QueueID) INCLUDE (ExceptionType)");
+
+                    Assert.IsFalse(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
+                        "an included column was counted as part of the unique key");
+                }
+                finally
+                {
+                    oCreation.RemoveQueue();
+                    oCreation.Dispose();
+                }
+            }
+        }
+
         private static bool UniqueIndexFound(QueueConnection queueConnection,
             Microsoft.Extensions.Logging.ILogger logProvider, ICreationScope scope, string errorTable)
         {

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.IntegrationTests.Shared;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -65,6 +68,90 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.Basic
                 {
                     oCreation.RemoveQueue();
                     oCreation.Dispose();
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CountsConcurrentFirstFailures_AsOneRow()
+        {
+            //the race the unique index and the single statement exist for: several workers failing the
+            //same message at the same moment, none of which has an error row to update yet.
+            //Thirty-two rather than a handful because SQLite serialises writers - at eight the older
+            //path came through unscathed there, and a test that cannot fail against the behaviour it
+            //replaces is not saying anything
+            const int failures = 32;
+            var queueName = GenerateQueueName.Create();
+            var connectionString = ConnectionInfo.ConnectionString;
+            var queueConnection = new QueueConnection(queueName, connectionString);
+            var logProvider = LoggerShared.Create(queueName, GetType().Name);
+
+            using (var queueCreator = new QueueCreationContainer<PostgreSqlMessageQueueInit>(
+                serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+            {
+                var oCreation = queueCreator.GetQueueCreation<PostgreSqlMessageQueueCreation>(queueConnection);
+                try
+                {
+                    var result = oCreation.CreateQueue();
+                    Assert.IsTrue(result.Success, result.ErrorMessage);
+
+                    var errorTable = $"{queueName}ErrorTracking";
+                    Assert.IsTrue(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
+                        "a new queue did not report the unique index, so this would not be testing the atomic path");
+
+                    CountConcurrently(queueConnection, logProvider, oCreation.Scope, 1, failures);
+
+                    Assert.AreEqual(1, RowCount(connectionString, errorTable, 1),
+                        "concurrent first failures wrote more than one row for the same message and exception type");
+                    Assert.AreEqual(failures, RetryCount(connectionString, errorTable, 1),
+                        "a concurrent failure was not counted");
+                }
+                finally
+                {
+                    oCreation.RemoveQueue();
+                    oCreation.Dispose();
+                }
+            }
+        }
+
+        private static void CountConcurrently(QueueConnection queueConnection,
+            Microsoft.Extensions.Logging.ILogger logProvider, ICreationScope scope, long queueId, int failures)
+        {
+            using (var container = Container(logProvider, scope))
+            using (var admin = container.CreateAdminContainer(queueConnection))
+            {
+                var handler = admin.GetInstance<ICommandHandler<SetErrorCountCommand<long>>>();
+                //resolved once and started together - the point is that they overlap
+                using (var start = new ManualResetEventSlim(false))
+                {
+                    var running = new Task[failures];
+                    for (var i = 0; i < failures; i++)
+                    {
+                        running[i] = Task.Factory.StartNew(() =>
+                        {
+                            start.Wait();
+                            handler.Handle(new SetErrorCountCommand<long>("System.Exception", queueId));
+                        }, TaskCreationOptions.LongRunning);
+                    }
+                    start.Set();
+                    Task.WaitAll(running);
+                }
+            }
+        }
+
+        private static int RowCount(string connectionString, string errorTable, long queueId)
+        {
+            using (var conn = new NpgsqlConnection(connectionString))
+            {
+                conn.Open();
+                using (var command = conn.CreateCommand())
+                {
+                    command.CommandText = $"SELECT COUNT(*) FROM {errorTable} WHERE QueueID = @id";
+                    var parameter = command.CreateParameter();
+                    parameter.ParameterName = "@id";
+                    parameter.Value = queueId;
+                    command.Parameters.Add(parameter);
+                    return Convert.ToInt32(command.ExecuteScalar());
                 }
             }
         }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLCommandStringCache.cs
@@ -79,8 +79,19 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
                    on conflict (QueueID, ExceptionType)
                    do update set retrycount = {TableNameHelper.ErrorTrackingName}.retrycount + 1");
 
+            //By shape, not by name. PostgreSQL folds unquoted identifiers to lower case and truncates
+            //them at 63 bytes, so comparing the name the schema asked for against the catalog misses -
+            //silently, and the racy path stays in use. The table name is lowered for the same reason.
             CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
-                "SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND tablename = @Table AND indexname = @Index");
+                @"SELECT 1 FROM pg_index ix
+                  JOIN pg_class t ON t.oid = ix.indrelid
+                  JOIN pg_namespace n ON n.oid = t.relnamespace
+                  WHERE n.nspname = 'public' AND t.relname = lower(@Table) AND ix.indisunique
+                  AND array_length(ix.indkey, 1) = 2
+                  AND EXISTS (SELECT 1 FROM pg_attribute a
+                              WHERE a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) AND lower(a.attname) = 'queueid')
+                  AND EXISTS (SELECT 1 FROM pg_attribute a
+                              WHERE a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) AND lower(a.attname) = 'exceptiontype')");
 
             CommandCache.Add(CommandStringTypes.GetHeartBeatExpiredMessageIds,
                 $"select {TableNameHelper.MetaDataName}.queueid, heartbeat, headers from {TableNameHelper.MetaDataName} inner join {TableNameHelper.QueueName} on {TableNameHelper.QueueName}.queueid = {TableNameHelper.MetaDataName}.queueid where status = @status and heartbeat is not null and heartbeat < @time FOR UPDATE SKIP LOCKED");

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLCommandStringCache.cs
@@ -73,6 +73,15 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             CommandCache.Add(CommandStringTypes.InsertErrorCount,
                 $"Insert into {TableNameHelper.ErrorTrackingName} (QueueID,ExceptionType, RetryCount) VALUES (@QueueID,@ExceptionType,1)");
 
+            CommandCache.Add(CommandStringTypes.UpsertErrorCount,
+                $@"insert into {TableNameHelper.ErrorTrackingName} (QueueID, ExceptionType, RetryCount)
+                   values (@QueueID, @ExceptionType, 1)
+                   on conflict (QueueID, ExceptionType)
+                   do update set retrycount = {TableNameHelper.ErrorTrackingName}.retrycount + 1");
+
+            CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
+                "SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND tablename = @Table AND indexname = @Index");
+
             CommandCache.Add(CommandStringTypes.GetHeartBeatExpiredMessageIds,
                 $"select {TableNameHelper.MetaDataName}.queueid, heartbeat, headers from {TableNameHelper.MetaDataName} inner join {TableNameHelper.QueueName} on {TableNameHelper.QueueName}.queueid = {TableNameHelper.MetaDataName}.queueid where status = @status and heartbeat is not null and heartbeat < @time FOR UPDATE SKIP LOCKED");
 

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLCommandStringCache.cs
@@ -81,17 +81,21 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
 
             //By shape, not by name. PostgreSQL folds unquoted identifiers to lower case and truncates
             //them at 63 bytes, so comparing the name the schema asked for against the catalog misses -
-            //silently, and the racy path stays in use. The table name is lowered for the same reason.
+            //silently, and the racy path stays in use. to_regclass resolves the table the way the rest
+            //of the statements here do: the same folding and truncation, and it honours a schema
+            //qualified queue name - a dot is legal in one - rather than assuming public. It answers
+            //null rather than throwing when the table is not there.
+            //A partial index is excluded. It fits the shape below, but the upsert's conflict target
+            //names no predicate, so PostgreSQL would reject the statement rather than infer it.
             CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
                 @"SELECT 1 FROM pg_index ix
-                  JOIN pg_class t ON t.oid = ix.indrelid
-                  JOIN pg_namespace n ON n.oid = t.relnamespace
-                  WHERE n.nspname = 'public' AND t.relname = lower(@Table) AND ix.indisunique
+                  WHERE ix.indrelid = to_regclass(@Table)
+                  AND ix.indisunique AND ix.indpred IS NULL
                   AND array_length(ix.indkey, 1) = 2
                   AND EXISTS (SELECT 1 FROM pg_attribute a
-                              WHERE a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) AND lower(a.attname) = 'queueid')
+                              WHERE a.attrelid = ix.indrelid AND a.attnum = ANY(ix.indkey) AND lower(a.attname) = 'queueid')
                   AND EXISTS (SELECT 1 FROM pg_attribute a
-                              WHERE a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) AND lower(a.attname) = 'exceptiontype')");
+                              WHERE a.attrelid = ix.indrelid AND a.attnum = ANY(ix.indkey) AND lower(a.attname) = 'exceptiontype')");
 
             CommandCache.Add(CommandStringTypes.GetHeartBeatExpiredMessageIds,
                 $"select {TableNameHelper.MetaDataName}.queueid, heartbeat, headers from {TableNameHelper.MetaDataName} inner join {TableNameHelper.QueueName} on {TableNameHelper.QueueName}.queueid = {TableNameHelper.MetaDataName}.queueid where status = @status and heartbeat is not null and heartbeat < @time FOR UPDATE SKIP LOCKED");

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLCommandStringCache.cs
@@ -87,15 +87,19 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             //null rather than throwing when the table is not there.
             //A partial index is excluded. It fits the shape below, but the upsert's conflict target
             //names no predicate, so PostgreSQL would reject the statement rather than infer it.
+            //indnkeyatts, not the length of indkey: indkey also holds INCLUDE columns, which are stored
+            //but carry no uniqueness, so a unique index on QueueID alone that merely includes
+            //ExceptionType would otherwise look like the two-column key being asked about. The key
+            //columns come first in indkey, so with two of them they are indkey[0] and indkey[1].
             CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
                 @"SELECT 1 FROM pg_index ix
                   WHERE ix.indrelid = to_regclass(@Table)
                   AND ix.indisunique AND ix.indpred IS NULL
-                  AND array_length(ix.indkey, 1) = 2
+                  AND ix.indnkeyatts = 2
                   AND EXISTS (SELECT 1 FROM pg_attribute a
-                              WHERE a.attrelid = ix.indrelid AND a.attnum = ANY(ix.indkey) AND lower(a.attname) = 'queueid')
+                              WHERE a.attrelid = ix.indrelid AND a.attnum IN (ix.indkey[0], ix.indkey[1]) AND lower(a.attname) = 'queueid')
                   AND EXISTS (SELECT 1 FROM pg_attribute a
-                              WHERE a.attrelid = ix.indrelid AND a.attnum = ANY(ix.indkey) AND lower(a.attname) = 'exceptiontype')");
+                              WHERE a.attrelid = ix.indrelid AND a.attnum IN (ix.indkey[0], ix.indkey[1]) AND lower(a.attname) = 'exceptiontype')");
 
             CommandCache.Add(CommandStringTypes.GetHeartBeatExpiredMessageIds,
                 $"select {TableNameHelper.MetaDataName}.queueid, heartbeat, headers from {TableNameHelper.MetaDataName} inner join {TableNameHelper.QueueName} on {TableNameHelper.QueueName}.queueid = {TableNameHelper.MetaDataName}.queueid where status = @status and heartbeat is not null and heartbeat < @time FOR UPDATE SKIP LOCKED");

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueSchema.cs
@@ -286,6 +286,12 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             errorTracking.PrimaryKey.Unique = true;
 
             errorTracking.Constraints.Add(new Constraint($"IX_QueueID{_tableNameHelper.ErrorTrackingName}", ConstraintType.Index, ColumnQueueId));
+            //One error row per message per exception type. Without this, the check-then-write in
+            //SetErrorCountCommandHandler can insert a second row for the same pair under concurrency,
+            //and the retry count then reads low - so a message gets more attempts than configured, and
+            //a poison message can loop instead of reaching the error queue.
+            errorTracking.Constraints.Add(new Constraint($"IX_QueueIDExceptionType{_tableNameHelper.ErrorTrackingName}", ConstraintType.Index,
+                new List<string> { ColumnQueueId, "ExceptionType" }) { Unique = true });
 
             foreach (var c in errorTracking.Constraints)
             {

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/CommandHandler/SetErrorCountCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/CommandHandler/SetErrorCountCommandHandlerTests.cs
@@ -1,0 +1,126 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
+using DotNetWorkQueue.Transport.RelationalDatabase.Tests.TestHelpers;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Transport.Shared.Basic.Query;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.CommandHandler
+{
+    /// <summary>
+    /// Counting how many times a message has failed with a given exception type.
+    ///
+    /// This was a check-then-write across two connections with nothing enforcing one row per
+    /// (QueueID, ExceptionType), so two failures of the same message arriving together could each see no
+    /// row and each insert one. The retry count then reads lower than reality and the message gets more
+    /// attempts than configured - a poison message can loop instead of reaching the error queue.
+    ///
+    /// New queues get a unique index and a single atomic statement. Queues created before that index
+    /// existed do not have it, and the library does not upgrade schemas, so the old path has to keep
+    /// working - which is what these cover.
+    /// </summary>
+    [TestClass]
+    public class SetErrorCountCommandHandlerTests
+    {
+        [TestMethod]
+        public void Handle_WithTheUniqueIndex_UsesTheSingleStatement()
+        {
+            var h = new Harness(indexExists: true);
+
+            h.Handler.Handle(new SetErrorCountCommand<long>("System.Exception", 42));
+
+            h.PrepareCommand.Received(1).Handle(Arg.Any<SetErrorCountCommand<long>>(), Arg.Any<System.Data.Common.DbCommand>(),
+                CommandStringTypes.UpsertErrorCount);
+            h.ExistsQuery.DidNotReceiveWithAnyArgs().Handle(null);
+        }
+
+        [TestMethod]
+        public void Handle_WithoutTheUniqueIndex_FallsBackToCheckThenWrite()
+        {
+            //a queue created before the index existed; the old path has to still count errors
+            var h = new Harness(indexExists: false, recordExists: false);
+
+            h.Handler.Handle(new SetErrorCountCommand<long>("System.Exception", 42));
+
+            h.PrepareCommand.Received(1).Handle(Arg.Any<SetErrorCountCommand<long>>(), Arg.Any<System.Data.Common.DbCommand>(),
+                CommandStringTypes.InsertErrorCount);
+        }
+
+        [TestMethod]
+        public void Handle_WithoutTheUniqueIndex_UpdatesAnExistingRow()
+        {
+            var h = new Harness(indexExists: false, recordExists: true);
+
+            h.Handler.Handle(new SetErrorCountCommand<long>("System.Exception", 42));
+
+            h.PrepareCommand.Received(1).Handle(Arg.Any<SetErrorCountCommand<long>>(), Arg.Any<System.Data.Common.DbCommand>(),
+                CommandStringTypes.UpdateErrorCount);
+        }
+
+        [TestMethod]
+        public void TheSchemaIsOnlyAskedAboutOnce()
+        {
+            //the schema does not change underneath a running consumer, and this is on the failure path
+            var h = new Harness(indexExists: true);
+
+            h.Handler.Handle(new SetErrorCountCommand<long>("System.Exception", 42));
+            h.Handler.Handle(new SetErrorCountCommand<long>("System.Exception", 42));
+            h.Handler.Handle(new SetErrorCountCommand<long>("System.Exception", 43));
+
+            h.IndexQuery.Received(1).Handle(Arg.Any<GetErrorTrackingUniqueIndexExistsQuery>());
+        }
+
+        private sealed class Harness
+        {
+            public SetErrorCountCommandHandler<long> Handler { get; }
+            public IPrepareCommandHandler<SetErrorCountCommand<long>> PrepareCommand { get; }
+            public IQueryHandler<GetErrorRecordExistsQuery<long>, bool> ExistsQuery { get; }
+            public IQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool> IndexQuery { get; }
+
+            public Harness(bool indexExists, bool recordExists = false)
+            {
+                var fixture = AdoNetMockFixture.Create();
+
+                ExistsQuery = Substitute.For<IQueryHandler<GetErrorRecordExistsQuery<long>, bool>>();
+                ExistsQuery.Handle(Arg.Any<GetErrorRecordExistsQuery<long>>()).Returns(recordExists);
+
+                IndexQuery = Substitute.For<IQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool>>();
+                IndexQuery.Handle(Arg.Any<GetErrorTrackingUniqueIndexExistsQuery>()).Returns(indexExists);
+
+                PrepareCommand = Substitute.For<IPrepareCommandHandler<SetErrorCountCommand<long>>>();
+
+                var tableNames = Substitute.For<ITableNameHelper>();
+                tableNames.ErrorTrackingName.Returns("ErrorTracking");
+
+                Handler = new SetErrorCountCommandHandler<long>(
+                    ExistsQuery,
+                    Substitute.For<IQueryHandlerAsync<GetErrorRecordExistsQuery<long>, bool>>(),
+                    fixture.ConnectionFactory,
+                    PrepareCommand,
+                    IndexQuery,
+                    tableNames);
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/CommandHandler/SetErrorCountCommandHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/CommandHandler/SetErrorCountCommandHandlerTests.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -91,6 +92,33 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.CommandHandle
             h.IndexQuery.Received(1).Handle(Arg.Any<GetErrorTrackingUniqueIndexExistsQuery>());
         }
 
+        [TestMethod]
+        public void TheSchemaLookUpFailing_StillRecordsTheError()
+        {
+            //the look-up needs the database too; failing to answer is not a reason to stop counting
+            var h = new Harness(indexAnswer: () => throw new TimeoutException());
+
+            h.Handler.Handle(new SetErrorCountCommand<long>("System.Exception", 42));
+
+            h.PrepareCommand.Received(1).Handle(Arg.Any<SetErrorCountCommand<long>>(), Arg.Any<System.Data.Common.DbCommand>(),
+                CommandStringTypes.InsertErrorCount);
+        }
+
+        [TestMethod]
+        public void TheSchemaLookUpFailing_IsAskedAgainOnTheNextFailure()
+        {
+            //one blip must not pin the queue to the racy path for the rest of its life
+            var attempts = 0;
+            var h = new Harness(indexAnswer: () => attempts++ == 0 ? throw new TimeoutException() : true);
+
+            h.Handler.Handle(new SetErrorCountCommand<long>("System.Exception", 42));
+            h.Handler.Handle(new SetErrorCountCommand<long>("System.Exception", 42));
+
+            Assert.AreEqual(2, attempts, "the look-up was not attempted again after it failed");
+            h.PrepareCommand.Received(1).Handle(Arg.Any<SetErrorCountCommand<long>>(), Arg.Any<System.Data.Common.DbCommand>(),
+                CommandStringTypes.UpsertErrorCount);
+        }
+
         private sealed class Harness
         {
             public SetErrorCountCommandHandler<long> Handler { get; }
@@ -98,15 +126,16 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.CommandHandle
             public IQueryHandler<GetErrorRecordExistsQuery<long>, bool> ExistsQuery { get; }
             public IQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool> IndexQuery { get; }
 
-            public Harness(bool indexExists, bool recordExists = false)
+            public Harness(bool indexExists = false, bool recordExists = false, Func<bool> indexAnswer = null)
             {
                 var fixture = AdoNetMockFixture.Create();
 
                 ExistsQuery = Substitute.For<IQueryHandler<GetErrorRecordExistsQuery<long>, bool>>();
                 ExistsQuery.Handle(Arg.Any<GetErrorRecordExistsQuery<long>>()).Returns(recordExists);
 
+                indexAnswer ??= () => indexExists;
                 IndexQuery = Substitute.For<IQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool>>();
-                IndexQuery.Handle(Arg.Any<GetErrorTrackingUniqueIndexExistsQuery>()).Returns(indexExists);
+                IndexQuery.Handle(Arg.Any<GetErrorTrackingUniqueIndexExistsQuery>()).Returns(_ => indexAnswer());
 
                 PrepareCommand = Substitute.For<IPrepareCommandHandler<SetErrorCountCommand<long>>>();
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetErrorCountCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetErrorCountCommandHandler.cs
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------
 using System;
 using System.Data.Common;
+using System.Threading;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.Shared;
@@ -68,9 +69,26 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
             Guard.NotNull(prepareCommand);
 
             _queryHandler = queryHandler;
-            _canUpsert = new Lazy<bool>(() => uniqueIndexQuery.Handle(
-                new GetErrorTrackingUniqueIndexExistsQuery(tableNameHelper.ErrorTrackingName,
-                    $"IX_QueueIDExceptionType{tableNameHelper.ErrorTrackingName}")));
+            //PublicationOnly so a failed look-up is not cached. The default Lazy remembers the
+            //exception for the life of the queue, which would turn one transient database blip during
+            //the first failed message into every later failure throwing, for good. And any failure here
+            //answers "no" rather than propagating: not knowing whether the index is there is a reason to
+            //take the older path, not a reason to stop recording errors. A transport whose command cache
+            //has no entry for the look-up - a custom relational one written before this existed - lands
+            //here too.
+            _canUpsert = new Lazy<bool>(() =>
+                {
+                    try
+                    {
+                        return uniqueIndexQuery.Handle(
+                            new GetErrorTrackingUniqueIndexExistsQuery(tableNameHelper.ErrorTrackingName));
+                    }
+                    catch (Exception)
+                    {
+                        return false;
+                    }
+                },
+                LazyThreadSafetyMode.PublicationOnly);
             _queryHandlerAsync = queryHandlerAsync;
             _dbConnectionFactory = dbConnectionFactory;
             _prepareCommand = prepareCommand;
@@ -79,12 +97,16 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query checked")]
         public void Handle(SetErrorCountCommand<T> command)
         {
+            //Read before the connection below is opened. The look-up takes a connection of its own, and
+            //asking for it while already holding one means every concurrent first failure holds one
+            //connection and waits for another.
+            var upsert = _canUpsert.Value;
             using (var connection = _dbConnectionFactory.Create())
             {
                 connection.Open();
                 using (var commandSql = connection.CreateCommand())
                 {
-                    if (_canUpsert.Value)
+                    if (upsert)
                     {
                         _prepareCommand.Handle(command, commandSql, CommandStringTypes.UpsertErrorCount);
                         commandSql.ExecuteNonQuery();
@@ -103,12 +125,14 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Query checked")]
         public async Task HandleAsync(SetErrorCountCommand<T> command)
         {
+            //see Handle: taken before a connection is held
+            var upsert = _canUpsert.Value;
             using (var connection = _dbConnectionFactory.Create())
             {
                 await connection.OpenAsync().ConfigureAwait(false);
                 using (var commandSql = connection.CreateCommand())
                 {
-                    if (_canUpsert.Value)
+                    if (upsert)
                     {
                         _prepareCommand.Handle(command, commandSql, CommandStringTypes.UpsertErrorCount);
                         await commandSql.ExecuteNonQueryAsync().ConfigureAwait(false);

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetErrorCountCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetErrorCountCommandHandler.cs
@@ -16,11 +16,13 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using System;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Transport.Shared.Basic.Query;
 using DotNetWorkQueue.Validation;
 
@@ -34,6 +36,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
         ICommandHandlerAsync<SetErrorCountCommand<T>>
     {
         private readonly IQueryHandler<GetErrorRecordExistsQuery<T>, bool> _queryHandler;
+        //Asked once per queue: the schema does not change underneath a running consumer, and the answer
+        //decides whether the atomic statement is available at all.
+        private readonly Lazy<bool> _canUpsert;
         private readonly IQueryHandlerAsync<GetErrorRecordExistsQuery<T>, bool> _queryHandlerAsync;
         private readonly IDbConnectionFactory _dbConnectionFactory;
         private readonly IPrepareCommandHandler<SetErrorCountCommand<T>> _prepareCommand;
@@ -45,18 +50,27 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
         /// <param name="queryHandlerAsync">The query handler, asynchronous.</param>
         /// <param name="dbConnectionFactory">The database connection factory.</param>
         /// <param name="prepareCommand">The prepare command.</param>
+        /// <param name="uniqueIndexQuery">Asks whether the error tracking table carries the unique index that the single-statement path needs.</param>
+        /// <param name="tableNameHelper">The table name helper; the index name is derived from the error tracking table's name.</param>
         public SetErrorCountCommandHandler(
             IQueryHandler<GetErrorRecordExistsQuery<T>, bool> queryHandler,
             IQueryHandlerAsync<GetErrorRecordExistsQuery<T>, bool> queryHandlerAsync,
             IDbConnectionFactory dbConnectionFactory,
-            IPrepareCommandHandler<SetErrorCountCommand<T>> prepareCommand)
+            IPrepareCommandHandler<SetErrorCountCommand<T>> prepareCommand,
+            IQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool> uniqueIndexQuery,
+            ITableNameHelper tableNameHelper)
         {
             Guard.NotNull(queryHandler);
+            Guard.NotNull(uniqueIndexQuery);
+            Guard.NotNull(tableNameHelper);
             Guard.NotNull(queryHandlerAsync);
             Guard.NotNull(dbConnectionFactory);
             Guard.NotNull(prepareCommand);
 
             _queryHandler = queryHandler;
+            _canUpsert = new Lazy<bool>(() => uniqueIndexQuery.Handle(
+                new GetErrorTrackingUniqueIndexExistsQuery(tableNameHelper.ErrorTrackingName,
+                    $"IX_QueueIDExceptionType{tableNameHelper.ErrorTrackingName}")));
             _queryHandlerAsync = queryHandlerAsync;
             _dbConnectionFactory = dbConnectionFactory;
             _prepareCommand = prepareCommand;
@@ -70,6 +84,13 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
                 connection.Open();
                 using (var commandSql = connection.CreateCommand())
                 {
+                    if (_canUpsert.Value)
+                    {
+                        _prepareCommand.Handle(command, commandSql, CommandStringTypes.UpsertErrorCount);
+                        commandSql.ExecuteNonQuery();
+                        return;
+                    }
+
                     var exists = _queryHandler.Handle(new GetErrorRecordExistsQuery<T>(command.ExceptionType,
                         command.QueueId));
                     Prepare(command, commandSql, exists);
@@ -87,6 +108,13 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
                 await connection.OpenAsync().ConfigureAwait(false);
                 using (var commandSql = connection.CreateCommand())
                 {
+                    if (_canUpsert.Value)
+                    {
+                        _prepareCommand.Handle(command, commandSql, CommandStringTypes.UpsertErrorCount);
+                        await commandSql.ExecuteNonQueryAsync().ConfigureAwait(false);
+                        return;
+                    }
+
                     var exists = await _queryHandlerAsync
                         .HandleAsync(new GetErrorRecordExistsQuery<T>(command.ExceptionType, command.QueueId))
                         .ConfigureAwait(false);
@@ -100,6 +128,13 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
         /// An error row is inserted the first time a message fails with a given exception type and
         /// updated on every failure after that.
         /// </summary>
+        /// <remarks>
+        /// The fallback for a queue whose error tracking table predates the unique index on
+        /// (QueueID, ExceptionType). Two failures of the same message arriving together can each see no
+        /// row and each insert one, which reads back as a lower retry count than reality - so the message
+        /// gets more attempts than configured. Nothing can close that without the index; re-create the
+        /// queue to get it.
+        /// </remarks>
         private void Prepare(SetErrorCountCommand<T> command, DbCommand commandSql, bool recordExists)
         {
             _prepareCommand.Handle(command, commandSql,

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetErrorCountCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/SetErrorCountCommandHandler.cs
@@ -69,25 +69,16 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
             Guard.NotNull(prepareCommand);
 
             _queryHandler = queryHandler;
-            //PublicationOnly so a failed look-up is not cached. The default Lazy remembers the
-            //exception for the life of the queue, which would turn one transient database blip during
-            //the first failed message into every later failure throwing, for good. And any failure here
-            //answers "no" rather than propagating: not knowing whether the index is there is a reason to
-            //take the older path, not a reason to stop recording errors. A transport whose command cache
-            //has no entry for the look-up - a custom relational one written before this existed - lands
-            //here too.
-            _canUpsert = new Lazy<bool>(() =>
-                {
-                    try
-                    {
-                        return uniqueIndexQuery.Handle(
-                            new GetErrorTrackingUniqueIndexExistsQuery(tableNameHelper.ErrorTrackingName));
-                    }
-                    catch (Exception)
-                    {
-                        return false;
-                    }
-                },
+            //PublicationOnly, and the look-up is allowed to throw. Under that mode an exception is not
+            //remembered, so the next failed message asks again; the default Lazy would remember it for
+            //the life of the queue. The exception is caught at each use instead, which is the difference
+            //between "the database could not answer just now" and "this queue has no index" - answering
+            //no here would pin the queue to the older, racy path for good over one transient blip. A
+            //transport whose command cache has no entry for the look-up - a custom relational one
+            //written before this existed - throws every time and simply keeps the older path.
+            _canUpsert = new Lazy<bool>(
+                () => uniqueIndexQuery.Handle(
+                    new GetErrorTrackingUniqueIndexExistsQuery(tableNameHelper.ErrorTrackingName)),
                 LazyThreadSafetyMode.PublicationOnly);
             _queryHandlerAsync = queryHandlerAsync;
             _dbConnectionFactory = dbConnectionFactory;
@@ -100,7 +91,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
             //Read before the connection below is opened. The look-up takes a connection of its own, and
             //asking for it while already holding one means every concurrent first failure holds one
             //connection and waits for another.
-            var upsert = _canUpsert.Value;
+            var upsert = CanUpsert();
             using (var connection = _dbConnectionFactory.Create())
             {
                 connection.Open();
@@ -126,7 +117,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
         public async Task HandleAsync(SetErrorCountCommand<T> command)
         {
             //see Handle: taken before a connection is held
-            var upsert = _canUpsert.Value;
+            var upsert = CanUpsert();
             using (var connection = _dbConnectionFactory.Create())
             {
                 await connection.OpenAsync().ConfigureAwait(false);
@@ -145,6 +136,27 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
                     Prepare(command, commandSql, exists);
                     await commandSql.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Whether the error tracking table carries the unique index that the single-statement path
+        /// needs, as far as this call can tell.
+        /// </summary>
+        /// <remarks>
+        /// A look-up that fails answers no for this call only - see the constructor. Recording the
+        /// failure is what matters; taking the older path to do it costs correctness under concurrency,
+        /// and not recording it at all costs more.
+        /// </remarks>
+        private bool CanUpsert()
+        {
+            try
+            {
+                return _canUpsert.Value;
+            }
+            catch (Exception)
+            {
+                return false;
             }
         }
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandStringCache.cs
@@ -176,6 +176,18 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         /// </summary>
         UpdateErrorCount,
         /// <summary>
+        /// Increments the retry count for a message and exception type, inserting the row if it is not
+        /// there yet - in one statement, so two failures of the same message cannot each insert a row.
+        /// Only used where the unique index backing it exists; see GetErrorTrackingUniqueIndexExists.
+        /// </summary>
+        UpsertErrorCount,
+        /// <summary>
+        /// Whether the unique index on (QueueID, ExceptionType) is present on the error tracking table.
+        /// Queues created before that index existed do not have it, and the library does not upgrade
+        /// schemas, so the error count write falls back to check-then-write when it is absent.
+        /// </summary>
+        GetErrorTrackingUniqueIndexExists,
+        /// <summary>
         /// insert error count
         /// </summary>
         InsertErrorCount,

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandStringCache.cs
@@ -176,18 +176,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         /// </summary>
         UpdateErrorCount,
         /// <summary>
-        /// Increments the retry count for a message and exception type, inserting the row if it is not
-        /// there yet - in one statement, so two failures of the same message cannot each insert a row.
-        /// Only used where the unique index backing it exists; see GetErrorTrackingUniqueIndexExists.
-        /// </summary>
-        UpsertErrorCount,
-        /// <summary>
-        /// Whether the unique index on (QueueID, ExceptionType) is present on the error tracking table.
-        /// Queues created before that index existed do not have it, and the library does not upgrade
-        /// schemas, so the error count write falls back to check-then-write when it is absent.
-        /// </summary>
-        GetErrorTrackingUniqueIndexExists,
-        /// <summary>
         /// insert error count
         /// </summary>
         InsertErrorCount,
@@ -422,7 +410,24 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         /// <summary>
         /// Dashboard: resets all stale messages in the Status table (only when EnableStatusTable is true)
         /// </summary>
-        DashboardResetAllStaleMessages_StatusTable
+        DashboardResetAllStaleMessages_StatusTable,
+        /// <summary>
+        /// Increments the retry count for a message and exception type, inserting the row if it is not
+        /// there yet - in one statement, so two failures of the same message cannot each insert a row.
+        /// Only used where the unique index backing it exists.
+        /// </summary>
+        /// <remarks>
+        /// Appended rather than slotted next to the other error-count members on purpose: this enum is
+        /// public and its values are implicit, so inserting in the middle renumbers everything after it
+        /// and a caller compiled against the old numbering would ask for the wrong statement.
+        /// </remarks>
+        UpsertErrorCount,
+        /// <summary>
+        /// Whether the error tracking table carries the unique index on (QueueID, ExceptionType).
+        /// Queues created before it existed do not have one, and the library does not upgrade schemas,
+        /// so the error count write falls back to check-then-write when it is absent.
+        /// </summary>
+        GetErrorTrackingUniqueIndexExists,
     }
 
     /// <summary>

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Query/GetErrorTrackingUniqueIndexExistsQuery.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Query/GetErrorTrackingUniqueIndexExistsQuery.cs
@@ -1,0 +1,56 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Validation;
+
+namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query
+{
+    /// <summary>
+    /// Whether the unique index on the error tracking table's (QueueID, ExceptionType) is present.
+    /// </summary>
+    /// <remarks>
+    /// Queues created before that index existed do not have it, and the library does not upgrade
+    /// schemas - a user re-creates the queue instead. So the error count write asks once, and falls back
+    /// to check-then-write where the index is missing rather than failing on a statement the older
+    /// schema cannot support.
+    /// </remarks>
+    public class GetErrorTrackingUniqueIndexExistsQuery : IQuery<bool>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetErrorTrackingUniqueIndexExistsQuery"/> class.
+        /// </summary>
+        /// <param name="tableName">The error tracking table.</param>
+        /// <param name="indexName">The index to look for.</param>
+        public GetErrorTrackingUniqueIndexExistsQuery(string tableName, string indexName)
+        {
+            TableName = tableName;
+            IndexName = indexName;
+        }
+
+        /// <summary>
+        /// The error tracking table.
+        /// </summary>
+        public string TableName { get; }
+
+        /// <summary>
+        /// The index to look for.
+        /// </summary>
+        public string IndexName { get; }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Query/GetErrorTrackingUniqueIndexExistsQuery.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/Query/GetErrorTrackingUniqueIndexExistsQuery.cs
@@ -36,21 +36,14 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query
         /// Initializes a new instance of the <see cref="GetErrorTrackingUniqueIndexExistsQuery"/> class.
         /// </summary>
         /// <param name="tableName">The error tracking table.</param>
-        /// <param name="indexName">The index to look for.</param>
-        public GetErrorTrackingUniqueIndexExistsQuery(string tableName, string indexName)
+        public GetErrorTrackingUniqueIndexExistsQuery(string tableName)
         {
             TableName = tableName;
-            IndexName = indexName;
         }
 
         /// <summary>
         /// The error tracking table.
         /// </summary>
         public string TableName { get; }
-
-        /// <summary>
-        /// The index to look for.
-        /// </summary>
-        public string IndexName { get; }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryHandler/GetErrorTrackingUniqueIndexExistsQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryHandler/GetErrorTrackingUniqueIndexExistsQueryHandler.cs
@@ -1,0 +1,65 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Validation;
+
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
+
+namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryHandler
+{
+    /// <inheritdoc />
+    internal class GetErrorTrackingUniqueIndexExistsQueryHandler : IQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool>
+    {
+        private readonly IPrepareQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool> _prepareQuery;
+        private readonly IDbConnectionFactory _connectionFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetErrorTrackingUniqueIndexExistsQueryHandler"/> class.
+        /// </summary>
+        /// <param name="prepareQuery">The prepare query.</param>
+        /// <param name="connectionFactory">The connection factory.</param>
+        public GetErrorTrackingUniqueIndexExistsQueryHandler(
+            IPrepareQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool> prepareQuery,
+            IDbConnectionFactory connectionFactory)
+        {
+            Guard.NotNull(prepareQuery);
+            Guard.NotNull(connectionFactory);
+
+            _prepareQuery = prepareQuery;
+            _connectionFactory = connectionFactory;
+        }
+
+        /// <inheritdoc />
+        public bool Handle(GetErrorTrackingUniqueIndexExistsQuery query)
+        {
+            using (var connection = _connectionFactory.Create())
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    _prepareQuery.Handle(query, command, CommandStringTypes.GetErrorTrackingUniqueIndexExists);
+                    using (var reader = command.ExecuteReader())
+                    {
+                        return reader.Read();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetErrorTrackingUniqueIndexExistsQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetErrorTrackingUniqueIndexExistsQueryPrepareHandler.cs
@@ -27,8 +27,8 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
 {
     /// <inheritdoc />
     /// <remarks>
-    /// Shared rather than written per transport: the statements differ, but all three take the same two
-    /// parameters, and all three name the index the same way.
+    /// Shared rather than written per transport: the statements differ, but each looks for an index by
+    /// its shape on a named table, so the only parameter is the table.
     /// </remarks>
     public class GetErrorTrackingUniqueIndexExistsQueryPrepareHandler : IPrepareQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool>
     {
@@ -54,12 +54,6 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             table.DbType = DbType.AnsiString;
             table.Value = query.TableName;
             dbCommand.Parameters.Add(table);
-
-            var index = dbCommand.CreateParameter();
-            index.ParameterName = "@Index";
-            index.DbType = DbType.AnsiString;
-            index.Value = query.IndexName;
-            dbCommand.Parameters.Add(index);
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetErrorTrackingUniqueIndexExistsQueryPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetErrorTrackingUniqueIndexExistsQueryPrepareHandler.cs
@@ -1,0 +1,65 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Validation;
+
+using System.Data;
+using System.Data.Common;
+using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
+
+namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Shared rather than written per transport: the statements differ, but all three take the same two
+    /// parameters, and all three name the index the same way.
+    /// </remarks>
+    public class GetErrorTrackingUniqueIndexExistsQueryPrepareHandler : IPrepareQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool>
+    {
+        private readonly CommandStringCache _commandCache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetErrorTrackingUniqueIndexExistsQueryPrepareHandler"/> class.
+        /// </summary>
+        /// <param name="commandCache">The command cache.</param>
+        public GetErrorTrackingUniqueIndexExistsQueryPrepareHandler(CommandStringCache commandCache)
+        {
+            Guard.NotNull(commandCache);
+            _commandCache = commandCache;
+        }
+
+        /// <inheritdoc />
+        public void Handle(GetErrorTrackingUniqueIndexExistsQuery query, DbCommand dbCommand, CommandStringTypes commandType)
+        {
+            dbCommand.CommandText = _commandCache.GetCommand(commandType);
+
+            var table = dbCommand.CreateParameter();
+            table.ParameterName = "@Table";
+            table.DbType = DbType.AnsiString;
+            table.Value = query.TableName;
+            dbCommand.Parameters.Add(table);
+
+            var index = dbCommand.CreateParameter();
+            index.ParameterName = "@Index";
+            index.DbType = DbType.AnsiString;
+            index.Value = query.IndexName;
+            dbCommand.Parameters.Add(index);
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/RelationalDatabaseMessageQueueInit.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/RelationalDatabaseMessageQueueInit.cs
@@ -254,6 +254,14 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     GetErrorRecordExistsQueryHandler<TQueueId>>(LifeStyles.Singleton);
 
             container
+                .Register<IQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool>,
+                    GetErrorTrackingUniqueIndexExistsQueryHandler>(LifeStyles.Singleton);
+
+            container
+                .Register<IPrepareQueryHandler<GetErrorTrackingUniqueIndexExistsQuery, bool>,
+                    GetErrorTrackingUniqueIndexExistsQueryPrepareHandler>(LifeStyles.Singleton);
+
+            container
                 .Register<IQueryHandlerAsync<GetErrorRecordExistsQuery<TQueueId>, bool>,
                     GetErrorRecordExistsQueryHandler<TQueueId>>(LifeStyles.Singleton);
 

--- a/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
@@ -1,0 +1,135 @@
+using System.Data.SQLite;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.Transport.Shared;
+using DotNetWorkQueue.Transport.Shared.Basic.Command;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
+{
+    /// <summary>
+    /// Counting errors against a real database, with and without the unique index.
+    ///
+    /// A new queue gets a unique index on (QueueID, ExceptionType) and a single atomic statement. A queue
+    /// created before that index existed does not have it, and the library does not upgrade schemas - so
+    /// the older check-then-write path has to keep working against the older table. Dropping the index
+    /// here is how an old queue is simulated, and it is the only way to exercise that path now that new
+    /// queues take the other branch.
+    /// </summary>
+    [TestClass]
+    public class SetErrorCountAgainstBothSchemasTests
+    {
+        [TestMethod]
+        public void CountsErrors_OnANewQueueAndOnOneWithoutTheIndex()
+        {
+            using (var connectionInfo = new IntegrationConnectionInfo(false))
+            {
+                var queueName = GenerateQueueName.Create();
+                var queueConnection = new QueueConnection(queueName, connectionInfo.ConnectionString);
+                var logProvider = LoggerShared.Create(queueName, GetType().Name);
+
+                using (var queueCreator = new QueueCreationContainer<SqLiteMessageQueueInit>(
+                    serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+                {
+                    var oCreation = queueCreator.GetQueueCreation<SqLiteMessageQueueCreation>(queueConnection);
+                    try
+                    {
+                        var result = oCreation.CreateQueue();
+                        Assert.IsTrue(result.Success, result.ErrorMessage);
+
+                        var errorTable = $"{queueName}ErrorTracking";
+                        var indexName = $"IX_QueueIDExceptionType{errorTable}";
+
+                        Assert.IsTrue(IndexExists(connectionInfo.ConnectionString, indexName),
+                            "a newly created queue should carry the unique index");
+
+                        //the atomic statement, on the schema that supports it
+                        CountTwice(queueConnection, logProvider, oCreation.Scope, 1);
+                        Assert.AreEqual(2, RetryCount(connectionInfo.ConnectionString, errorTable, 1));
+
+                        //now an older queue: same table, no index
+                        Execute(connectionInfo.ConnectionString, $"DROP INDEX {indexName}");
+                        Assert.IsFalse(IndexExists(connectionInfo.ConnectionString, indexName));
+
+                        //a different message id, so this counts from zero on the fallback path
+                        CountTwice(queueConnection, logProvider, oCreation.Scope, 2);
+                        Assert.AreEqual(2, RetryCount(connectionInfo.ConnectionString, errorTable, 2),
+                            "the fallback stopped counting errors on a queue without the index");
+                    }
+                    finally
+                    {
+                        oCreation.RemoveQueue();
+                        oCreation.Dispose();
+                    }
+                }
+            }
+        }
+
+        private static void CountTwice(QueueConnection queueConnection, Microsoft.Extensions.Logging.ILogger logProvider,
+            ICreationScope scope, long queueId)
+        {
+            //a fresh container each time, so the cached answer about the schema is taken again
+            using (var container = new QueueContainer<SqLiteMessageQueueInit>(serviceRegister =>
+            {
+                serviceRegister.Register(() => logProvider, LifeStyles.Singleton);
+                serviceRegister.RegisterNonScopedSingleton(scope);
+            }))
+            {
+                using (var admin = container.CreateAdminContainer(queueConnection))
+                {
+                    var handler = admin.GetInstance<ICommandHandler<SetErrorCountCommand<long>>>();
+                    handler.Handle(new SetErrorCountCommand<long>("System.Exception", queueId));
+                    handler.Handle(new SetErrorCountCommand<long>("System.Exception", queueId));
+                }
+            }
+        }
+
+        private static bool IndexExists(string connectionString, string indexName)
+        {
+            using (var conn = new SQLiteConnection(connectionString))
+            {
+                conn.Open();
+                using (var command = conn.CreateCommand())
+                {
+                    command.CommandText = "SELECT 1 FROM sqlite_master WHERE type='index' AND name=@name";
+                    command.Parameters.AddWithValue("@name", indexName);
+                    using (var reader = command.ExecuteReader())
+                    {
+                        return reader.Read();
+                    }
+                }
+            }
+        }
+
+        private static int RetryCount(string connectionString, string errorTable, long queueId)
+        {
+            using (var conn = new SQLiteConnection(connectionString))
+            {
+                conn.Open();
+                using (var command = conn.CreateCommand())
+                {
+                    command.CommandText = $"SELECT RetryCount FROM {errorTable} WHERE QueueID = @id";
+                    command.Parameters.AddWithValue("@id", queueId);
+                    using (var reader = command.ExecuteReader())
+                    {
+                        return reader.Read() ? reader.GetInt32(0) : 0;
+                    }
+                }
+            }
+        }
+
+        private static void Execute(string connectionString, string sql)
+        {
+            using (var conn = new SQLiteConnection(connectionString))
+            {
+                conn.Open();
+                using (var command = conn.CreateCommand())
+                {
+                    command.CommandText = sql;
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/Basic/SetErrorCountAgainstBothSchemasTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.IntegrationTests.Shared;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -68,6 +71,93 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
                         oCreation.RemoveQueue();
                         oCreation.Dispose();
                     }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CountsConcurrentFirstFailures_AsOneRow()
+        {
+            //the race the unique index and the single statement exist for: several workers failing the
+            //same message at the same moment, none of which has an error row to update yet.
+            //Thirty-two rather than a handful because SQLite serialises writers - at eight the older
+            //path came through unscathed there, and a test that cannot fail against the behaviour it
+            //replaces is not saying anything
+            const int failures = 32;
+            using (var connectionInfo = new IntegrationConnectionInfo(false))
+            {
+                var queueName = GenerateQueueName.Create();
+                var connectionString = connectionInfo.ConnectionString;
+                var queueConnection = new QueueConnection(queueName, connectionString);
+                var logProvider = LoggerShared.Create(queueName, GetType().Name);
+
+                using (var queueCreator = new QueueCreationContainer<SqLiteMessageQueueInit>(
+                    serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+                {
+                    var oCreation = queueCreator.GetQueueCreation<SqLiteMessageQueueCreation>(queueConnection);
+                    try
+                    {
+                        var result = oCreation.CreateQueue();
+                        Assert.IsTrue(result.Success, result.ErrorMessage);
+
+                        var errorTable = $"{queueName}ErrorTracking";
+                        Assert.IsTrue(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
+                            "a new queue did not report the unique index, so this would not be testing the atomic path");
+
+                        CountConcurrently(queueConnection, logProvider, oCreation.Scope, 1, failures);
+
+                        Assert.AreEqual(1, RowCount(connectionString, errorTable, 1),
+                            "concurrent first failures wrote more than one row for the same message and exception type");
+                        Assert.AreEqual(failures, RetryCount(connectionString, errorTable, 1),
+                            "a concurrent failure was not counted");
+                    }
+                    finally
+                    {
+                        oCreation.RemoveQueue();
+                        oCreation.Dispose();
+                    }
+                }
+            }
+        }
+
+        private static void CountConcurrently(QueueConnection queueConnection,
+            Microsoft.Extensions.Logging.ILogger logProvider, ICreationScope scope, long queueId, int failures)
+        {
+            using (var container = Container(logProvider, scope))
+            using (var admin = container.CreateAdminContainer(queueConnection))
+            {
+                var handler = admin.GetInstance<ICommandHandler<SetErrorCountCommand<long>>>();
+                //resolved once and started together - the point is that they overlap
+                using (var start = new ManualResetEventSlim(false))
+                {
+                    var running = new Task[failures];
+                    for (var i = 0; i < failures; i++)
+                    {
+                        running[i] = Task.Factory.StartNew(() =>
+                        {
+                            start.Wait();
+                            handler.Handle(new SetErrorCountCommand<long>("System.Exception", queueId));
+                        }, TaskCreationOptions.LongRunning);
+                    }
+                    start.Set();
+                    Task.WaitAll(running);
+                }
+            }
+        }
+
+        private static int RowCount(string connectionString, string errorTable, long queueId)
+        {
+            using (var conn = new SQLiteConnection(connectionString))
+            {
+                conn.Open();
+                using (var command = conn.CreateCommand())
+                {
+                    command.CommandText = $"SELECT COUNT(*) FROM {errorTable} WHERE QueueID = @id";
+                    var parameter = command.CreateParameter();
+                    parameter.ParameterName = "@id";
+                    parameter.Value = queueId;
+                    command.Parameters.Add(parameter);
+                    return Convert.ToInt32(command.ExecuteScalar());
                 }
             }
         }

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteCommandStringCache.cs
@@ -76,6 +76,15 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             CommandCache.Add(CommandStringTypes.InsertErrorCount,
                 $"Insert into {TableNameHelper.ErrorTrackingName} (QueueID,ExceptionType, RetryCount) VALUES (@QueueID,@ExceptionType,1)");
 
+            CommandCache.Add(CommandStringTypes.UpsertErrorCount,
+                $@"insert into {TableNameHelper.ErrorTrackingName} (QueueID, ExceptionType, RetryCount)
+                   values (@QueueID, @ExceptionType, 1)
+                   on conflict (QueueID, ExceptionType)
+                   do update set retrycount = retrycount + 1");
+
+            CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' AND tbl_name = @Table AND name = @Index");
+
             CommandCache.Add(CommandStringTypes.GetHeartBeatExpiredMessageIds,
                 $"select {TableNameHelper.MetaDataName}.queueid, heartbeat, headers from {TableNameHelper.MetaDataName} inner join {TableNameHelper.QueueName} on {TableNameHelper.QueueName}.queueid = {TableNameHelper.MetaDataName}.queueid where status = @Status and heartbeat is not null and heartbeat < @Time");
 

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteCommandStringCache.cs
@@ -82,8 +82,14 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                    on conflict (QueueID, ExceptionType)
                    do update set retrycount = retrycount + 1");
 
+            //By shape, not by name - see the other transports; SQLite appends the table name to an
+            //index name of its own accord, which is one more reason not to match on it.
             CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
-                "SELECT 1 FROM sqlite_master WHERE type = 'index' AND tbl_name = @Table AND name = @Index");
+                @"SELECT 1 FROM pragma_index_list(@Table) il
+                  WHERE il.""unique"" = 1
+                  AND (SELECT COUNT(*) FROM pragma_index_info(il.name)) = 2
+                  AND EXISTS (SELECT 1 FROM pragma_index_info(il.name) ii WHERE lower(ii.name) = 'queueid')
+                  AND EXISTS (SELECT 1 FROM pragma_index_info(il.name) ii WHERE lower(ii.name) = 'exceptiontype')");
 
             CommandCache.Add(CommandStringTypes.GetHeartBeatExpiredMessageIds,
                 $"select {TableNameHelper.MetaDataName}.queueid, heartbeat, headers from {TableNameHelper.MetaDataName} inner join {TableNameHelper.QueueName} on {TableNameHelper.QueueName}.queueid = {TableNameHelper.MetaDataName}.queueid where status = @Status and heartbeat is not null and heartbeat < @Time");

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteCommandStringCache.cs
@@ -83,10 +83,12 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                    do update set retrycount = retrycount + 1");
 
             //By shape, not by name - see the other transports; SQLite appends the table name to an
-            //index name of its own accord, which is one more reason not to match on it.
+            //index name of its own accord, which is one more reason not to match on it. A partial index
+            //is excluded: it fits the shape, but the upsert's conflict target names no predicate, so
+            //SQLite would reject the statement rather than infer it.
             CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
                 @"SELECT 1 FROM pragma_index_list(@Table) il
-                  WHERE il.""unique"" = 1
+                  WHERE il.""unique"" = 1 AND il.""partial"" = 0
                   AND (SELECT COUNT(*) FROM pragma_index_info(il.name)) = 2
                   AND EXISTS (SELECT 1 FROM pragma_index_info(il.name) ii WHERE lower(ii.name) = 'queueid')
                   AND EXISTS (SELECT 1 FROM pragma_index_info(il.name) ii WHERE lower(ii.name) = 'exceptiontype')");

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/SqLiteMessageQueueSchema.cs
@@ -277,6 +277,15 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             errorTracking.Columns.Add(new Column("RetryCount", ColumnTypes.Integer, false, null));
 
             errorTracking.Constraints.Add(new Constraint("IX_QueueID", ConstraintType.Index, ColumnQueueId));
+            //One error row per message per exception type. Without this, the check-then-write in
+            //SetErrorCountCommandHandler can insert a second row for the same pair under concurrency,
+            //and the retry count then reads low - so a message gets more attempts than configured, and
+            //a poison message can loop instead of reaching the error queue.
+            //SQLite's script writer appends the table name to an index name, so this is passed plain and
+            //ends up as IX_QueueIDExceptionType<table> - the same name the other transports build
+            //explicitly, which is what lets the check for it be shared
+            errorTracking.Constraints.Add(new Constraint("IX_QueueIDExceptionType", ConstraintType.Index,
+                new List<string> { ColumnQueueId, "ExceptionType" }) { Unique = true });
 
             foreach (var c in errorTracking.Constraints)
             {

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Basic/SetErrorCountAgainstBothSchemasTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Basic/SetErrorCountAgainstBothSchemasTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.IntegrationTests.Shared;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
@@ -65,6 +68,90 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Basic
                 {
                     oCreation.RemoveQueue();
                     oCreation.Dispose();
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CountsConcurrentFirstFailures_AsOneRow()
+        {
+            //the race the unique index and the single statement exist for: several workers failing the
+            //same message at the same moment, none of which has an error row to update yet.
+            //Thirty-two rather than a handful because SQLite serialises writers - at eight the older
+            //path came through unscathed there, and a test that cannot fail against the behaviour it
+            //replaces is not saying anything
+            const int failures = 32;
+            var queueName = GenerateQueueName.Create();
+            var connectionString = ConnectionInfo.ConnectionString;
+            var queueConnection = new QueueConnection(queueName, connectionString);
+            var logProvider = LoggerShared.Create(queueName, GetType().Name);
+
+            using (var queueCreator = new QueueCreationContainer<SqlServerMessageQueueInit>(
+                serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+            {
+                var oCreation = queueCreator.GetQueueCreation<SqlServerMessageQueueCreation>(queueConnection);
+                try
+                {
+                    var result = oCreation.CreateQueue();
+                    Assert.IsTrue(result.Success, result.ErrorMessage);
+
+                    var errorTable = $"{queueName}ErrorTracking";
+                    Assert.IsTrue(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
+                        "a new queue did not report the unique index, so this would not be testing the atomic path");
+
+                    CountConcurrently(queueConnection, logProvider, oCreation.Scope, 1, failures);
+
+                    Assert.AreEqual(1, RowCount(connectionString, errorTable, 1),
+                        "concurrent first failures wrote more than one row for the same message and exception type");
+                    Assert.AreEqual(failures, RetryCount(connectionString, errorTable, 1),
+                        "a concurrent failure was not counted");
+                }
+                finally
+                {
+                    oCreation.RemoveQueue();
+                    oCreation.Dispose();
+                }
+            }
+        }
+
+        private static void CountConcurrently(QueueConnection queueConnection,
+            Microsoft.Extensions.Logging.ILogger logProvider, ICreationScope scope, long queueId, int failures)
+        {
+            using (var container = Container(logProvider, scope))
+            using (var admin = container.CreateAdminContainer(queueConnection))
+            {
+                var handler = admin.GetInstance<ICommandHandler<SetErrorCountCommand<long>>>();
+                //resolved once and started together - the point is that they overlap
+                using (var start = new ManualResetEventSlim(false))
+                {
+                    var running = new Task[failures];
+                    for (var i = 0; i < failures; i++)
+                    {
+                        running[i] = Task.Factory.StartNew(() =>
+                        {
+                            start.Wait();
+                            handler.Handle(new SetErrorCountCommand<long>("System.Exception", queueId));
+                        }, TaskCreationOptions.LongRunning);
+                    }
+                    start.Set();
+                    Task.WaitAll(running);
+                }
+            }
+        }
+
+        private static int RowCount(string connectionString, string errorTable, long queueId)
+        {
+            using (var conn = new SqlConnection(connectionString))
+            {
+                conn.Open();
+                using (var command = conn.CreateCommand())
+                {
+                    command.CommandText = $"SELECT COUNT(*) FROM {errorTable} WHERE QueueID = @id";
+                    var parameter = command.CreateParameter();
+                    parameter.ParameterName = "@id";
+                    parameter.Value = queueId;
+                    command.Parameters.Add(parameter);
+                    return Convert.ToInt32(command.ExecuteScalar());
                 }
             }
         }

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Basic/SetErrorCountAgainstBothSchemasTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Basic/SetErrorCountAgainstBothSchemasTests.cs
@@ -4,10 +4,10 @@ using DotNetWorkQueue.Transport.RelationalDatabase.Basic.Query;
 using DotNetWorkQueue.Transport.Shared;
 using DotNetWorkQueue.Transport.Shared.Basic.Command;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using DotNetWorkQueue.Transport.SQLite.Basic;
-using System.Data.SQLite;
+using DotNetWorkQueue.Transport.SqlServer.Basic;
+using Microsoft.Data.SqlClient;
 
-namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
+namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Basic
 {
     /// <summary>
     /// Counting errors against a real database, with and without the unique index.
@@ -28,46 +28,43 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
         [TestMethod]
         public void CountsErrors_OnANewQueueAndOnOneWithoutTheIndex()
         {
-            using (var connectionInfo = new IntegrationConnectionInfo(false))
+            var queueName = GenerateQueueName.Create();
+            var connectionString = ConnectionInfo.ConnectionString;
+            var queueConnection = new QueueConnection(queueName, connectionString);
+            var logProvider = LoggerShared.Create(queueName, GetType().Name);
+
+            using (var queueCreator = new QueueCreationContainer<SqlServerMessageQueueInit>(
+                serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
             {
-                var queueName = GenerateQueueName.Create();
-                var connectionString = connectionInfo.ConnectionString;
-                var queueConnection = new QueueConnection(queueName, connectionString);
-                var logProvider = LoggerShared.Create(queueName, GetType().Name);
-
-                using (var queueCreator = new QueueCreationContainer<SqLiteMessageQueueInit>(
-                    serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+                var oCreation = queueCreator.GetQueueCreation<SqlServerMessageQueueCreation>(queueConnection);
+                try
                 {
-                    var oCreation = queueCreator.GetQueueCreation<SqLiteMessageQueueCreation>(queueConnection);
-                    try
-                    {
-                        var result = oCreation.CreateQueue();
-                        Assert.IsTrue(result.Success, result.ErrorMessage);
+                    var result = oCreation.CreateQueue();
+                    Assert.IsTrue(result.Success, result.ErrorMessage);
 
-                        var errorTable = $"{queueName}ErrorTracking";
+                    var errorTable = $"{queueName}ErrorTracking";
 
-                        Assert.IsTrue(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
-                            "a new queue did not report the unique index, so it would keep using the racy count");
+                    Assert.IsTrue(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
+                        "a new queue did not report the unique index, so it would keep using the racy count");
 
-                        //the atomic statement, on the schema that supports it
-                        CountTwice(queueConnection, logProvider, oCreation.Scope, 1);
-                        Assert.AreEqual(2, RetryCount(connectionString, errorTable, 1));
+                    //the atomic statement, on the schema that supports it
+                    CountTwice(queueConnection, logProvider, oCreation.Scope, 1);
+                    Assert.AreEqual(2, RetryCount(connectionString, errorTable, 1));
 
-                        //now an older queue: same table, no index
-                        Execute(connectionString, $"DROP INDEX IX_QueueIDExceptionType{errorTable}");
-                        Assert.IsFalse(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
-                            "the index was still reported after it had been dropped");
+                    //now an older queue: same table, no index
+                    Execute(connectionString, $"DROP INDEX IX_QueueIDExceptionType ON {errorTable}");
+                    Assert.IsFalse(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
+                        "the index was still reported after it had been dropped");
 
-                        //a different message id, so this counts from zero on the fallback path
-                        CountTwice(queueConnection, logProvider, oCreation.Scope, 2);
-                        Assert.AreEqual(2, RetryCount(connectionString, errorTable, 2),
-                            "the fallback stopped counting errors on a queue without the index");
-                    }
-                    finally
-                    {
-                        oCreation.RemoveQueue();
-                        oCreation.Dispose();
-                    }
+                    //a different message id, so this counts from zero on the fallback path
+                    CountTwice(queueConnection, logProvider, oCreation.Scope, 2);
+                    Assert.AreEqual(2, RetryCount(connectionString, errorTable, 2),
+                        "the fallback stopped counting errors on a queue without the index");
+                }
+                finally
+                {
+                    oCreation.RemoveQueue();
+                    oCreation.Dispose();
                 }
             }
         }
@@ -96,10 +93,10 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
             }
         }
 
-        private static QueueContainer<SqLiteMessageQueueInit> Container(
+        private static QueueContainer<SqlServerMessageQueueInit> Container(
             Microsoft.Extensions.Logging.ILogger logProvider, ICreationScope scope)
         {
-            return new QueueContainer<SqLiteMessageQueueInit>(serviceRegister =>
+            return new QueueContainer<SqlServerMessageQueueInit>(serviceRegister =>
             {
                 serviceRegister.Register(() => logProvider, LifeStyles.Singleton);
                 serviceRegister.RegisterNonScopedSingleton(scope);
@@ -108,7 +105,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
 
         private static int RetryCount(string connectionString, string errorTable, long queueId)
         {
-            using (var conn = new SQLiteConnection(connectionString))
+            using (var conn = new SqlConnection(connectionString))
             {
                 conn.Open();
                 using (var command = conn.CreateCommand())
@@ -128,7 +125,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
 
         private static void Execute(string connectionString, string sql)
         {
-            using (var conn = new SQLiteConnection(connectionString))
+            using (var conn = new SqlConnection(connectionString))
             {
                 conn.Open();
                 using (var command = conn.CreateCommand())

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Basic/SetErrorCountAgainstBothSchemasTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/Basic/SetErrorCountAgainstBothSchemasTests.cs
@@ -156,6 +156,41 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.Basic
             }
         }
 
+        [TestMethod]
+        public void DoesNotMistakeAnIncludedColumnForAKeyColumn()
+        {
+            //a unique index on QueueID alone that merely stores ExceptionType alongside it. It has the
+            //two column names and it is unique, but it guarantees one row per message rather than one
+            //per message and exception type - the single statement would break on the second exception
+            var queueName = GenerateQueueName.Create();
+            var connectionString = ConnectionInfo.ConnectionString;
+            var queueConnection = new QueueConnection(queueName, connectionString);
+            var logProvider = LoggerShared.Create(queueName, GetType().Name);
+
+            using (var queueCreator = new QueueCreationContainer<SqlServerMessageQueueInit>(
+                serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+            {
+                var oCreation = queueCreator.GetQueueCreation<SqlServerMessageQueueCreation>(queueConnection);
+                try
+                {
+                    var result = oCreation.CreateQueue();
+                    Assert.IsTrue(result.Success, result.ErrorMessage);
+
+                    var errorTable = $"{queueName}ErrorTracking";
+                    Execute(connectionString, $"DROP INDEX IX_QueueIDExceptionType ON {errorTable}");
+                    Execute(connectionString, $"CREATE UNIQUE INDEX IX_Included ON {errorTable} (QueueID) INCLUDE (ExceptionType)");
+
+                    Assert.IsFalse(UniqueIndexFound(queueConnection, logProvider, oCreation.Scope, errorTable),
+                        "an included column was counted as part of the unique key");
+                }
+                finally
+                {
+                    oCreation.RemoveQueue();
+                    oCreation.Dispose();
+                }
+            }
+        }
+
         private static bool UniqueIndexFound(QueueConnection queueConnection,
             Microsoft.Extensions.Logging.ILogger logProvider, ICreationScope scope, string errorTable)
         {

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueSchema.cs
@@ -293,6 +293,12 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             errorTracking.PrimaryKey.Unique = true;
 
             errorTracking.Constraints.Add(new Constraint("IX_QueueID", ConstraintType.Index, ColumnQueueId));
+            //One error row per message per exception type. Without this, the check-then-write in
+            //SetErrorCountCommandHandler can insert a second row for the same pair under concurrency,
+            //and the retry count then reads low - so a message gets more attempts than configured, and
+            //a poison message can loop instead of reaching the error queue.
+            errorTracking.Constraints.Add(new Constraint($"IX_QueueIDExceptionType{_tableNameHelper.ErrorTrackingName}", ConstraintType.Index,
+                new List<string> { ColumnQueueId, "ExceptionType" }) { Unique = true });
 
             foreach (var c in errorTracking.Constraints)
             {

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SQLServerMessageQueueSchema.cs
@@ -297,7 +297,9 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             //SetErrorCountCommandHandler can insert a second row for the same pair under concurrency,
             //and the retry count then reads low - so a message gets more attempts than configured, and
             //a poison message can loop instead of reaching the error queue.
-            errorTracking.Constraints.Add(new Constraint($"IX_QueueIDExceptionType{_tableNameHelper.ErrorTrackingName}", ConstraintType.Index,
+            //No table name in it: SQL Server scopes index names to the table, and appending the table
+            //pushed the identifier past the 128 character limit for queue names the validator allows
+            errorTracking.Constraints.Add(new Constraint("IX_QueueIDExceptionType", ConstraintType.Index,
                 new List<string> { ColumnQueueId, "ExceptionType" }) { Unique = true });
 
             foreach (var c in errorTracking.Constraints)

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerCommandStringCache.cs
@@ -92,10 +92,12 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
 
             //By shape, not by name: an index name is not something this can rely on. It is folded,
             //truncated or suffixed differently by each provider, and a same-named index that happened to
-            //be non-unique would send the atomic statement at a table that cannot support it.
+            //be non-unique would send the atomic statement at a table that cannot support it. A filtered
+            //index is excluded for the same reason - it fits the shape but guarantees nothing about the
+            //rows outside its filter, which is the guarantee being asked about.
             CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
                 @"SELECT 1 FROM sys.indexes i
-                  WHERE i.object_id = OBJECT_ID(@Table) AND i.is_unique = 1
+                  WHERE i.object_id = OBJECT_ID(@Table) AND i.is_unique = 1 AND i.has_filter = 0
                   AND (SELECT COUNT(*) FROM sys.index_columns ic
                        WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id) = 2
                   AND EXISTS (SELECT 1 FROM sys.index_columns ic

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerCommandStringCache.cs
@@ -95,17 +95,20 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             //be non-unique would send the atomic statement at a table that cannot support it. A filtered
             //index is excluded for the same reason - it fits the shape but guarantees nothing about the
             //rows outside its filter, which is the guarantee being asked about.
+            //key_ordinal > 0 everywhere: sys.index_columns also lists INCLUDE columns, which are stored
+            //but carry no uniqueness, so a unique index on QueueID alone that merely includes
+            //ExceptionType would otherwise look like the two-column key being asked about.
             CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
                 @"SELECT 1 FROM sys.indexes i
                   WHERE i.object_id = OBJECT_ID(@Table) AND i.is_unique = 1 AND i.has_filter = 0
                   AND (SELECT COUNT(*) FROM sys.index_columns ic
-                       WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id) = 2
+                       WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.key_ordinal > 0) = 2
                   AND EXISTS (SELECT 1 FROM sys.index_columns ic
                               JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
-                              WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND c.name = 'QueueID')
+                              WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.key_ordinal > 0 AND c.name = 'QueueID')
                   AND EXISTS (SELECT 1 FROM sys.index_columns ic
                               JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
-                              WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND c.name = 'ExceptionType')");
+                              WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND ic.key_ordinal > 0 AND c.name = 'ExceptionType')");
 
             CommandCache.Add(CommandStringTypes.GetHeartBeatExpiredMessageIds,
                 $"select {TableNameHelper.MetaDataName}.queueid, heartbeat, headers from {TableNameHelper.MetaDataName} with (updlock, readpast, rowlock) inner join {TableNameHelper.QueueName} on {TableNameHelper.QueueName}.queueid = {TableNameHelper.MetaDataName}.queueid where status = @status and heartbeat is not null and (DATEDIFF(SECOND, heartbeat, GETUTCDATE()) > @time)");

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerCommandStringCache.cs
@@ -78,6 +78,15 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             CommandCache.Add(CommandStringTypes.InsertErrorCount,
                 $"Insert into {TableNameHelper.ErrorTrackingName} (QueueID,ExceptionType, RetryCount) VALUES (@QueueID,@ExceptionType,1)");
 
+            CommandCache.Add(CommandStringTypes.UpsertErrorCount,
+                $@"update {TableNameHelper.ErrorTrackingName} with (updlock, holdlock) set retrycount = retrycount + 1
+                   where queueid = @QueueID and ExceptionType = @ExceptionType;
+                   if @@rowcount = 0
+                   insert into {TableNameHelper.ErrorTrackingName} (QueueID, ExceptionType, RetryCount) values (@QueueID, @ExceptionType, 1);");
+
+            CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
+                "SELECT 1 FROM sys.indexes WHERE name = @Index AND object_id = OBJECT_ID(@Table)");
+
             CommandCache.Add(CommandStringTypes.GetHeartBeatExpiredMessageIds,
                 $"select {TableNameHelper.MetaDataName}.queueid, heartbeat, headers from {TableNameHelper.MetaDataName} with (updlock, readpast, rowlock) inner join {TableNameHelper.QueueName} on {TableNameHelper.QueueName}.queueid = {TableNameHelper.MetaDataName}.queueid where status = @status and heartbeat is not null and (DATEDIFF(SECOND, heartbeat, GETUTCDATE()) > @time)");
 

--- a/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerCommandStringCache.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer/Basic/SqlServerCommandStringCache.cs
@@ -78,14 +78,32 @@ namespace DotNetWorkQueue.Transport.SqlServer.Basic
             CommandCache.Add(CommandStringTypes.InsertErrorCount,
                 $"Insert into {TableNameHelper.ErrorTrackingName} (QueueID,ExceptionType, RetryCount) VALUES (@QueueID,@ExceptionType,1)");
 
+            //One transaction on purpose. Without it each statement commits on its own, the range lock
+            //the update took is released before the insert runs, and two first failures can both find no
+            //row - after which the unique index rejects one of them and that error count is lost.
             CommandCache.Add(CommandStringTypes.UpsertErrorCount,
-                $@"update {TableNameHelper.ErrorTrackingName} with (updlock, holdlock) set retrycount = retrycount + 1
+                $@"set nocount on;
+                   begin transaction;
+                   update {TableNameHelper.ErrorTrackingName} with (updlock, holdlock) set retrycount = retrycount + 1
                    where queueid = @QueueID and ExceptionType = @ExceptionType;
                    if @@rowcount = 0
-                   insert into {TableNameHelper.ErrorTrackingName} (QueueID, ExceptionType, RetryCount) values (@QueueID, @ExceptionType, 1);");
+                   insert into {TableNameHelper.ErrorTrackingName} (QueueID, ExceptionType, RetryCount) values (@QueueID, @ExceptionType, 1);
+                   commit transaction;");
 
+            //By shape, not by name: an index name is not something this can rely on. It is folded,
+            //truncated or suffixed differently by each provider, and a same-named index that happened to
+            //be non-unique would send the atomic statement at a table that cannot support it.
             CommandCache.Add(CommandStringTypes.GetErrorTrackingUniqueIndexExists,
-                "SELECT 1 FROM sys.indexes WHERE name = @Index AND object_id = OBJECT_ID(@Table)");
+                @"SELECT 1 FROM sys.indexes i
+                  WHERE i.object_id = OBJECT_ID(@Table) AND i.is_unique = 1
+                  AND (SELECT COUNT(*) FROM sys.index_columns ic
+                       WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id) = 2
+                  AND EXISTS (SELECT 1 FROM sys.index_columns ic
+                              JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+                              WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND c.name = 'QueueID')
+                  AND EXISTS (SELECT 1 FROM sys.index_columns ic
+                              JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+                              WHERE ic.object_id = i.object_id AND ic.index_id = i.index_id AND c.name = 'ExceptionType')");
 
             CommandCache.Add(CommandStringTypes.GetHeartBeatExpiredMessageIds,
                 $"select {TableNameHelper.MetaDataName}.queueid, heartbeat, headers from {TableNameHelper.MetaDataName} with (updlock, readpast, rowlock) inner join {TableNameHelper.QueueName} on {TableNameHelper.QueueName}.queueid = {TableNameHelper.MetaDataName}.queueid where status = @status and heartbeat is not null and (DATEDIFF(SECOND, heartbeat, GETUTCDATE()) > @time)");


### PR DESCRIPTION
`SetErrorCountCommandHandler` asked whether a row existed for `(QueueID, ExceptionType)` and then inserted or updated, with nothing enforcing one row per pair. Two failures of the same message arriving together could each see no row and each insert one. The retry count then reads lower than reality — so a message gets more attempts than configured, and a poison message can loop instead of reaching the error queue.

## What changed

New queues get a unique index on `(QueueID, ExceptionType)`, and the count becomes a single statement:

| | |
|---|---|
| PostgreSQL, SQLite | `INSERT … ON CONFLICT (QueueID, ExceptionType) DO UPDATE` |
| SQL Server | `UPDATE … WITH (UPDLOCK, HOLDLOCK)` then insert when no row was touched, inside one explicit transaction |

## Existing queues

The library does not upgrade schemas — a user drains and re-creates — so an older error tracking table has no such index, and `ON CONFLICT` against a table without one throws rather than degrading. The queue is therefore asked once whether the index is there and keeps the old check-then-write when it is not. The answer is cached: the schema does not change underneath a running consumer, and this sits on the failure path. A look-up that *fails* is not cached, so one transient outage cannot pin a queue to the old path for its lifetime.

**Adding the index cannot break an existing deployment.** `CreateQueue` returns `AlreadyExists` without touching anything when the tables are present, so the index is only ever created as part of a new, empty table. An upgrade that added it to a live table would have to de-duplicate first — a queue that ran on an older version may hold exactly the duplicate rows this bug produces. That is written into the upgrade issue (#308).

## Where to look

The detection query is the part worth review. It matches the index by **shape** rather than by name, per transport:

- unique, and not partial or filtered — a predicate means the guarantee does not hold for the rows outside it, and `ON CONFLICT` cannot infer such an index anyway
- exactly two **key** columns, `QueueID` and `ExceptionType`, compared case-insensitively — an `INCLUDE`d column is stored by the index but carries no uniqueness
- the table resolved the way the transport's own statements resolve it: `to_regclass` on PostgreSQL (schema-qualified queue names are legal, and identifiers are folded and truncated), `OBJECT_ID` on SQL Server, `pragma_index_list` on SQLite

Matching by name does not work here: PostgreSQL lower-cases and truncates, SQLite appends the table name to whatever name it is given, and SQL Server scopes names per table.

## Tests

Unit: both branches, that the schema is asked about once, and that a failed look-up falls back for that call only and is retried on the next.

Against real databases, on all three transports:

- a new queue reports the index and counts through the single statement; drop the index and the fallback still counts
- 32 workers failing the same message at once produce one row with a count of 32
- a unique index on `QueueID` that merely `INCLUDE`s `ExceptionType` is not accepted as the key (PostgreSQL, SQL Server — SQLite has no included columns)

Each asserts what the queue *decided*, not only the resulting count. Both paths count correctly when nothing is racing, so a count-only assertion passes either way.

Validated locally: relational unit suites, the integration tests above on SQL Server, PostgreSQL and SQLite, and a `Release -p:CI=true` build. The full error-path integration sweep runs on Jenkins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
