### PR TITLE
The rest of the timestamps that bypassed the time provider (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ﻿### Unreleased
+- Fix: the dashboard's stale-message threshold, the history retention cut-off and LiteDB's send, receive and heartbeat timestamps come from the queue's configured time provider rather than the machine clock, so each is compared against data written on the same clock (GitHub #304)
+- ⚠️ Monitors, `DataStorage` and LiteDB's command and query handlers take an `IGetTimeFactory`. Only affects code that constructs or subclasses these directly (GitHub #304)
 - Fix: message history timestamps come from the queue's configured time provider rather than the machine clock. On SQL Server and PostgreSQL that is the database server's clock, so history agrees with the rest of the queue's timestamps and durations cannot read negative (GitHub #304)
 - ⚠️ `WriteMessageHistoryHandler` constructors take an `IGetTimeFactory` on every transport. Only affects code that constructs or subclasses these directly; queues built through the container are unaffected (GitHub #304)
 - ⚠️ Fix: two failures arriving at once each added an error row, so a message got more retries than configured and could loop instead of reaching the error queue. Re-create an existing SQL Server, PostgreSQL or SQLite queue to pick up the fix (GitHub #299)

--- a/Source/DotNetWorkQueue.Tests/Queue/BaseMonitorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/BaseMonitorTests.cs
@@ -15,6 +15,9 @@ namespace DotNetWorkQueue.Tests.Queue
     [TestClass]
     public class BaseMonitorTests
     {
+        /// <summary>A date nowhere near the machine clock, so a value from the wrong source cannot match.</summary>
+        internal static readonly DateTime FixedNow = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
         [TestMethod]
         public void IsDisposed_False_By_Default()
         {
@@ -52,6 +55,22 @@ namespace DotNetWorkQueue.Tests.Queue
                 Thread.Sleep(3000);
             }
             Assert.ContainsSingle(action.ReceivedCalls());
+        }
+
+        [TestMethod]
+        public void LastRunUtc_ComesFromTheConfiguredTimeProvider()
+        {
+            //shown on the dashboard beside timestamps the transport wrote, so it is on the same clock
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
+            var action = Substitute.For<Func<CancellationToken, long>>();
+            var monitor = Substitute.For<IMonitorTimespan>();
+            monitor.MonitorTime.Returns(TimeSpan.FromHours(1));
+            using (var test = CreateMonitor(action, monitor, fixture.Create<ILogger>()))
+            {
+                test.Start();
+                Thread.Sleep(3000);
+                Assert.AreEqual(FixedNow, test.LastRunUtc);
+            }
         }
 
         [TestMethod]
@@ -151,7 +170,7 @@ namespace DotNetWorkQueue.Tests.Queue
         private static IGetTimeFactory FixedClock()
         {
             var time = Substitute.For<IGetTime>();
-            time.GetCurrentUtcDate().Returns(new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc));
+            time.GetCurrentUtcDate().Returns(BaseMonitorTests.FixedNow);
             var factory = Substitute.For<IGetTimeFactory>();
             factory.Create().Returns(time);
             return factory;

--- a/Source/DotNetWorkQueue.Tests/Queue/BaseMonitorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/BaseMonitorTests.cs
@@ -148,8 +148,17 @@ namespace DotNetWorkQueue.Tests.Queue
 
     internal class BaseMonitorTest : BaseMonitor
     {
+        private static IGetTimeFactory FixedClock()
+        {
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc));
+            var factory = Substitute.For<IGetTimeFactory>();
+            factory.Create().Returns(time);
+            return factory;
+        }
+
         public BaseMonitorTest(Func<CancellationToken, long> monitorAction, IMonitorTimespan monitorTimeSpan, ILogger log)
-            : base(monitorAction, monitorTimeSpan, log)
+            : base(monitorAction, monitorTimeSpan, log, FixedClock())
         {
 
         }

--- a/Source/DotNetWorkQueue.Tests/Queue/ClearHistoryMonitorTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Queue/ClearHistoryMonitorTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using DotNetWorkQueue.Queue;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace DotNetWorkQueue.Tests.Queue
+{
+    [TestClass]
+    public class ClearHistoryMonitorTests
+    {
+        private static readonly DateTime FixedNow = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
+        [TestMethod]
+        public void PurgeCutoff_ComesFromTheConfiguredTimeProvider()
+        {
+            //the cut-off is compared against timestamps the transport wrote. Taken from this machine
+            //instead, the retention window moves by the difference between the two clocks - so records
+            //are kept too long, or deleted early
+            const int retentionDays = 30;
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
+
+            var historyOptions = Substitute.For<IHistoryTransportOptions>();
+            historyOptions.RetentionDays.Returns(retentionDays);
+            historyOptions.MonitorTime.Returns(TimeSpan.FromHours(1));
+            var options = Substitute.For<IBaseTransportOptions>();
+            options.HistoryOptions.Returns(historyOptions);
+
+            var purge = Substitute.For<IPurgeMessageHistory>();
+
+            using (var monitor = new ClearHistoryMonitor(options, purge, fixture.Create<ILogger>(), FixedClock()))
+            {
+                monitor.Start();
+                Thread.Sleep(3000);
+            }
+
+            purge.Received(1).Purge(FixedNow.AddDays(-retentionDays));
+        }
+
+        private static IGetTimeFactory FixedClock()
+        {
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(FixedNow);
+            var factory = Substitute.For<IGetTimeFactory>();
+            factory.Create().Returns(time);
+            return factory;
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Tests/Transport/Memory/DataStorageTests.cs
+++ b/Source/DotNetWorkQueue.Tests/Transport/Memory/DataStorageTests.cs
@@ -74,6 +74,9 @@ namespace DotNetWorkQueue.Tests.Transport.Memory
             test.Dispose();
         }
 
+        /// <summary>A date far from any machine clock, so a timestamp from the wrong source cannot match.</summary>
+        private static readonly DateTime ProviderNow = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
         private static DataStorage Create(IMessageFactory messageFactory)
         {
             var jobSchedulerMetaData = Substitute.For<IJobSchedulerMetaData>();
@@ -83,9 +86,14 @@ namespace DotNetWorkQueue.Tests.Transport.Memory
             var connection = new DotNetWorkQueue.Transport.Memory.ConnectionInformation(
                 new QueueConnection("dataStorageTests" + Guid.NewGuid().ToString("N"), "memory"));
 
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(ProviderNow);
+            var timeFactory = Substitute.For<IGetTimeFactory>();
+            timeFactory.Create().Returns(time);
+
             return new DataStorage(jobSchedulerMetaData, connection,
                 Substitute.For<IReceivedMessageFactory>(), messageFactory,
-                Substitute.For<IQueueCancelWork>());
+                Substitute.For<IQueueCancelWork>(), timeFactory);
         }
 
         private static IMessageFactory MessageFactory()

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandler.cs
@@ -51,6 +51,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             TableNameHelper tableNameHelper,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandler.cs
@@ -33,6 +33,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         private readonly LiteDbConnectionManager _connectionInformation;
         private readonly TableNameHelper _tableNameHelper;
         private readonly Lazy<LiteDbMessageQueueTransportOptions> _options;
+        //LiteDB is embedded, so the configured provider is normally the local clock anyway - but
+        //these values are stored and compared against each other, so they take whichever clock
+        //the queue was told to use rather than going around it
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MoveRecordToErrorQueueCommandHandler"/> class.
@@ -40,11 +44,14 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         /// <param name="optionsFactory">The options factory.</param>
         /// <param name="connectionInformation">The connection information.</param>
         /// <param name="tableNameHelper">The table name helper.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public MoveRecordToErrorQueueCommandHandler(
             ILiteDbMessageQueueTransportOptionsFactory optionsFactory,
             LiteDbConnectionManager connectionInformation,
-            TableNameHelper tableNameHelper)
+            TableNameHelper tableNameHelper,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
             Guard.NotNull(optionsFactory);
@@ -73,7 +80,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
                         //move record to error table
                         var errorRecord = new MetaDataErrorsTable()
                         {
-                            LastExceptionDate = DateTime.UtcNow,
+                            LastExceptionDate = _getTime.GetCurrentUtcDate(),
                             LastException = command.Exception.ToString(),
                             QueueId = results[0].QueueId,
                             Status = QueueStatuses.Error,

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendHeartBeatCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendHeartBeatCommandHandler.cs
@@ -44,6 +44,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             TableNameHelper tableNameHelper,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendHeartBeatCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendHeartBeatCommandHandler.cs
@@ -32,13 +32,19 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
     {
         private readonly LiteDbConnectionManager _connectionInformation;
         private readonly TableNameHelper _tableNameHelper;
+        //LiteDB is embedded, so the configured provider is normally the local clock anyway - but
+        //these values are stored and compared against each other, so they take whichever clock
+        //the queue was told to use rather than going around it
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SendHeartBeatCommandHandler" /> class.
         /// </summary>
         public SendHeartBeatCommandHandler(LiteDbConnectionManager connectionInformation,
-            TableNameHelper tableNameHelper)
+            TableNameHelper tableNameHelper,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
 
@@ -65,7 +71,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
                     if (results.Count == 1)
                     {
                         var record = results[0];
-                        date = DateTime.UtcNow;
+                        date = _getTime.GetCurrentUtcDate();
                         record.HeartBeat = date;
                         col.Update(record);
                     }

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandBatchShared.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandBatchShared.cs
@@ -54,6 +54,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         private readonly IJobSchedulerMetaData _jobSchedulerMetaData;
         private readonly ISentMessageFactory _sentMessageFactory;
         private readonly DatabaseExists _databaseExists;
+        //LiteDB is embedded, so the configured provider is normally the local clock anyway - but
+        //these values are stored and compared against each other, so they take whichever clock
+        //the queue was told to use rather than going around it
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SendMessageCommandBatchShared"/> class.
@@ -65,8 +69,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             IHeaders headers,
             IJobSchedulerMetaData jobSchedulerMetaData,
             ISentMessageFactory sentMessageFactory,
-            DatabaseExists databaseExists)
+            DatabaseExists databaseExists,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
             Guard.NotNull(serializer);
@@ -182,21 +188,21 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             {
                 QueueId = id,
                 CorrelationId = (Guid)message.MessageData.CorrelationId.Id.Value,
-                QueuedDateTime = DateTime.UtcNow
+                QueuedDateTime = _getTime.GetCurrentUtcDate()
             };
 
             if (_options.Value.EnableDelayedProcessing)
             {
                 var delay = message.MessageData.GetDelay();
                 if (delay.HasValue)
-                    metaData.QueueProcessTime = DateTime.UtcNow.Add(delay.Value);
+                    metaData.QueueProcessTime = _getTime.GetCurrentUtcDate().Add(delay.Value);
             }
 
             if (_options.Value.EnableMessageExpiration)
             {
                 var expiration = message.MessageData.GetExpiration();
                 if (expiration.HasValue)
-                    metaData.ExpirationTime = DateTime.UtcNow.Add(expiration.Value);
+                    metaData.ExpirationTime = _getTime.GetCurrentUtcDate().Add(expiration.Value);
             }
 
             if (_options.Value.EnableStatus)

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandBatchShared.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandBatchShared.cs
@@ -72,6 +72,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             DatabaseExists databaseExists,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandler.cs
@@ -49,6 +49,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
 
         private readonly IJobSchedulerMetaData _jobSchedulerMetaData;
         private readonly DatabaseExists _databaseExists;
+        //LiteDB is embedded, so the configured provider is normally the local clock anyway - but
+        //these values are stored and compared against each other, so they take whichever clock
+        //the queue was told to use rather than going around it
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SendMessageCommandHandler"/> class.
@@ -62,6 +66,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         /// <param name="jobExistsHandler">The job exists handler.</param>
         /// <param name="jobSchedulerMetaData">The job scheduler meta data.</param>
         /// <param name="databaseExists">The database exists.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public SendMessageCommandHandler(
             LiteDbConnectionManager connectionInformation,
             TableNameHelper tableNameHelper,
@@ -71,8 +76,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             ICommandHandler<SetJobLastKnownEventCommand> sendJobStatus,
             IQueryHandler<DoesJobExistQuery, QueueStatuses> jobExistsHandler,
             IJobSchedulerMetaData jobSchedulerMetaData,
-            DatabaseExists databaseExists)
+            DatabaseExists databaseExists,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
             Guard.NotNull(serializer);
@@ -160,7 +167,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
                             {
                                 QueueId = id,
                                 CorrelationId = (Guid)commandSend.MessageData.CorrelationId.Id.Value,
-                                QueuedDateTime = DateTime.UtcNow
+                                QueuedDateTime = _getTime.GetCurrentUtcDate()
                             };
 
                             if (!string.IsNullOrWhiteSpace(jobName))
@@ -172,12 +179,12 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
                                 var delay = commandSend.MessageData.GetDelay();
                                 if (delay.HasValue)
                                 {
-                                    metaData.QueueProcessTime = DateTime.UtcNow.Add(delay.Value);
+                                    metaData.QueueProcessTime = _getTime.GetCurrentUtcDate().Add(delay.Value);
                                 }
                             }
 
                             if (_options.Value.EnableMessageExpiration && expiration.HasValue)
-                                metaData.ExpirationTime = DateTime.UtcNow.Add(expiration.Value);
+                                metaData.ExpirationTime = _getTime.GetCurrentUtcDate().Add(expiration.Value);
 
                             if (_options.Value.EnableStatus)
                                 metaData.Status = QueueStatuses.Waiting;

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandler.cs
@@ -79,6 +79,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             DatabaseExists databaseExists,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -76,6 +76,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             DatabaseExists databaseExists,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/SendMessageCommandHandlerAsync.cs
@@ -47,6 +47,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         private readonly IQueryHandler<DoesJobExistQuery, QueueStatuses> _jobExistsHandler;
         private readonly IJobSchedulerMetaData _jobSchedulerMetaData;
         private readonly DatabaseExists _databaseExists;
+        //LiteDB is embedded, so the configured provider is normally the local clock anyway - but
+        //these values are stored and compared against each other, so they take whichever clock
+        //the queue was told to use rather than going around it
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SendMessageCommandHandlerAsync"/> class.
@@ -60,6 +64,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         /// <param name="jobExistsHandler">The job exists handler.</param>
         /// <param name="jobSchedulerMetaData">The job scheduler meta data.</param>
         /// <param name="databaseExists">The database exists.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public SendMessageCommandHandlerAsync(
             LiteDbConnectionManager connectionInformation,
             TableNameHelper tableNameHelper,
@@ -68,8 +73,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             IHeaders headers,
             ICommandHandler<SetJobLastKnownEventCommand> sendJobStatus, IQueryHandler<DoesJobExistQuery, QueueStatuses> jobExistsHandler,
             IJobSchedulerMetaData jobSchedulerMetaData,
-            DatabaseExists databaseExists)
+            DatabaseExists databaseExists,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
             Guard.NotNull(serializer);
@@ -163,7 +170,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
                                 {
                                     QueueId = id,
                                     CorrelationId = (Guid)commandSend.MessageData.CorrelationId.Id.Value,
-                                    QueuedDateTime = DateTime.UtcNow
+                                    QueuedDateTime = _getTime.GetCurrentUtcDate()
                                 };
 
                                 if (!string.IsNullOrWhiteSpace(jobName))
@@ -175,12 +182,12 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
                                     var delay = commandSend.MessageData.GetDelay();
                                     if (delay.HasValue)
                                     {
-                                        metaData.QueueProcessTime = DateTime.UtcNow.Add(delay.Value);
+                                        metaData.QueueProcessTime = _getTime.GetCurrentUtcDate().Add(delay.Value);
                                     }
                                 }
 
                                 if (_options.Value.EnableMessageExpiration && expiration.HasValue)
-                                    metaData.ExpirationTime = DateTime.UtcNow.Add(expiration.Value);
+                                    metaData.ExpirationTime = _getTime.GetCurrentUtcDate().Add(expiration.Value);
 
                                 if (_options.Value.EnableStatus)
                                     metaData.Status = QueueStatuses.Waiting;

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindErrorRecordsToDeleteQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindErrorRecordsToDeleteQueryHandler.cs
@@ -34,6 +34,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
         private readonly LiteDbConnectionManager _connectionInformation;
         private readonly TableNameHelper _tableNameHelper;
         private readonly IMessageErrorConfiguration _configuration;
+        //LiteDB is embedded, so the configured provider is normally the local clock anyway - but
+        //these values are stored and compared against each other, so they take whichever clock
+        //the queue was told to use rather than going around it
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FindErrorRecordsToDeleteQueryHandler"/> class.
@@ -41,10 +45,13 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
         /// <param name="connectionInformation">The connection information.</param>
         /// <param name="tableNameHelper">The table name helper.</param>
         /// <param name="configuration">The configuration.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public FindErrorRecordsToDeleteQueryHandler(LiteDbConnectionManager connectionInformation,
             TableNameHelper tableNameHelper,
-            IMessageErrorConfiguration configuration)
+            IMessageErrorConfiguration configuration,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
             Guard.NotNull(configuration);
@@ -73,7 +80,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
 
                 var col = db.Database.GetCollection<Schema.MetaDataErrorsTable>(_tableNameHelper.MetaDataErrorsName);
 
-                var date = DateTime.UtcNow.Subtract(_configuration.MessageAge);
+                var date = _getTime.GetCurrentUtcDate().Subtract(_configuration.MessageAge);
                 var results = col.Query()
                     .Where(x => x.LastExceptionDate < date)
                     .ToList();

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindErrorRecordsToDeleteQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindErrorRecordsToDeleteQueryHandler.cs
@@ -51,6 +51,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
             IMessageErrorConfiguration configuration,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindExpiredRecordsToDeleteQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindExpiredRecordsToDeleteQueryHandler.cs
@@ -48,6 +48,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
             TableNameHelper tableNameHelper,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
@@ -74,8 +75,12 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
 
                 var col = db.Database.GetCollection<Schema.MetaDataTable>(_tableNameHelper.MetaDataName);
 
+                //read once, outside the expression - the sibling handlers do the same. LiteDB does
+                //translate the call in place, but one reading for the whole sweep is what is meant
+                var now = _getTime.GetCurrentUtcDate();
+
                 var results = col.Query()
-                    .Where(x => x.ExpirationTime < _getTime.GetCurrentUtcDate())
+                    .Where(x => x.ExpirationTime < now)
                     .ToList();
 
                 var data = new List<int>(results.Count);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindExpiredRecordsToDeleteQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindExpiredRecordsToDeleteQueryHandler.cs
@@ -33,15 +33,22 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
     {
         private readonly LiteDbConnectionManager _connectionInformation;
         private readonly TableNameHelper _tableNameHelper;
+        //LiteDB is embedded, so the configured provider is normally the local clock anyway - but
+        //these values are stored and compared against each other, so they take whichever clock
+        //the queue was told to use rather than going around it
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FindExpiredRecordsToDeleteQueryHandler"/> class.
         /// </summary>
         /// <param name="connectionInformation">The connection information.</param>
         /// <param name="tableNameHelper">The table name helper.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public FindExpiredRecordsToDeleteQueryHandler(LiteDbConnectionManager connectionInformation,
-            TableNameHelper tableNameHelper)
+            TableNameHelper tableNameHelper,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
 
@@ -68,7 +75,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
                 var col = db.Database.GetCollection<Schema.MetaDataTable>(_tableNameHelper.MetaDataName);
 
                 var results = col.Query()
-                    .Where(x => x.ExpirationTime < DateTime.UtcNow)
+                    .Where(x => x.ExpirationTime < _getTime.GetCurrentUtcDate())
                     .ToList();
 
                 var data = new List<int>(results.Count);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindRecordsToResetByHeartBeatQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindRecordsToResetByHeartBeatQueryHandler.cs
@@ -36,6 +36,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
         private readonly TableNameHelper _tableNameHelper;
         private readonly IHeartBeatConfiguration _configuration;
         private readonly ICompositeSerialization _serialization;
+        //LiteDB is embedded, so the configured provider is normally the local clock anyway - but
+        //these values are stored and compared against each other, so they take whichever clock
+        //the queue was told to use rather than going around it
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FindRecordsToResetByHeartBeatQueryHandler"/> class.
@@ -44,11 +48,14 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
         /// <param name="tableNameHelper">The table name helper.</param>
         /// <param name="configuration">The configuration.</param>
         /// <param name="serialization">The serialization.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public FindRecordsToResetByHeartBeatQueryHandler(LiteDbConnectionManager connectionInformation,
             TableNameHelper tableNameHelper,
             IHeartBeatConfiguration configuration,
-            ICompositeSerialization serialization)
+            ICompositeSerialization serialization,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
             Guard.NotNull(configuration);
@@ -78,7 +85,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
                 }
 
                 var col = db.Database.GetCollection<Schema.MetaDataTable>(_tableNameHelper.MetaDataName);
-                var date = DateTime.UtcNow.Subtract(_configuration.Time);
+                var date = _getTime.GetCurrentUtcDate().Subtract(_configuration.Time);
 
                 var results = col.Query()
                     .Where(x => x.Status == QueueStatuses.Processing)

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindRecordsToResetByHeartBeatQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/FindRecordsToResetByHeartBeatQueryHandler.cs
@@ -55,6 +55,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
             ICompositeSerialization serialization,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
@@ -42,6 +42,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
 
             _connectionInformation = connectionInformation;
             _tableNameHelper = tableNameHelper;
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
         }
 

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
@@ -30,21 +30,24 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
     {
         private readonly LiteDbConnectionManager _connectionInformation;
         private readonly TableNameHelper _tableNameHelper;
+        //Staleness is measured against heartbeats the transport wrote, so the cut-off has to come from the clock that wrote them rather than this machine's.
+        private readonly IGetTime _getTime;
 
-        public GetDashboardStaleMessagesQueryHandlerAsync(
-            LiteDbConnectionManager connectionInformation,
-            TableNameHelper tableNameHelper)
+        public GetDashboardStaleMessagesQueryHandlerAsync(            LiteDbConnectionManager connectionInformation,
+            TableNameHelper tableNameHelper,
+            IGetTimeFactory getTimeFactory)
         {
             Guard.NotNull(connectionInformation);
             Guard.NotNull(tableNameHelper);
 
             _connectionInformation = connectionInformation;
             _tableNameHelper = tableNameHelper;
+            _getTime = getTimeFactory.Create();
         }
 
         public Task<IReadOnlyList<DashboardMessage>> HandleAsync(GetDashboardStaleMessagesQuery query)
         {
-            var cutoff = DateTime.UtcNow.AddSeconds(-query.ThresholdSeconds);
+            var cutoff = _getTime.GetCurrentUtcDate().AddSeconds(-query.ThresholdSeconds);
 
             using (var db = _connectionInformation.GetDatabase())
             {

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/ReceiveMessageQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/ReceiveMessageQueryHandler.cs
@@ -38,6 +38,10 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
         private readonly LiteDbConnectionManager _connectionInformation;
         private readonly DatabaseExists _databaseExists;
         private readonly MessageDeQueue _messageDeQueue;
+        //LiteDB is embedded, so the configured provider is normally the local clock anyway - but
+        //these values are stored and compared against each other, so they take whichever clock
+        //the queue was told to use rather than going around it
+        private readonly IGetTime _getTime;
 
         /// <summary>
         /// Where the next poll resumes its search. Only ever read or written inside
@@ -53,12 +57,15 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
         /// <param name="connectionInformation">The connection information.</param>
         /// <param name="databaseExists">The database exists.</param>
         /// <param name="messageDeQueue">The message de queue.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public ReceiveMessageQueryHandler(ILiteDbMessageQueueTransportOptionsFactory optionsFactory,
             TableNameHelper tableNameHelper,
             LiteDbConnectionManager connectionInformation,
             DatabaseExists databaseExists,
-            MessageDeQueue messageDeQueue)
+            MessageDeQueue messageDeQueue,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             Guard.NotNull(optionsFactory);
             Guard.NotNull(tableNameHelper);
             Guard.NotNull(databaseExists);
@@ -134,7 +141,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
         private Schema.MetaDataTable FindNextEligible(ReceiveMessageQuery query,
             ILiteCollection<Schema.MetaDataTable> col)
         {
-            var nowUtc = DateTime.UtcNow;
+            var nowUtc = _getTime.GetCurrentUtcDate();
             var routes = _options.Value.EnableRoute && query.Routes != null && query.Routes.Count > 0
                 ? query.Routes
                 : null;
@@ -228,7 +235,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
             var record = FindNextEligible(query, col);
             if (record != null)
             {
-                record.HeartBeat = DateTime.UtcNow;
+                record.HeartBeat = _getTime.GetCurrentUtcDate();
                 record.Status = QueueStatuses.Processing;
 
                 col.Update(record);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/ReceiveMessageQueryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/QueryHandler/ReceiveMessageQueryHandler.cs
@@ -65,6 +65,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.QueryHandler
             MessageDeQueue messageDeQueue,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             Guard.NotNull(optionsFactory);
             Guard.NotNull(tableNameHelper);

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/WriteMessageHistoryHandler.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using DotNetWorkQueue.Validation;
 using System;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
@@ -50,6 +51,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic
             _connectionManager = connectionManager;
             _tableNameHelper = tableNameHelper;
             _options = options;
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
         }
 

--- a/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDb.Tests/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsyncTests.cs
@@ -27,12 +27,21 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
     [TestClass]
     public class GetDashboardStaleMessagesQueryHandlerAsyncTests
     {
+        private static IGetTimeFactory FixedClock()
+        {
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc));
+            var factory = Substitute.For<IGetTimeFactory>();
+            factory.Create().Returns(time);
+            return factory;
+        }
+
         [TestMethod]
         public void Create_Default()
         {
             var connectionManager = CreateConnectionManager();
             var tableNameHelper = CreateTableNameHelper();
-            Assert.IsNotNull(new GetDashboardStaleMessagesQueryHandlerAsync(connectionManager, tableNameHelper));
+            Assert.IsNotNull(new GetDashboardStaleMessagesQueryHandlerAsync(connectionManager, tableNameHelper, FixedClock()));
         }
 
         [TestMethod]
@@ -40,7 +49,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
         {
             var tableNameHelper = CreateTableNameHelper();
             Assert.ThrowsExactly<ArgumentNullException>(
-                () => new GetDashboardStaleMessagesQueryHandlerAsync(null, tableNameHelper));
+                () => new GetDashboardStaleMessagesQueryHandlerAsync(null, tableNameHelper, FixedClock()));
         }
 
         [TestMethod]
@@ -48,7 +57,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Tests.Basic.QueryHandler
         {
             var connectionManager = CreateConnectionManager();
             Assert.ThrowsExactly<ArgumentNullException>(
-                () => new GetDashboardStaleMessagesQueryHandlerAsync(connectionManager, null));
+                () => new GetDashboardStaleMessagesQueryHandlerAsync(connectionManager, null, FixedClock()));
         }
 
         private static LiteDbConnectionManager CreateConnectionManager()

--- a/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsyncTests.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis.Tests/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsyncTests.cs
@@ -27,13 +27,22 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic.QueryHandler
     [TestClass]
     public class GetDashboardStaleMessagesQueryHandlerAsyncTests
     {
+        private static IGetTimeFactory FixedClock()
+        {
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc));
+            var factory = Substitute.For<IGetTimeFactory>();
+            factory.Create().Returns(time);
+            return factory;
+        }
+
         [TestMethod]
         public void Create_Default()
         {
             var connection = Substitute.For<IRedisConnection>();
             var redisNames = Substitute.For<RedisNames>(Substitute.For<IConnectionInformation>());
             var serializer = Substitute.For<IInternalSerializer>();
-            Assert.IsNotNull(new GetDashboardStaleMessagesQueryHandlerAsync(connection, redisNames, serializer));
+            Assert.IsNotNull(new GetDashboardStaleMessagesQueryHandlerAsync(connection, redisNames, serializer, FixedClock()));
         }
 
         [TestMethod]
@@ -42,7 +51,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic.QueryHandler
             var redisNames = Substitute.For<RedisNames>(Substitute.For<IConnectionInformation>());
             var serializer = Substitute.For<IInternalSerializer>();
             Assert.ThrowsExactly<ArgumentNullException>(
-                () => new GetDashboardStaleMessagesQueryHandlerAsync(null, redisNames, serializer));
+                () => new GetDashboardStaleMessagesQueryHandlerAsync(null, redisNames, serializer, FixedClock()));
         }
 
         [TestMethod]
@@ -51,7 +60,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic.QueryHandler
             var connection = Substitute.For<IRedisConnection>();
             var serializer = Substitute.For<IInternalSerializer>();
             Assert.ThrowsExactly<ArgumentNullException>(
-                () => new GetDashboardStaleMessagesQueryHandlerAsync(connection, null, serializer));
+                () => new GetDashboardStaleMessagesQueryHandlerAsync(connection, null, serializer, FixedClock()));
         }
 
         [TestMethod]
@@ -60,7 +69,7 @@ namespace DotNetWorkQueue.Transport.Redis.Tests.Basic.QueryHandler
             var connection = Substitute.For<IRedisConnection>();
             var redisNames = Substitute.For<RedisNames>(Substitute.For<IConnectionInformation>());
             Assert.ThrowsExactly<ArgumentNullException>(
-                () => new GetDashboardStaleMessagesQueryHandlerAsync(connection, redisNames, null));
+                () => new GetDashboardStaleMessagesQueryHandlerAsync(connection, redisNames, null, FixedClock()));
         }
     }
 }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
@@ -46,6 +46,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.QueryHandler
             _connection = connection;
             _redisNames = redisNames;
             _internalSerializer = internalSerializer;
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
         }
 

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/QueryHandler/GetDashboardStaleMessagesQueryHandlerAsync.cs
@@ -31,11 +31,13 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.QueryHandler
         private readonly IRedisConnection _connection;
         private readonly RedisNames _redisNames;
         private readonly IInternalSerializer _internalSerializer;
+        //Staleness is measured against heartbeats the transport wrote, so the cut-off has to come from the clock that wrote them rather than this machine's.
+        private readonly IGetTime _getTime;
 
-        public GetDashboardStaleMessagesQueryHandlerAsync(
-            IRedisConnection connection,
+        public GetDashboardStaleMessagesQueryHandlerAsync(            IRedisConnection connection,
             RedisNames redisNames,
-            IInternalSerializer internalSerializer)
+            IInternalSerializer internalSerializer,
+            IGetTimeFactory getTimeFactory)
         {
             Guard.NotNull(connection);
             Guard.NotNull(redisNames);
@@ -44,12 +46,14 @@ namespace DotNetWorkQueue.Transport.Redis.Basic.QueryHandler
             _connection = connection;
             _redisNames = redisNames;
             _internalSerializer = internalSerializer;
+            _getTime = getTimeFactory.Create();
         }
 
         public Task<IReadOnlyList<DashboardMessage>> HandleAsync(GetDashboardStaleMessagesQuery query)
         {
             var db = _connection.Connection.GetDatabase();
-            var cutoffMs = DateTimeOffset.UtcNow.AddSeconds(-query.ThresholdSeconds).ToUnixTimeMilliseconds();
+            var cutoffMs = new DateTimeOffset(_getTime.GetCurrentUtcDate())
+                .AddSeconds(-query.ThresholdSeconds).ToUnixTimeMilliseconds();
 
             // Get stale message IDs (in Working sorted set with score < cutoff)
             var staleIds = db.SortedSetRangeByScore(_redisNames.Working, 0, cutoffMs,

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisDelayedProcessingMonitor.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/RedisDelayedProcessingMonitor.cs
@@ -37,8 +37,10 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
         /// <param name="action">The action.</param>
         /// <param name="log">The log.</param>
         /// <param name="options">The options.</param>
-        public RedisDelayedProcessingMonitor(IDelayedProcessingAction action, ILogger log, RedisQueueTransportOptions options)
-            : base(Guard.NotNull(action).Run, options.DelayedProcessingConfiguration, log)
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
+        public RedisDelayedProcessingMonitor(IDelayedProcessingAction action, ILogger log, RedisQueueTransportOptions options,
+            IGetTimeFactory getTimeFactory)
+            : base(Guard.NotNull(action).Run, options.DelayedProcessingConfiguration, log, getTimeFactory)
         {
 
         }

--- a/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.Redis/Basic/WriteMessageHistoryHandler.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using DotNetWorkQueue.Validation;
 using System;
 using System.Threading.Tasks;
 using DotNetWorkQueue.Configuration;
@@ -51,6 +52,7 @@ namespace DotNetWorkQueue.Transport.Redis.Basic
             _connection = connection;
             _redisNames = redisNames;
             _options = options;
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
         }
 

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandlerTests.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase.Tests/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandlerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -58,7 +59,34 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Tests.Basic.QueryPrepareH
             var optionsFactory = Substitute.For<ITransportOptionsFactory>();
             var options = Substitute.For<ITransportOptions>();
             optionsFactory.Create().Returns(options);
-            return new GetDashboardStaleMessagesPrepareHandler(cache, optionsFactory);
+            return new GetDashboardStaleMessagesPrepareHandler(cache, optionsFactory, FixedClock());
+        }
+
+        /// <summary>A date far from any machine clock, so a threshold from the wrong source cannot match.</summary>
+        private static readonly DateTime ProviderNow = new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
+        private static IGetTimeFactory FixedClock()
+        {
+            var time = Substitute.For<IGetTime>();
+            time.GetCurrentUtcDate().Returns(ProviderNow);
+            var factory = Substitute.For<IGetTimeFactory>();
+            factory.Create().Returns(time);
+            return factory;
+        }
+
+        [TestMethod]
+        public void Handle_TakesTheThresholdFromTheConfiguredTimeProvider()
+        {
+            //staleness is measured against heartbeats the transport wrote, so the cut-off has to be on
+            //the same clock as those - not on whichever machine happens to be asking
+            var handler = CreateHandler();
+            var command = CreateDbCommand();
+
+            handler.Handle(new GetDashboardStaleMessagesQuery(120, 0, 50), command, CommandStringTypes.GetDashboardStaleMessages);
+
+            var parameters = (DataParameterCollection)command.Parameters;
+            var ticks = parameters.First(p => p.ParameterName == "@ThresholdTicks");
+            Assert.AreEqual(ProviderNow.AddSeconds(-120).Ticks, ticks.Value);
         }
 
         private static DbCommand CreateDbCommand()

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandler.cs
@@ -39,6 +39,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             Guard.NotNull(commandCache);
             Guard.NotNull(optionsFactory);
             _commandCache = commandCache;
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             _dynamicColumns = new Lazy<string>(() => DashboardDynamicColumnHelper.BuildDynamicColumns(optionsFactory.Create()));
         }

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryPrepareHandler/GetDashboardStaleMessagesPrepareHandler.cs
@@ -30,12 +30,16 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
     {
         private readonly CommandStringCache _commandCache;
         private readonly Lazy<string> _dynamicColumns;
+        //Staleness is measured against heartbeats the transport wrote, so the cut-off has to come from the clock that wrote them rather than this machine's.
+        private readonly IGetTime _getTime;
 
-        public GetDashboardStaleMessagesPrepareHandler(CommandStringCache commandCache, ITransportOptionsFactory optionsFactory)
+        public GetDashboardStaleMessagesPrepareHandler(CommandStringCache commandCache, ITransportOptionsFactory optionsFactory,
+            IGetTimeFactory getTimeFactory)
         {
             Guard.NotNull(commandCache);
             Guard.NotNull(optionsFactory);
             _commandCache = commandCache;
+            _getTime = getTimeFactory.Create();
             _dynamicColumns = new Lazy<string>(() => DashboardDynamicColumnHelper.BuildDynamicColumns(optionsFactory.Create()));
         }
 
@@ -52,7 +56,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.QueryPrepareHandler
             var thresholdTicks = dbCommand.CreateParameter();
             thresholdTicks.ParameterName = "@ThresholdTicks";
             thresholdTicks.DbType = DbType.Int64;
-            thresholdTicks.Value = DateTime.UtcNow.AddSeconds(-query.ThresholdSeconds).Ticks;
+            thresholdTicks.Value = _getTime.GetCurrentUtcDate().AddSeconds(-query.ThresholdSeconds).Ticks;
             dbCommand.Parameters.Add(thresholdTicks);
 
             var offset = dbCommand.CreateParameter();

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/WriteMessageHistoryHandler.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using DotNetWorkQueue.Validation;
 using System;
 using System.Data;
 using System.Data.Common;
@@ -56,6 +57,7 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
             _connectionFactory = connectionFactory;
             _tableNameHelper = tableNameHelper;
             _options = options;
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
         }
 

--- a/Source/DotNetWorkQueue/Queue/BaseMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/BaseMonitor.cs
@@ -41,6 +41,9 @@ namespace DotNetWorkQueue.Queue
         private volatile bool _stopping;
         private readonly object _runningLock = new object();
         private readonly ILogger _log;
+        //LastRunUtc is shown on the dashboard beside timestamps the transport wrote, so it comes from
+        //the same clock rather than from whichever machine happens to run the monitor
+        private readonly IGetTime _getTime;
         private readonly object _cancelSync = new object();
         private readonly ManualResetEventSlim _monitorCompleted = new ManualResetEventSlim(true);
         private int _disposeCount;
@@ -51,18 +54,22 @@ namespace DotNetWorkQueue.Queue
         /// <param name="monitorAction">The monitor action.</param>
         /// <param name="monitorTimeSpan">The monitor time span.</param>
         /// <param name="log">The log.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         protected BaseMonitor(Func<CancellationToken, long> monitorAction,
             IMonitorTimespan monitorTimeSpan,
-            ILogger log)
+            ILogger log,
+            IGetTimeFactory getTimeFactory)
         {
             Guard.NotNull(monitorAction);
             Guard.NotNull(monitorTimeSpan);
             Guard.NotNull(log);
+            Guard.NotNull(getTimeFactory);
 
             _monitorAction = monitorAction;
             _monitorActionIds = null;
             _monitorTimeSpan = monitorTimeSpan;
             _log = log;
+            _getTime = getTimeFactory.Create();
         }
 
         /// <summary>
@@ -71,18 +78,22 @@ namespace DotNetWorkQueue.Queue
         /// <param name="monitorAction">The monitor action.</param>
         /// <param name="monitorTimeSpan">The monitor time span.</param>
         /// <param name="log">The log.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         protected BaseMonitor(IMonitorTimespan monitorTimeSpan,
             Func<CancellationToken, List<ResetHeartBeatOutput>> monitorAction,
-            ILogger log)
+            ILogger log,
+            IGetTimeFactory getTimeFactory)
         {
             Guard.NotNull(monitorAction);
             Guard.NotNull(monitorTimeSpan);
             Guard.NotNull(log);
+            Guard.NotNull(getTimeFactory);
 
             _monitorActionIds = monitorAction;
             _monitorAction = null;
             _monitorTimeSpan = monitorTimeSpan;
             _log = log;
+            _getTime = getTimeFactory.Create();
         }
         /// <inheritdoc />
         public DateTime? LastRunUtc { get; private set; }
@@ -139,7 +150,7 @@ namespace DotNetWorkQueue.Queue
             finally
             {
                 CancelTokenDestroy();
-                LastRunUtc = DateTime.UtcNow;
+                LastRunUtc = _getTime.GetCurrentUtcDate();
                 try
                 {
                     Running = false;

--- a/Source/DotNetWorkQueue/Queue/ClearErrorMessagesMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/ClearErrorMessagesMonitor.cs
@@ -38,9 +38,10 @@ namespace DotNetWorkQueue.Queue
         /// <param name="configuration">The configuration.</param>
         /// <param name="clearErrorMessages">The clear messages implementation.</param>
         /// <param name="log">The log.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public ClearErrorMessagesMonitor(IMessageErrorConfiguration configuration,
-            IClearErrorMessages clearErrorMessages, ILogger log)
-            : base(Guard.NotNull(clearErrorMessages).ClearMessages, configuration, log)
+            IClearErrorMessages clearErrorMessages, ILogger log, IGetTimeFactory getTimeFactory)
+            : base(Guard.NotNull(clearErrorMessages).ClearMessages, configuration, log, getTimeFactory)
         {
 
         }

--- a/Source/DotNetWorkQueue/Queue/ClearExpiredMessagesMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/ClearExpiredMessagesMonitor.cs
@@ -36,9 +36,10 @@ namespace DotNetWorkQueue.Queue
         /// <param name="configuration">The configuration.</param>
         /// <param name="clearExpiredMessages">The clear expired messages implementation.</param>
         /// <param name="log">The log.</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public ClearExpiredMessagesMonitor(IMessageExpirationConfiguration configuration,
-            IClearExpiredMessages clearExpiredMessages, ILogger log)
-            : base(Guard.NotNull(clearExpiredMessages).ClearMessages, configuration, log)
+            IClearExpiredMessages clearExpiredMessages, ILogger log, IGetTimeFactory getTimeFactory)
+            : base(Guard.NotNull(clearExpiredMessages).ClearMessages, configuration, log, getTimeFactory)
         {
 
         }

--- a/Source/DotNetWorkQueue/Queue/ClearHistoryMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/ClearHistoryMonitor.cs
@@ -32,19 +32,22 @@ namespace DotNetWorkQueue.Queue
     {
         /// <inheritdoc />
         public ClearHistoryMonitor(IBaseTransportOptions options,
-            IPurgeMessageHistory purgeHistory, ILogger log)
-            : base(CreatePurgeAction(options, Guard.NotNull(purgeHistory)),
-                  new MonitorTimespanWrapper(options.HistoryOptions?.MonitorTime ?? TimeSpan.FromDays(1)), log)
+            IPurgeMessageHistory purgeHistory, ILogger log, IGetTimeFactory getTimeFactory)
+            : base(CreatePurgeAction(options, Guard.NotNull(purgeHistory), Guard.NotNull(getTimeFactory)),
+                  new MonitorTimespanWrapper(options.HistoryOptions?.MonitorTime ?? TimeSpan.FromDays(1)), log, getTimeFactory)
         {
         }
 
         private static Func<CancellationToken, long> CreatePurgeAction(
-            IBaseTransportOptions options, IPurgeMessageHistory purgeHistory)
+            IBaseTransportOptions options, IPurgeMessageHistory purgeHistory, IGetTimeFactory getTimeFactory)
         {
+            var getTime = getTimeFactory.Create();
             return token =>
             {
                 var retentionDays = options.HistoryOptions?.RetentionDays ?? 30;
-                var cutoff = DateTime.UtcNow.AddDays(-retentionDays);
+                //the cut-off is compared against timestamps the transport wrote, so it has to be on
+                //the same clock - otherwise the retention window is off by the difference between them
+                var cutoff = getTime.GetCurrentUtcDate().AddDays(-retentionDays);
                 return purgeHistory.Purge(cutoff);
             };
         }

--- a/Source/DotNetWorkQueue/Queue/HeartBeatMonitor.cs
+++ b/Source/DotNetWorkQueue/Queue/HeartBeatMonitor.cs
@@ -36,7 +36,9 @@ namespace DotNetWorkQueue.Queue
         /// <param name="configuration">The configuration.</param>
         /// <param name="resetHeartBeat">The reset heart beat module.</param>
         /// <param name="log">The log.</param>
-        public HeartBeatMonitor(IHeartBeatConfiguration configuration, IResetHeartBeat resetHeartBeat, ILogger log) : base(configuration, Guard.NotNull(resetHeartBeat).Reset, log)
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
+        public HeartBeatMonitor(IHeartBeatConfiguration configuration, IResetHeartBeat resetHeartBeat, ILogger log,
+            IGetTimeFactory getTimeFactory) : base(configuration, Guard.NotNull(resetHeartBeat).Reset, log, getTimeFactory)
         {
 
         }

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/DataStorage.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/DataStorage.cs
@@ -64,6 +64,8 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         private readonly IReceivedMessageFactory _receivedMessageFactory;
         private readonly IMessageFactory _messageFactory;
         private readonly IQueueCancelWork _cancelToken;
+        //stored on the message and compared against later, so it takes the configured clock
+        private readonly IGetTime _getTime;
 
         private int _completeBackValue = 0;
         private int _clearedBackValue = 0;
@@ -83,13 +85,16 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         /// <param name="receivedMessageFactory">The received message factory.</param>
         /// <param name="messageFactory">The message factory.</param>
         /// <param name="cancelToken">cancel token for stopping</param>
+        /// <param name="getTimeFactory">The time provider the queue is configured with.</param>
         public DataStorage(
             IJobSchedulerMetaData jobSchedulerMetaData,
             IConnectionInformation connectionInformation,
             IReceivedMessageFactory receivedMessageFactory,
             IMessageFactory messageFactory,
-            IQueueCancelWork cancelToken)
+            IQueueCancelWork cancelToken,
+            IGetTimeFactory getTimeFactory)
         {
+            _getTime = getTimeFactory.Create();
             _jobSchedulerMetaData = jobSchedulerMetaData;
             _connectionInformation = connectionInformation;
             _receivedMessageFactory = receivedMessageFactory;
@@ -156,7 +161,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
                         CorrelationId = (Guid)inputData.CorrelationId.Id.Value,
                         Headers = message.Headers,
                         Id = Guid.NewGuid(),
-                        QueuedDateTime = DateTime.UtcNow,
+                        QueuedDateTime = _getTime.GetCurrentUtcDate(),
                         JobEventTime = eventTime,
                         JobName = jobName,
                         JobScheduledTime = scheduledTime

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/DataStorage.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/DataStorage.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using DotNetWorkQueue.Validation;
 using DotNetWorkQueue.Exceptions;
 using Microsoft.Extensions.Caching.Memory;
 using System;
@@ -94,6 +95,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
             IQueueCancelWork cancelToken,
             IGetTimeFactory getTimeFactory)
         {
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
             _jobSchedulerMetaData = jobSchedulerMetaData;
             _connectionInformation = connectionInformation;

--- a/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue/Transport/Memory/Basic/WriteMessageHistoryHandler.cs
@@ -16,6 +16,7 @@
 //License along with this library; if not, write to the Free Software
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // ---------------------------------------------------------------------
+using DotNetWorkQueue.Validation;
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
@@ -47,6 +48,7 @@ namespace DotNetWorkQueue.Transport.Memory.Basic
         {
             _connectionInformation = connectionInformation;
             _options = options;
+            Guard.NotNull(getTimeFactory);
             _getTime = getTimeFactory.Create();
         }
 


### PR DESCRIPTION
Items 2 to 4 of #304. The history handlers were #310; this is the rest, and it closes the issue.

`IGetTime` is registered per transport — the database server's clock on SQL Server and PostgreSQL, the Redis server's on Redis — and code calling `DateTime.UtcNow` silently opts out of whatever the user chose.

## What changed

| | why it matters |
|---|---|
| dashboard stale-message threshold (relational, Redis, LiteDB) | staleness is the age of a heartbeat the *transport* wrote; a cut-off from the asking machine measures the gap between two clocks as well as the age |
| history retention cut-off (`ClearHistoryMonitor`) | compared directly against stored timestamps, so a clock difference moves the retention window by that difference |
| `BaseMonitor.LastRunUtc` | shown on the dashboard beside timestamps the transport wrote |
| Memory `DataStorage.QueuedDateTime` | stored, then compared against later |
| LiteDB: send ×3, receive, heartbeat, error-move, the three find/reset queries | embedded, so the provider is normally the local clock anyway — but these values are compared against each other, and bypassing the provider is how they stop agreeing |

Redis computed its threshold through `DateTimeOffset.UtcNow`, which is why a search for `DateTime.UtcNow` alone did not list it.

## Where to look

Two places keep `DateTime.UtcNow` deliberately, and are the only judgement calls here:

- `JobScheduler` logs the scheduler's time from the provider and the local time on the next line. That is a deliberate side-by-side comparison; converting it would print the same value twice and say nothing.
- The trace decorator and the Dashboard API/UI services measure spans and request timing rather than queue data — where #304 left them.

## Tests

The unit tests for the monitors, `DataStorage` and the three dashboard handlers constructed these types directly, so they now run on a fixed clock; the relational one asserts `@ThresholdTicks` is derived from it rather than from the machine.

Validated locally: `Release -p:CI=true`; unit suites 1192 / 277 / 198 / 183 / 242 / 36 / 222; **LiteDB integration 115/115**, which is the transport this touches most. Memory and Dashboard API integration are left to Jenkins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queue timestamps now consistently use the configured time provider instead of the machine clock.
  * Improved consistency for message queuing, expiration, heartbeats, stale-message detection, monitor timestamps, and history retention across transports.

* **Breaking Changes**
  * Applications that directly construct or subclass monitors, data storage, or transport handlers must now provide a configured time-provider factory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->