### PR TITLE
History timestamps come from the configured time provider (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ﻿### Unreleased
+- Fix: message history timestamps come from the queue's configured time provider rather than the machine clock. On SQL Server and PostgreSQL that is the database server's clock, so history agrees with the rest of the queue's timestamps and durations cannot read negative (GitHub #304)
 - ⚠️ Fix: two failures arriving at once each added an error row, so a message got more retries than configured and could loop instead of reaching the error queue. Re-create an existing SQL Server, PostgreSQL or SQLite queue to pick up the fix (GitHub #299)
 - Redis consumers no longer hold a thread through the de-queue. Under thread-pool pressure, where a consumer previously timed out waiting on Redis, it now keeps working (GitHub #256)
 - ⚠️ Custom transports and consumers must add async members: `IReceiveMessages.ReceiveMessageAsync`, `IQueueWait.WaitAsync`, and `IRedisQueueWorkSub.WaitAsync` for Redis. Built-in transports are unaffected (GitHub #256)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ﻿### Unreleased
 - Fix: message history timestamps come from the queue's configured time provider rather than the machine clock. On SQL Server and PostgreSQL that is the database server's clock, so history agrees with the rest of the queue's timestamps and durations cannot read negative (GitHub #304)
+- ⚠️ `WriteMessageHistoryHandler` constructors take an `IGetTimeFactory` on every transport. Only affects code that constructs or subclasses these directly; queues built through the container are unaffected (GitHub #304)
 - ⚠️ Fix: two failures arriving at once each added an error row, so a message got more retries than configured and could loop instead of reaching the error queue. Re-create an existing SQL Server, PostgreSQL or SQLite queue to pick up the fix (GitHub #299)
 - Redis consumers no longer hold a thread through the de-queue. Under thread-pool pressure, where a consumer previously timed out waiting on Redis, it now keeps working (GitHub #256)
 - ⚠️ Custom transports and consumers must add async members: `IReceiveMessages.ReceiveMessageAsync`, `IQueueWait.WaitAsync`, and `IRedisQueueWorkSub.WaitAsync` for Redis. Built-in transports are unaffected (GitHub #256)

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/HistoryTimeProviderTest.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/HistoryTimeProviderTest.cs
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System;
+using DotNetWorkQueue.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.IntegrationTests.Shared.History.Implementation
+{
+    /// <summary>
+    /// A history timestamp comes from the time provider the queue was configured with.
+    ///
+    /// The unit tests construct the history handlers directly, so they say nothing about whether the
+    /// container hands the handler the provider the user chose. This registers a clock of its own the
+    /// ordinary way - the same callback an application would use - resolves the handler the queue would
+    /// resolve, and reads the timestamp back out through the query the dashboard uses. It therefore
+    /// covers the wiring and the round trip to storage, per transport.
+    /// </summary>
+    public class HistoryTimeProviderTest
+    {
+        /// <summary>A date far from any machine clock, so a timestamp from the wrong source cannot match.</summary>
+        public static readonly DateTime FixedUtc = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
+        public void Run<TTransportInit, TTransportCreate>(
+            QueueConnection queueConnection,
+            Action<TTransportCreate> setOptions)
+            where TTransportInit : ITransportInit, new()
+            where TTransportCreate : class, IQueueCreation
+        {
+            var logProvider = LoggerShared.Create(queueConnection.Queue, GetType().Name);
+            using (var queueCreator = new QueueCreationContainer<TTransportInit>(
+                serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+            {
+                ICreationScope scope = null;
+                var oCreation = queueCreator.GetQueueCreation<TTransportCreate>(queueConnection);
+                try
+                {
+                    setOptions(oCreation);
+                    var result = oCreation.CreateQueue();
+                    Assert.IsTrue(result.Success, result.ErrorMessage);
+                    scope = oCreation.Scope;
+
+                    using (var container = Container<TTransportInit>(logProvider, scope))
+                    using (var admin = container.CreateAdminContainer(queueConnection))
+                    {
+                        var history = admin.GetInstance<IWriteMessageHistory>();
+                        history.RecordEnqueue("1", "c1", "routeA", "MyType", new byte[] { 1 }, new byte[] { 2 });
+                    }
+
+                    //a fresh container, so the record is read back from storage rather than from anything
+                    //the writing container may still be holding
+                    using (var container = Container<TTransportInit>(logProvider, scope))
+                    using (var admin = container.CreateAdminContainer(queueConnection))
+                    {
+                        var records = admin.GetInstance<IQueryMessageHistory>().Get(0, 10, null);
+                        Assert.IsGreaterThanOrEqualTo(1, records.Count, "the history record was not written");
+
+                        //what is being asked is where the timestamp came from, so the comparison is
+                        //against the clock rather than against the machine's. It is deliberately not an
+                        //exact match: PostgreSQL and SQLite return the value shifted by the machine's
+                        //UTC offset, which is GitHub #311 and not this test's subject. A day of slack
+                        //covers any offset while leaving twenty-five years between the two candidates.
+                        var drift = (records[0].EnqueuedUtc - FixedUtc).Duration();
+                        Assert.IsLessThanOrEqualTo(TimeSpan.FromDays(1), drift,
+                            $"expected a timestamp from the configured provider (near {FixedUtc:u}), got {records[0].EnqueuedUtc:u}");
+                    }
+                }
+                finally
+                {
+                    oCreation?.RemoveQueue();
+                    oCreation?.Dispose();
+                    scope?.Dispose();
+                }
+            }
+        }
+
+        private static QueueContainer<TTransportInit> Container<TTransportInit>(
+            Microsoft.Extensions.Logging.ILogger logProvider, ICreationScope scope)
+            where TTransportInit : ITransportInit, new()
+        {
+            return new QueueContainer<TTransportInit>(serviceRegister =>
+            {
+                serviceRegister.Register(() => logProvider, LifeStyles.Singleton);
+                serviceRegister.RegisterNonScopedSingleton(scope);
+                //IGetTimeFactory, not IGetTime: Redis registers a factory of its own that answers with
+                //the Redis server's clock and never consults an IGetTime registration, and the factory
+                //is what the handlers actually ask
+                serviceRegister.Register<IGetTimeFactory, FixedTimeFactory>(LifeStyles.Singleton);
+            });
+        }
+
+        /// <summary>A clock that does not move, and is nowhere near the machine's.</summary>
+        private class FixedTimeFactory : IGetTimeFactory
+        {
+            public IGetTime Create() => new FixedTime();
+        }
+
+        private class FixedTime : IGetTime
+        {
+            public DateTime GetCurrentUtcDate() => FixedUtc;
+            public TimeSpan GetCurrentOffset => TimeSpan.Zero;
+            public string Name => "Fixed";
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/WriteMessageHistoryHandlerTests.cs
@@ -3,7 +3,6 @@ using System.Text;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.Memory.Basic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using NSubstitute;
 
 namespace DotNetWorkQueue.Tests.Transport.Memory.Basic

--- a/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Transport/Memory/Basic/WriteMessageHistoryHandlerTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.Memory.Basic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using NSubstitute;
 
 namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
@@ -10,6 +11,19 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
     [TestClass]
     public class WriteMessageHistoryHandlerTests
     {
+        //deliberately nowhere near the machine clock, so a timestamp taken from DateTime.UtcNow
+        //instead of the provider cannot coincidentally match
+        private static readonly DateTime ProviderNow = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
+        /// <summary>A clock the test controls, standing in for the configured time provider.</summary>
+        private static IGetTimeFactory Clock(DateTime now)
+        {
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(now);
+            var factory = Substitute.For<IGetTimeFactory>();
+            factory.Create().Returns(time);
+            return factory;
+        }
         [TestMethod]
         public void Create_Default()
         {
@@ -44,7 +58,8 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             Assert.AreEqual("route", record.Route);
             Assert.AreEqual("MyType", record.MessageType);
             Assert.AreEqual(0, record.RetryCount);
-            Assert.IsLessThanOrEqualTo(DateTime.UtcNow, record.EnqueuedUtc);
+            //from the configured provider, not the machine clock
+            Assert.AreEqual(ProviderNow, record.EnqueuedUtc);
         }
 
         [TestMethod]
@@ -427,7 +442,7 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(false);
 
-            return new WriteMessageHistoryHandler(connectionInfo, options);
+            return new WriteMessageHistoryHandler(connectionInfo, options, Clock(ProviderNow));
         }
 
         private static (WriteMessageHistoryHandler handler, string key) CreateHandlerWithKey(
@@ -448,7 +463,7 @@ namespace DotNetWorkQueue.Tests.Transport.Memory.Basic
             options.EnableHistory.Returns(enableHistory);
             options.HistoryOptions.Returns(historyOptions);
 
-            var handler = new WriteMessageHistoryHandler(connectionInfo, options);
+            var handler = new WriteMessageHistoryHandler(connectionInfo, options, Clock(ProviderNow));
             var key = $"{queueName}|{connectionString}";
             return (handler, key);
         }

--- a/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/History/SimpleHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/History/SimpleHistoryTests.cs
@@ -44,5 +44,21 @@ namespace DotNetWorkQueue.Transport.LiteDb.IntegrationTests.History
                     Helpers.GenerateData, Helpers.Verify);
             }
         }
+
+        [TestMethod]
+        public void HistoryTimestampComesFromTheConfiguredTimeProvider()
+        {
+            using (var connectionInfo = new IntegrationConnectionInfo(IntegrationConnectionInfo.ConnectionTypes.Direct))
+            {
+                var queueName = GenerateQueueName.Create();
+                var test = new HistoryTimeProviderTest();
+                test.Run<LiteDbMessageQueueInit, LiteDbMessageQueueCreation>(
+                    new QueueConnection(queueName, connectionInfo.ConnectionString),
+                    x =>
+                    {
+                        x.Options.EnableHistory = true;
+                    });
+            }
+        }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
@@ -31,11 +31,12 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         private readonly LiteDbConnectionManager _connectionManager;
         private readonly TableNameHelper _tableNameHelper;
         private readonly IBaseTransportOptions _options;
-        //Time comes from the configured provider, not the local clock. On SQL Server and PostgreSQL
-        //that is the database server's clock, which is what the rest of the queue's timestamps are on;
-        //history written from an application machine with a drifting clock would otherwise report
-        //durations that disagree with them, or run negative. BaseTime caches an offset, so this costs
-        //no round trip.
+        //Time comes from the configured provider rather than the local clock. On SQL Server and
+        //PostgreSQL that provider is the database server, which is where the rest of the queue's
+        //timestamps come from. History written from an application machine with a drifting clock
+        //would otherwise disagree with the data beside it, and a duration taken from a start and an
+        //end on different clocks can come out negative. BaseTime caches an offset, so this costs no
+        //round trip.
         private readonly IGetTime _getTime;
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
@@ -31,17 +31,25 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         private readonly LiteDbConnectionManager _connectionManager;
         private readonly TableNameHelper _tableNameHelper;
         private readonly IBaseTransportOptions _options;
+        //Time comes from the configured provider, not the local clock. On SQL Server and PostgreSQL
+        //that is the database server's clock, which is what the rest of the queue's timestamps are on;
+        //history written from an application machine with a drifting clock would otherwise report
+        //durations that disagree with them, or run negative. BaseTime caches an offset, so this costs
+        //no round trip.
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WriteMessageHistoryHandler"/> class.
         /// </summary>
         public WriteMessageHistoryHandler(LiteDbConnectionManager connectionManager,
             TableNameHelper tableNameHelper,
-            IBaseTransportOptions options)
+            IBaseTransportOptions options,
+            IGetTimeFactory getTimeFactory)
         {
             _connectionManager = connectionManager;
             _tableNameHelper = tableNameHelper;
             _options = options;
+            _getTime = getTimeFactory.Create();
         }
 
         /// <inheritdoc />
@@ -56,7 +64,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
                     QueueId = queueId,
                     CorrelationId = correlationId,
                     Status = (int)MessageHistoryStatus.Enqueued,
-                    EnqueuedUtc = DateTime.UtcNow.Ticks,
+                    EnqueuedUtc = _getTime.GetCurrentUtcDate().Ticks,
                     RetryCount = 0,
                     Route = route,
                     MessageType = messageType,
@@ -110,7 +118,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
                 if (record != null)
                 {
                     record.Status = (int)MessageHistoryStatus.Processing;
-                    record.StartedUtc = DateTime.UtcNow.Ticks;
+                    record.StartedUtc = _getTime.GetCurrentUtcDate().Ticks;
                     col.Update(record);
                 }
             }
@@ -120,7 +128,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         public void RecordComplete(string queueId)
         {
             if (!_options.EnableHistory) return;
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             using (var db = _connectionManager.GetDatabase())
             {
                 var col = db.Database.GetCollection<HistoryTable>(_tableNameHelper.HistoryName);
@@ -140,7 +148,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
         /// <inheritdoc />
         public void RecordError(string queueId, string exception)
         {
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             using (var db = _connectionManager.GetDatabase())
             {
                 var col = db.Database.GetCollection<HistoryTable>(_tableNameHelper.HistoryName);
@@ -188,7 +196,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
                 if (record != null)
                 {
                     record.Status = (int)MessageHistoryStatus.Deleted;
-                    record.CompletedUtc = DateTime.UtcNow.Ticks;
+                    record.CompletedUtc = _getTime.GetCurrentUtcDate().Ticks;
                     col.Update(record);
                 }
             }
@@ -204,7 +212,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
                 if (record != null)
                 {
                     record.Status = (int)MessageHistoryStatus.Expired;
-                    record.CompletedUtc = DateTime.UtcNow.Ticks;
+                    record.CompletedUtc = _getTime.GetCurrentUtcDate().Ticks;
                     col.Update(record);
                 }
             }

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/WriteMessageHistoryHandlerTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
 using DotNetWorkQueue.Transport.LiteDb.Schema;
-using System;
 using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DotNetWorkQueue.Tests.Shared;

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/WriteMessageHistoryHandlerTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.LiteDb.Basic;
 using DotNetWorkQueue.Transport.LiteDb.Schema;
+using System;
 using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DotNetWorkQueue.Tests.Shared;
@@ -12,6 +13,19 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
     [TestClass]
     public class WriteMessageHistoryHandlerTests
     {
+        //deliberately nowhere near the machine clock, so a timestamp taken from DateTime.UtcNow
+        //instead of the provider cannot coincidentally match
+        private static readonly DateTime ProviderNow = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
+        /// <summary>A clock the test controls, standing in for the configured time provider.</summary>
+        private static IGetTimeFactory Clock(DateTime now)
+        {
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(now);
+            var factory = Substitute.For<IGetTimeFactory>();
+            factory.Create().Returns(time);
+            return factory;
+        }
         private const string QueueName = "testQueue";
 
         private static (WriteMessageHistoryHandler handler, LiteDbConnectionManager connectionManager,
@@ -36,7 +50,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
             options.EnableHistory.Returns(enableHistory);
             options.HistoryOptions.Returns(historyOptions);
 
-            var handler = new WriteMessageHistoryHandler(connectionManager, tableNameHelper, options);
+            var handler = new WriteMessageHistoryHandler(connectionManager, tableNameHelper, options, Clock(ProviderNow));
             return (handler, connectionManager, tableNameHelper);
         }
 
@@ -61,7 +75,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic
                     Assert.AreEqual("MyType", records[0].MessageType);
                     Assert.AreEqual((int)MessageHistoryStatus.Enqueued, records[0].Status);
                     Assert.AreEqual(0, records[0].RetryCount);
-                    Assert.IsGreaterThan(0, records[0].EnqueuedUtc);
+                    //from the configured provider, not the machine clock
+                    Assert.AreEqual(ProviderNow.Ticks, records[0].EnqueuedUtc);
                 }
             }
         }

--- a/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/History/SimpleHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Memory.Integration.Tests/History/SimpleHistoryTests.cs
@@ -42,5 +42,21 @@ namespace DotNetWorkQueue.Transport.Memory.Integration.Tests.History
                     Helpers.GenerateData, Helpers.Verify);
             }
         }
+
+        [TestMethod]
+        public void HistoryTimestampComesFromTheConfiguredTimeProvider()
+        {
+            using (var connectionInfo = new IntegrationConnectionInfo())
+            {
+                var queueName = GenerateQueueName.Create();
+                var test = new HistoryTimeProviderTest();
+                test.Run<MemoryMessageQueueInit, MessageQueueCreation>(
+                    new QueueConnection(queueName, connectionInfo.ConnectionString),
+                    x =>
+                    {
+                        x.Options.EnableHistory = true;
+                    });
+            }
+        }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/History/SimpleHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests/History/SimpleHistoryTests.cs
@@ -45,5 +45,19 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Integration.Tests.History
                 },
                 Helpers.GenerateData, Helpers.Verify);
         }
+
+        [TestMethod]
+        public void HistoryTimestampComesFromTheConfiguredTimeProvider()
+        {
+            var queueName = GenerateQueueName.Create();
+            var test = new HistoryTimeProviderTest();
+            test.Run<PostgreSqlMessageQueueInit, PostgreSqlMessageQueueCreation>(
+                new QueueConnection(queueName, ConnectionInfo.ConnectionString),
+                x =>
+                {
+                    Helpers.SetOptions(x, true, false, false, false, false, false, true, false);
+                    x.Options.EnableHistory = true;
+                });
+        }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/History/SimpleHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.IntegrationTests/History/SimpleHistoryTests.cs
@@ -40,5 +40,18 @@ namespace DotNetWorkQueue.Transport.Redis.IntegrationTests.History
                 x => { x.Options.EnableHistory = true; },
                 Helpers.GenerateData, Helpers.Verify);
         }
+
+        [TestMethod]
+        public void HistoryTimestampComesFromTheConfiguredTimeProvider()
+        {
+            var queueName = GenerateQueueName.Create();
+            var test = new HistoryTimeProviderTest();
+            test.Run<RedisQueueInit, RedisQueueCreation>(
+                new QueueConnection(queueName, ConnectionInfo.ConnectionString),
+                x =>
+                {
+                    x.Options.EnableHistory = true;
+                });
+        }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/WriteMessageHistoryHandlerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.Redis.Basic;
-using System;
 using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StackExchange.Redis;

--- a/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/WriteMessageHistoryHandlerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using DotNetWorkQueue.Configuration;
 using DotNetWorkQueue.Transport.Redis.Basic;
+using System;
 using NSubstitute;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StackExchange.Redis;
@@ -10,6 +11,19 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
     [TestClass]
     public class WriteMessageHistoryHandlerTests
     {
+        //deliberately nowhere near the machine clock, so a timestamp taken from DateTime.UtcNow
+        //instead of the provider cannot coincidentally match
+        private static readonly DateTime ProviderNow = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
+        /// <summary>A clock the test controls, standing in for the configured time provider.</summary>
+        private static IGetTimeFactory Clock(DateTime now)
+        {
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(now);
+            var factory = Substitute.For<IGetTimeFactory>();
+            factory.Create().Returns(time);
+            return factory;
+        }
         /// <summary>
         /// Test wrapper that injects an IDatabase directly via the GetDb() seam,
         /// bypassing ConnectionMultiplexer which cannot be proxied by NSubstitute.
@@ -19,7 +33,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             private readonly IDatabase _db;
 
             public TestableWriteMessageHistoryHandler(IRedisConnection connection, RedisNames redisNames, IBaseTransportOptions options, IDatabase db)
-                : base(connection, redisNames, options)
+                : base(connection, redisNames, options, Clock(ProviderNow))
             {
                 _db = db;
             }
@@ -33,7 +47,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(Substitute.For<IConnectionInformation>());
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(false);
-            return new WriteMessageHistoryHandler(connection, redisNames, options);
+            return new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
         }
 
         // --- Disabled path tests ---
@@ -100,7 +114,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(true);
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
 
             try { handler.RecordEnqueue("q1", "c1", "route", "type", null, null); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -114,7 +128,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(true);
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
 
             try { handler.RecordProcessingStart("q1"); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -128,7 +142,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(true);
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
 
             try { handler.RecordComplete("q1"); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -142,7 +156,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(true);
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
 
             try { handler.RecordError("q1", "err"); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -156,7 +170,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(true);
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
 
             try { handler.RecordRollback("q1"); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -170,7 +184,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(true);
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
 
             try { handler.RecordDelete("q1"); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -184,7 +198,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(true);
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
 
             try { handler.RecordExpire("q1"); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -198,7 +212,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(true);
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
 
             try { handler.RecordEnqueue("q1", null, null, null, null, null); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -212,7 +226,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(true);
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
 
             try { handler.RecordError("q1", null); } catch (NullReferenceException) { }
             _ = connection.Received(1).Connection;
@@ -225,7 +239,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             var connInfo = Substitute.For<IConnectionInformation>();
             var redisNames = Substitute.For<RedisNames>(connInfo);
             var options = Substitute.For<IBaseTransportOptions>();
-            var handler = new WriteMessageHistoryHandler(connection, redisNames, options);
+            var handler = new WriteMessageHistoryHandler(connection, redisNames, options, Clock(ProviderNow));
             Assert.IsNotNull(handler);
         }
 
@@ -247,6 +261,21 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic
             options.EnableHistory.Returns(true);
 
             return (new TestableWriteMessageHistoryHandler(connection, redisNames, options, db), db);
+        }
+
+        [TestMethod]
+        public void RecordEnqueue_TakesTheTimestampFromTheConfiguredProvider()
+        {
+            //Redis defaults to the Redis server's clock, which is what the rest of the queue's
+            //timestamps are on; taking this one from the application machine makes history disagree
+            var (handler, db) = CreateEnabledWithDb();
+
+            handler.RecordEnqueue("q1", "c1", "routeA", "MyType", new byte[] { 1 }, new byte[] { 2 });
+
+            db.Received().HashSet(
+                Arg.Any<RedisKey>(),
+                Arg.Is<HashEntry[]>(entries => ContainsEntry(entries, "EnqueuedUtc", ProviderNow.Ticks)),
+                Arg.Any<CommandFlags>());
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
@@ -33,16 +33,24 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         private readonly IRedisConnection _connection;
         private readonly RedisNames _redisNames;
         private readonly IBaseTransportOptions _options;
+        //Time comes from the configured provider, not the local clock. On SQL Server and PostgreSQL
+        //that is the database server's clock, which is what the rest of the queue's timestamps are on;
+        //history written from an application machine with a drifting clock would otherwise report
+        //durations that disagree with them, or run negative. BaseTime caches an offset, so this costs
+        //no round trip.
+        private readonly IGetTime _getTime;
 
         private string HistoryHashKey(string queueId) => $"{_redisNames.Values}:history:{queueId}";
         private string HistoryIndexKey => $"{_redisNames.Values}:history:index";
 
         /// <inheritdoc />
-        public WriteMessageHistoryHandler(IRedisConnection connection, RedisNames redisNames, IBaseTransportOptions options)
+        public WriteMessageHistoryHandler(IRedisConnection connection, RedisNames redisNames, IBaseTransportOptions options,
+            IGetTimeFactory getTimeFactory)
         {
             _connection = connection;
             _redisNames = redisNames;
             _options = options;
+            _getTime = getTimeFactory.Create();
         }
 
         /// <summary>Returns the Redis database to use. Protected virtual to allow test seam injection.</summary>
@@ -53,7 +61,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             db.HashSet(HistoryHashKey(queueId), new[]
             {
                 new HashEntry("QueueID", queueId), new HashEntry("CorrelationID", correlationId ?? ""),
@@ -72,7 +80,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             var db = GetDb();
             var rawStatus = db.HashGet(HistoryHashKey(queueId), FieldStatus);
             if (!rawStatus.HasValue || (int)rawStatus != (int)MessageHistoryStatus.Enqueued) return;
-            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Processing), new HashEntry(FieldStartedUtc, DateTime.UtcNow.Ticks) });
+            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Processing), new HashEntry(FieldStartedUtc, _getTime.GetCurrentUtcDate().Ticks) });
         }
 
         /// <inheritdoc />
@@ -82,7 +90,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             var db = GetDb();
             var rawStatus = await db.HashGetAsync(HistoryHashKey(queueId), FieldStatus).ConfigureAwait(false);
             if (!rawStatus.HasValue || (int)rawStatus != (int)MessageHistoryStatus.Enqueued) return;
-            await db.HashSetAsync(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Processing), new HashEntry(FieldStartedUtc, DateTime.UtcNow.Ticks) }).ConfigureAwait(false);
+            await db.HashSetAsync(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Processing), new HashEntry(FieldStartedUtc, _getTime.GetCurrentUtcDate().Ticks) }).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -90,7 +98,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             var rawStarted = await db.HashGetAsync(HistoryHashKey(queueId), FieldStartedUtc).ConfigureAwait(false);
             var startedTicks = rawStarted.HasValue ? (long)rawStarted : 0L;
             var durationMs = startedTicks > 0 ? (long)(now - new DateTime(startedTicks, DateTimeKind.Utc)).TotalMilliseconds : 0L;
@@ -111,7 +119,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             var rawStarted = db.HashGet(HistoryHashKey(queueId), FieldStartedUtc);
             var startedTicks = rawStarted.HasValue ? (long)rawStarted : 0L;
             var durationMs = startedTicks > 0 ? (long)(now - new DateTime(startedTicks, DateTimeKind.Utc)).TotalMilliseconds : 0L;
@@ -123,7 +131,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             var rawStarted = await db.HashGetAsync(HistoryHashKey(queueId), FieldStartedUtc).ConfigureAwait(false);
             var startedTicks = rawStarted.HasValue ? (long)rawStarted : 0L;
             var durationMs = startedTicks > 0 ? (long)(now - new DateTime(startedTicks, DateTimeKind.Utc)).TotalMilliseconds : 0L;
@@ -135,7 +143,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             var rawStarted = db.HashGet(HistoryHashKey(queueId), FieldStartedUtc);
             var startedTicks = rawStarted.HasValue ? (long)rawStarted : 0L;
             var durationMs = startedTicks > 0 ? (long)(now - new DateTime(startedTicks, DateTimeKind.Utc)).TotalMilliseconds : 0L;
@@ -156,7 +164,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Deleted), new HashEntry(FieldCompletedUtc, DateTime.UtcNow.Ticks) });
+            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Deleted), new HashEntry(FieldCompletedUtc, _getTime.GetCurrentUtcDate().Ticks) });
         }
 
         /// <inheritdoc />
@@ -164,7 +172,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         {
             if (!_options.EnableHistory) return;
             var db = GetDb();
-            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Expired), new HashEntry(FieldCompletedUtc, DateTime.UtcNow.Ticks) });
+            db.HashSet(HistoryHashKey(queueId), new[] { new HashEntry(FieldStatus, (int)MessageHistoryStatus.Expired), new HashEntry(FieldCompletedUtc, _getTime.GetCurrentUtcDate().Ticks) });
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
@@ -33,11 +33,12 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         private readonly IRedisConnection _connection;
         private readonly RedisNames _redisNames;
         private readonly IBaseTransportOptions _options;
-        //Time comes from the configured provider, not the local clock. On SQL Server and PostgreSQL
-        //that is the database server's clock, which is what the rest of the queue's timestamps are on;
-        //history written from an application machine with a drifting clock would otherwise report
-        //durations that disagree with them, or run negative. BaseTime caches an offset, so this costs
-        //no round trip.
+        //Time comes from the configured provider rather than the local clock. On SQL Server and
+        //PostgreSQL that provider is the database server, which is where the rest of the queue's
+        //timestamps come from. History written from an application machine with a drifting clock
+        //would otherwise disagree with the data beside it, and a duration taken from a start and an
+        //end on different clocks can come out negative. BaseTime caches an offset, so this costs no
+        //round trip.
         private readonly IGetTime _getTime;
 
         private string HistoryHashKey(string queueId) => $"{_redisNames.Values}:history:{queueId}";

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/WriteMessageHistoryHandlerTests.cs
@@ -3,7 +3,6 @@ using System.Data;
 using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using NSubstitute;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/WriteMessageHistoryHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/WriteMessageHistoryHandlerTests.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Data.Common;
 using DotNetWorkQueue.Transport.RelationalDatabase.Basic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using NSubstitute;
 
 namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
@@ -10,6 +11,19 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
     [TestClass]
     public class WriteMessageHistoryHandlerTests
     {
+        //deliberately nowhere near the machine clock, so a timestamp taken from DateTime.UtcNow
+        //instead of the provider cannot coincidentally match
+        private static readonly DateTime ProviderNow = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
+        /// <summary>A clock the test controls, standing in for the configured time provider.</summary>
+        private static IGetTimeFactory Clock(DateTime now)
+        {
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(now);
+            var factory = Substitute.For<IGetTimeFactory>();
+            factory.Create().Returns(time);
+            return factory;
+        }
         [TestMethod]
         public void RecordEnqueue_When_Disabled_Does_Not_Open_Connection()
         {
@@ -275,6 +289,41 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             Assert.AreEqual(0L, durationParam.Value);
         }
 
+        [TestMethod]
+        public void RecordEnqueue_TakesTheTimestampFromTheConfiguredProvider()
+        {
+            //on SQL Server and PostgreSQL the provider is the database server's clock, which is what the
+            //rest of the queue's timestamps are on. Taking this one from the application machine instead
+            //makes history disagree with the data beside it, and durations can come out negative
+            var (handler, factory, _) = Create(enabled: true);
+            var parameters = new System.Collections.Generic.List<DbParameter>();
+            var connection = Substitute.For<DbConnection>();
+            var command = Substitute.For<DbCommand>();
+            command.Parameters.Returns(Substitute.For<DbParameterCollection>());
+            command.CreateParameter().Returns(_ =>
+            {
+                var parameter = Substitute.For<DbParameter>();
+                parameters.Add(parameter);
+                return parameter;
+            });
+            connection.CreateCommand().Returns(command);
+            factory.Create().Returns(connection);
+
+            handler.RecordEnqueue("q1", "c1", "route1", "MyType", new byte[] { 1 }, new byte[] { 2 });
+
+            DbParameter enqueued = null;
+            foreach (var parameter in parameters)
+            {
+                if ((string)parameter.ParameterName == "@EnqueuedUtc")
+                {
+                    enqueued = parameter;
+                    break;
+                }
+            }
+            Assert.IsNotNull(enqueued, "Expected an @EnqueuedUtc parameter to have been created");
+            Assert.AreEqual(ProviderNow, enqueued.Value);
+        }
+
         private static (WriteMessageHistoryHandler handler, IDbConnectionFactory factory, IBaseTransportOptions options)
             Create(bool enabled = false)
         {
@@ -286,7 +335,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic
             var options = Substitute.For<IBaseTransportOptions>();
             options.EnableHistory.Returns(enabled);
             options.HistoryOptions.Returns(historyOptions);
-            return (new WriteMessageHistoryHandler(factory, tableNameHelper, options), factory, options);
+            return (new WriteMessageHistoryHandler(factory, tableNameHelper, options, Clock(ProviderNow)), factory, options);
         }
 
         private static (DbConnection connection, DbCommand command) SetupConnection(IDbConnectionFactory factory)

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
@@ -37,11 +37,12 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         private readonly IDbConnectionFactory _connectionFactory;
         private readonly ITableNameHelper _tableNameHelper;
         private readonly IBaseTransportOptions _options;
-        //Time comes from the configured provider, not the local clock. On SQL Server and PostgreSQL
-        //that is the database server's clock, which is what the rest of the queue's timestamps are on;
-        //history written from an application machine with a drifting clock would otherwise report
-        //durations that disagree with them, or run negative. BaseTime caches an offset, so this costs
-        //no round trip.
+        //Time comes from the configured provider rather than the local clock. On SQL Server and
+        //PostgreSQL that provider is the database server, which is where the rest of the queue's
+        //timestamps come from. History written from an application machine with a drifting clock
+        //would otherwise disagree with the data beside it, and a duration taken from a start and an
+        //end on different clocks can come out negative. BaseTime caches an offset, so this costs no
+        //round trip.
         private readonly IGetTime _getTime;
 
         /// <summary>

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
@@ -37,17 +37,25 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         private readonly IDbConnectionFactory _connectionFactory;
         private readonly ITableNameHelper _tableNameHelper;
         private readonly IBaseTransportOptions _options;
+        //Time comes from the configured provider, not the local clock. On SQL Server and PostgreSQL
+        //that is the database server's clock, which is what the rest of the queue's timestamps are on;
+        //history written from an application machine with a drifting clock would otherwise report
+        //durations that disagree with them, or run negative. BaseTime caches an offset, so this costs
+        //no round trip.
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WriteMessageHistoryHandler"/> class.
         /// </summary>
         public WriteMessageHistoryHandler(IDbConnectionFactory connectionFactory,
             ITableNameHelper tableNameHelper,
-            IBaseTransportOptions options)
+            IBaseTransportOptions options,
+            IGetTimeFactory getTimeFactory)
         {
             _connectionFactory = connectionFactory;
             _tableNameHelper = tableNameHelper;
             _options = options;
+            _getTime = getTimeFactory.Create();
         }
 
         /// <inheritdoc />
@@ -67,7 +75,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                     AddParameter(command, QueueIdParameter, DbType.String, queueId);
                     AddParameter(command, "@CorrelationID", DbType.String, (object)correlationId ?? DBNull.Value);
                     AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Enqueued);
-                    AddParameter(command, "@EnqueuedUtc", DbType.DateTime, DateTime.UtcNow);
+                    AddParameter(command, "@EnqueuedUtc", DbType.DateTime, _getTime.GetCurrentUtcDate());
                     AddParameter(command, "@Route", DbType.String, (object)route ?? DBNull.Value);
                     AddParameter(command, "@MessageType", DbType.String, (object)messageType ?? DBNull.Value);
                     AddParameter(command, "@Body", DbType.Binary, _options.HistoryOptions.StoreBody ? (object)body ?? DBNull.Value : DBNull.Value);
@@ -92,7 +100,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         WHERE QueueID = @QueueID AND Status = @PrevStatus";
 
                     AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Processing);
-                    AddParameter(command, "@StartedUtc", DbType.DateTime, DateTime.UtcNow);
+                    AddParameter(command, "@StartedUtc", DbType.DateTime, _getTime.GetCurrentUtcDate());
                     AddParameter(command, QueueIdParameter, DbType.String, queueId);
                     AddParameter(command, PrevStatusParameter, DbType.Int32, (int)MessageHistoryStatus.Enqueued);
 
@@ -122,7 +130,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         WHERE QueueID = @QueueID AND Status = @PrevStatus";
 
                     AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Processing);
-                    AddParameter(command, "@StartedUtc", DbType.DateTime, DateTime.UtcNow);
+                    AddParameter(command, "@StartedUtc", DbType.DateTime, _getTime.GetCurrentUtcDate());
                     AddParameter(command, QueueIdParameter, DbType.String, queueId);
                     AddParameter(command, PrevStatusParameter, DbType.Int32, (int)MessageHistoryStatus.Enqueued);
 
@@ -136,7 +144,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         public async Task RecordCompleteAsync(string queueId)
         {
             if (!_options.EnableHistory) return;
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             using (var connection = _connectionFactory.Create())
             {
                 await connection.OpenAsync().ConfigureAwait(false);
@@ -199,7 +207,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         public void RecordComplete(string queueId)
         {
             if (!_options.EnableHistory) return;
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             using (var connection = _connectionFactory.Create())
             {
                 connection.Open();
@@ -263,7 +271,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         public async Task RecordErrorAsync(string queueId, string exception)
         {
             if (!_options.EnableHistory) return;
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             using (var connection = _connectionFactory.Create())
             {
                 await connection.OpenAsync().ConfigureAwait(false);
@@ -282,7 +290,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
         public void RecordError(string queueId, string exception)
         {
             if (!_options.EnableHistory) return;
-            var now = DateTime.UtcNow;
+            var now = _getTime.GetCurrentUtcDate();
             using (var connection = _connectionFactory.Create())
             {
                 connection.Open();
@@ -332,7 +340,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         WHERE QueueID = @QueueID";
 
                     AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Deleted);
-                    AddParameter(command, CompletedUtcParameter, DbType.DateTime, DateTime.UtcNow);
+                    AddParameter(command, CompletedUtcParameter, DbType.DateTime, _getTime.GetCurrentUtcDate());
                     AddParameter(command, QueueIdParameter, DbType.String, queueId);
 
                     command.ExecuteNonQuery();
@@ -354,7 +362,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                         WHERE QueueID = @QueueID";
 
                     AddParameter(command, StatusParameter, DbType.Int32, (int)MessageHistoryStatus.Expired);
-                    AddParameter(command, CompletedUtcParameter, DbType.DateTime, DateTime.UtcNow);
+                    AddParameter(command, CompletedUtcParameter, DbType.DateTime, _getTime.GetCurrentUtcDate());
                     AddParameter(command, QueueIdParameter, DbType.String, queueId);
 
                     command.ExecuteNonQuery();

--- a/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/History/SimpleHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/History/SimpleHistoryTests.cs
@@ -47,5 +47,22 @@ namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.History
                     Helpers.GenerateData, Helpers.Verify);
             }
         }
+
+        [TestMethod]
+        public void HistoryTimestampComesFromTheConfiguredTimeProvider()
+        {
+            using (var connectionInfo = new IntegrationConnectionInfo(false))
+            {
+                var queueName = GenerateQueueName.Create();
+                var test = new HistoryTimeProviderTest();
+                test.Run<SqLiteMessageQueueInit, SqLiteMessageQueueCreation>(
+                    new QueueConnection(queueName, connectionInfo.ConnectionString),
+                    x =>
+                    {
+                        Helpers.SetOptions(x, true, false, false, false, false, false, false);
+                        x.Options.EnableHistory = true;
+                    });
+            }
+        }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/History/SimpleHistoryTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SqlServer.IntegrationTests/History/SimpleHistoryTests.cs
@@ -45,5 +45,19 @@ namespace DotNetWorkQueue.Transport.SqlServer.IntegrationTests.History
                 },
                 Helpers.GenerateData, Helpers.Verify);
         }
+
+        [TestMethod]
+        public void HistoryTimestampComesFromTheConfiguredTimeProvider()
+        {
+            var queueName = GenerateQueueName.Create();
+            var test = new HistoryTimeProviderTest();
+            test.Run<SqlServerMessageQueueInit, SqlServerMessageQueueCreation>(
+                new QueueConnection(queueName, ConnectionInfo.ConnectionString),
+                x =>
+                {
+                    Helpers.SetOptions(x, true, false, false, false, false, false, true, false);
+                    x.Options.EnableHistory = true;
+                });
+        }
     }
 }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
@@ -33,11 +33,12 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
 
         private readonly IConnectionInformation _connectionInformation;
         private readonly IBaseTransportOptions _options;
-        //Time comes from the configured provider, not the local clock. On SQL Server and PostgreSQL
-        //that is the database server's clock, which is what the rest of the queue's timestamps are on;
-        //history written from an application machine with a drifting clock would otherwise report
-        //durations that disagree with them, or run negative. BaseTime caches an offset, so this costs
-        //no round trip.
+        //Time comes from the configured provider rather than the local clock. On SQL Server and
+        //PostgreSQL that provider is the database server, which is where the rest of the queue's
+        //timestamps come from. History written from an application machine with a drifting clock
+        //would otherwise disagree with the data beside it, and a duration taken from a start and an
+        //end on different clocks can come out negative. BaseTime caches an offset, so this costs no
+        //round trip.
         private readonly IGetTime _getTime;
 
         /// <inheritdoc />

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
@@ -33,12 +33,20 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
 
         private readonly IConnectionInformation _connectionInformation;
         private readonly IBaseTransportOptions _options;
+        //Time comes from the configured provider, not the local clock. On SQL Server and PostgreSQL
+        //that is the database server's clock, which is what the rest of the queue's timestamps are on;
+        //history written from an application machine with a drifting clock would otherwise report
+        //durations that disagree with them, or run negative. BaseTime caches an offset, so this costs
+        //no round trip.
+        private readonly IGetTime _getTime;
 
         /// <inheritdoc />
-        public WriteMessageHistoryHandler(IConnectionInformation connectionInformation, IBaseTransportOptions options)
+        public WriteMessageHistoryHandler(IConnectionInformation connectionInformation, IBaseTransportOptions options,
+            IGetTimeFactory getTimeFactory)
         {
             _connectionInformation = connectionInformation;
             _options = options;
+            _getTime = getTimeFactory.Create();
         }
 
         /// <inheritdoc />
@@ -49,7 +57,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
             records[queueId] = new MessageHistoryRecord
             {
                 QueueId = queueId, CorrelationId = correlationId, Status = MessageHistoryStatus.Enqueued,
-                EnqueuedUtc = DateTime.UtcNow, RetryCount = 0, Route = route, MessageType = messageType,
+                EnqueuedUtc = _getTime.GetCurrentUtcDate(), RetryCount = 0, Route = route, MessageType = messageType,
                 Body = _options.HistoryOptions.StoreBody ? body : null, Headers = _options.HistoryOptions.StoreBody ? headers : null
             };
         }
@@ -58,7 +66,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         public void RecordProcessingStart(string queueId)
         {
             if (!_options.EnableHistory) return;
-            if (GetRecords().TryGetValue(queueId, out var r) && r.Status == MessageHistoryStatus.Enqueued) { r.Status = MessageHistoryStatus.Processing; r.StartedUtc = DateTime.UtcNow; }
+            if (GetRecords().TryGetValue(queueId, out var r) && r.Status == MessageHistoryStatus.Enqueued) { r.Status = MessageHistoryStatus.Processing; r.StartedUtc = _getTime.GetCurrentUtcDate(); }
         }
 
         /// <inheritdoc />
@@ -102,7 +110,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
             if (!_options.EnableHistory) return;
             if (GetRecords().TryGetValue(queueId, out var r))
             {
-                var now = DateTime.UtcNow;
+                var now = _getTime.GetCurrentUtcDate();
                 r.Status = MessageHistoryStatus.Complete; r.CompletedUtc = now;
                 if (r.StartedUtc.HasValue) r.DurationMs = (long)(now - r.StartedUtc.Value).TotalMilliseconds;
                 else r.DurationMs = 0;
@@ -115,7 +123,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
             if (!_options.EnableHistory) return;
             if (GetRecords().TryGetValue(queueId, out var r))
             {
-                var now = DateTime.UtcNow;
+                var now = _getTime.GetCurrentUtcDate();
                 r.Status = MessageHistoryStatus.Error; r.CompletedUtc = now; r.ExceptionText = exception;
                 if (r.StartedUtc.HasValue) r.DurationMs = (long)(now - r.StartedUtc.Value).TotalMilliseconds;
                 else r.DurationMs = 0;
@@ -134,14 +142,14 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         public void RecordDelete(string queueId)
         {
             if (!_options.EnableHistory) return;
-            if (GetRecords().TryGetValue(queueId, out var r)) { r.Status = MessageHistoryStatus.Deleted; r.CompletedUtc = DateTime.UtcNow; }
+            if (GetRecords().TryGetValue(queueId, out var r)) { r.Status = MessageHistoryStatus.Deleted; r.CompletedUtc = _getTime.GetCurrentUtcDate(); }
         }
 
         /// <inheritdoc />
         public void RecordExpire(string queueId)
         {
             if (!_options.EnableHistory) return;
-            if (GetRecords().TryGetValue(queueId, out var r)) { r.Status = MessageHistoryStatus.Expired; r.CompletedUtc = DateTime.UtcNow; }
+            if (GetRecords().TryGetValue(queueId, out var r)) { r.Status = MessageHistoryStatus.Expired; r.CompletedUtc = _getTime.GetCurrentUtcDate(); }
         }
 
         internal static ConcurrentDictionary<string, MessageHistoryRecord> GetRecordsForQueue(string key)


### PR DESCRIPTION
The queue lets a user choose where time comes from — `IGetTime` is registered per transport, and on SQL Server and PostgreSQL the default is the **database server's** clock, not the local one. The four `WriteMessageHistoryHandler`s ignored that and called `DateTime.UtcNow`, 36 calls between them.

The effect is not that local time is wrong — it is the default on some transports — but that these timestamps land beside data written on a different clock. History written from an application machine that drifts from the database server can record a `StartedUtc` later than its `CompletedUtc`, and `DurationMs` is derived by subtracting the two.

## What changed

`Transport.RelationalDatabase`, `Transport.Redis`, `Transport.LiteDB` and `Transport/Memory` history handlers take `IGetTimeFactory` and hold the `IGetTime` it creates, the same shape `HeartBeatWorker` uses. `BaseTime` caches an offset against the local clock and refreshes periodically, so none of these calls costs a round trip.

## Where to look

The constructor change is the only behavioural decision here: the `IGetTime` is resolved once and held, rather than resolved per call. These handlers are registered `LifeStyles.Singleton`, and container verification passes on every transport.

## Tests

The existing unit tests constructed these handlers directly and asserted only that a timestamp was present and not in the future — which `DateTime.UtcNow` satisfies, so they could not tell the two sources apart. They now drive a clock fixed at a date nowhere near the machine's and assert the stored value equals it, on all four transports. Each fails if the handler is put back on `DateTime.UtcNow`.

Validated: all nine unit suites (1,192 core, 276/198/183/242/212/180/36 transports, 222 dashboard), history integration on Memory, SQLite, LiteDB, PostgreSQL, SQL Server and Redis, and a `Release -p:CI=true` build.

## Scope

First item of #304 and does not close it. Still outstanding there: the dashboard stale-message queries, LiteDB's send and heartbeat paths, and the monitors and job scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Message history timestamps now use the queue’s configured time provider across supported transports.
  - Improved consistency between history timestamps, queue timestamps, and duration calculations.
  - Prevented negative durations caused by differences between machine and queue clocks.

- **Breaking Changes**
  - Directly constructed or subclassed history handlers must now provide a time-provider factory. Queues created through the container are unaffected.

- **Tests**
  - Added coverage verifying configured provider timestamps across memory, LiteDB, Redis, and relational database transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->