### PR TITLE
History timestamps read back as the UTC they were written as (#311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ﻿### Unreleased
+- Fix: message history timestamps read back as the UTC values they were written as on PostgreSQL and SQLite. They were shifted by the machine's UTC offset, so `EnqueuedUtc` held local time and purging by date removed the wrong window (GitHub #311)
+- ⚠️ PostgreSQL stores history and metadata timestamps as `timestamptz` rather than `timestamp`. Existing queues keep the old columns and the old behaviour; re-create a queue to pick up the fix (GitHub #311)
+- ⚠️ SQLite connections are opened with `DateTimeKind=Utc` unless the connection string already sets it. Existing data is unaffected — it was already stored as UTC and only the read was converting (GitHub #311)
 - Fix: a heartbeat no longer misses its interval under load, so a message still being processed is not reset and handed to a second worker (GitHub #303)
 - ⚠️ `HeartBeat.UpdateTime` is a `TimeSpan` rather than a cron string — `"*/10 * * * * *"` becomes `TimeSpan.FromSeconds(10)` (GitHub #303)
 - ⚠️ A consumer refuses to start when `HeartBeat.Time` is less than three times `HeartBeat.UpdateTime`, since one late beat would then cost the message its claim. The error names both values and how to fix them (GitHub #303)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ﻿### Unreleased
 - Fix: message history timestamps read back as the UTC values they were written as on PostgreSQL and SQLite. They were shifted by the machine's UTC offset, so `EnqueuedUtc` held local time and purging by date removed the wrong window (GitHub #311)
-- ⚠️ PostgreSQL stores history and metadata timestamps as `timestamptz` rather than `timestamp`. Existing queues keep the old columns and the old behaviour; re-create a queue to pick up the fix (GitHub #311)
+- ⚠️ PostgreSQL stores history and metadata timestamps as `timestamptz` rather than `timestamp`. Existing queues keep their columns and their stored values untouched; re-create a queue to pick up the fix (GitHub #311)
+- ⚠️ History timestamps come back with `DateTimeKind.Utc` on the relational transports, where they were `Unspecified`. Code that corrected them with `ToUniversalTime()` must stop doing so (GitHub #311)
 - ⚠️ SQLite connections are opened with `DateTimeKind=Utc` unless the connection string already sets it. Existing data is unaffected — it was already stored as UTC and only the read was converting (GitHub #311)
 - Fix: a heartbeat no longer misses its interval under load, so a message still being processed is not reset and handed to a second worker (GitHub #303)
 - ⚠️ `HeartBeat.UpdateTime` is a `TimeSpan` rather than a cron string — `"*/10 * * * * *"` becomes `TimeSpan.FromSeconds(10)` (GitHub #303)

--- a/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/HistoryTimeProviderTest.cs
+++ b/Source/DotNetWorkQueue.IntegrationTests.Shared/History/Implementation/HistoryTimeProviderTest.cs
@@ -70,14 +70,13 @@ namespace DotNetWorkQueue.IntegrationTests.Shared.History.Implementation
                         var records = admin.GetInstance<IQueryMessageHistory>().Get(0, 10, null);
                         Assert.IsGreaterThanOrEqualTo(1, records.Count, "the history record was not written");
 
-                        //what is being asked is where the timestamp came from, so the comparison is
-                        //against the clock rather than against the machine's. It is deliberately not an
-                        //exact match: PostgreSQL and SQLite return the value shifted by the machine's
-                        //UTC offset, which is GitHub #311 and not this test's subject. A day of slack
-                        //covers any offset while leaving twenty-five years between the two candidates.
-                        var drift = (records[0].EnqueuedUtc - FixedUtc).Duration();
-                        Assert.IsLessThanOrEqualTo(TimeSpan.FromDays(1), drift,
-                            $"expected a timestamp from the configured provider (near {FixedUtc:u}), got {records[0].EnqueuedUtc:u}");
+                        //Exact, including the Kind. This was a day of slack until GitHub #311, because
+                        //PostgreSQL and SQLite returned the value shifted by the machine's UTC offset -
+                        //so a run on a machine that is not on UTC is what catches a regression here.
+                        Assert.AreEqual(FixedUtc, records[0].EnqueuedUtc,
+                            $"expected the timestamp the provider gave ({FixedUtc:O}), got {records[0].EnqueuedUtc:O}");
+                        Assert.AreEqual(DateTimeKind.Utc, records[0].EnqueuedUtc.Kind,
+                            "a timestamp on a column named EnqueuedUtc came back without a UTC kind");
                     }
                 }
                 finally

--- a/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueSchema.cs
+++ b/Source/DotNetWorkQueue.Transport.PostgreSQL/Basic/PostgreSQLMessageQueueSchema.cs
@@ -169,7 +169,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
                 meta.Columns.Add(new Column("Priority", ColumnTypes.Integer, false));
             }
 
-            meta.Columns.Add(new Column("QueuedDateTime", ColumnTypes.Timestamp, false));
+            meta.Columns.Add(new Column("QueuedDateTime", ColumnTypes.TimestampTZ, false));
 
             if (_options.Value.EnableStatus)
             {
@@ -315,7 +315,7 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
                 metaErrors.Columns.Add(c.Clone());
             }
             metaErrors.Columns.Add(new Column("LastException", ColumnTypes.Text, -1, true));
-            metaErrors.Columns.Add(new Column("LastExceptionDate", ColumnTypes.Timestamp, true));
+            metaErrors.Columns.Add(new Column("LastExceptionDate", ColumnTypes.TimestampTZ, true));
 
             //add primary key constraint
             metaErrors.Constraints.Add(new Constraint("PK_" + _tableNameHelper.MetaDataErrorsName, ConstraintType.PrimaryKey, "ID"));
@@ -342,9 +342,12 @@ namespace DotNetWorkQueue.Transport.PostgreSQL.Basic
             history.Columns.Add(new Column(ColumnQueueId, ColumnTypes.Varchar, 100, false));
             history.Columns.Add(new Column("CorrelationID", ColumnTypes.Varchar, 38, true));
             history.Columns.Add(new Column(ColumnStatus, ColumnTypes.Integer, false));
-            history.Columns.Add(new Column("EnqueuedUtc", ColumnTypes.Timestamp, false));
-            history.Columns.Add(new Column("StartedUtc", ColumnTypes.Timestamp, true));
-            history.Columns.Add(new Column("CompletedUtc", ColumnTypes.Timestamp, true));
+            //timestamptz, not timestamp. Npgsql maps a DateTime to "timestamp with time zone", so a
+            //UTC value written into a naive column was converted to the session time zone on the way
+            //in - the stored value was local time under a column named ...Utc (GitHub #311)
+            history.Columns.Add(new Column("EnqueuedUtc", ColumnTypes.TimestampTZ, false));
+            history.Columns.Add(new Column("StartedUtc", ColumnTypes.TimestampTZ, true));
+            history.Columns.Add(new Column("CompletedUtc", ColumnTypes.TimestampTZ, true));
             history.Columns.Add(new Column("DurationMs", ColumnTypes.Bigint, true));
             history.Columns.Add(new Column("ExceptionText", ColumnTypes.Text, -1, true));
             history.Columns.Add(new Column("RetryCount", ColumnTypes.Integer, false));

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryMessageHistoryHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/QueryMessageHistoryHandler.cs
@@ -157,9 +157,9 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                 QueueId = reader.GetString(0),
                 CorrelationId = reader.IsDBNull(1) ? null : reader.GetString(1),
                 Status = (MessageHistoryStatus)reader.GetInt32(2),
-                EnqueuedUtc = reader.GetDateTime(3),
-                StartedUtc = reader.IsDBNull(4) ? null : (DateTime?)reader.GetDateTime(4),
-                CompletedUtc = reader.IsDBNull(5) ? null : (DateTime?)reader.GetDateTime(5),
+                EnqueuedUtc = Utc(reader.GetDateTime(3)),
+                StartedUtc = reader.IsDBNull(4) ? null : (DateTime?)Utc(reader.GetDateTime(4)),
+                CompletedUtc = reader.IsDBNull(5) ? null : (DateTime?)Utc(reader.GetDateTime(5)),
                 DurationMs = reader.IsDBNull(6) ? null : (long?)reader.GetInt64(6),
                 ExceptionText = reader.IsDBNull(7) ? null : reader.GetString(7),
                 RetryCount = reader.GetInt32(8),
@@ -167,6 +167,18 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic
                 MessageType = reader.IsDBNull(10) ? null : reader.GetString(10)
             };
         }
+
+        /// <summary>
+        /// Labels a stored timestamp as UTC, which is what these columns hold.
+        /// </summary>
+        /// <remarks>
+        /// SQL Server's datetime carries no time zone, so the provider hands back Unspecified and a
+        /// caller comparing it to DateTime.UtcNow gets the right answer by luck rather than by type.
+        /// PostgreSQL's timestamptz and SQLite with DateTimeKind=Utc already answer Utc, so for those
+        /// this is a no-op that keeps the three transports returning the same thing.
+        /// </remarks>
+        private static DateTime Utc(DateTime value) =>
+            value.Kind == DateTimeKind.Utc ? value : DateTime.SpecifyKind(value, DateTimeKind.Utc);
 
         private static void AddParameter(DbCommand command, string name, DbType dbType, object value)
         {

--- a/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/ConnectionStringPoolingTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Tests/Basic/ConnectionStringPoolingTests.cs
@@ -75,7 +75,9 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var result = ConnectionStringPooling.Apply(inMemory, false);
 
             Assert.IsFalse(SpecifiesPooling(result));
-            Assert.AreEqual(inMemory, result);
+            //the caller's string is still there; the timestamp kind is added to every connection,
+            //an in-memory database included - its history has the same reads (GitHub #311)
+            Assert.StartsWith(inMemory, result);
         }
 
         [TestMethod]
@@ -87,7 +89,27 @@ namespace DotNetWorkQueue.Transport.SQLite.Tests.Basic
             var result = ConnectionStringPooling.Apply(sharedMemory, false);
 
             Assert.IsFalse(SpecifiesPooling(result));
-            Assert.AreEqual(sharedMemory, result);
+            Assert.StartsWith(sharedMemory, result);
+        }
+
+        [TestMethod]
+        public void Apply_ReadsAndWritesTimestampsAsUtc()
+        {
+            //without this the provider converts a stored UTC value to local on the way out and drops
+            //the kind, so a history record written at 04:05 came back as 22:05 the day before (#311)
+            var result = ConnectionStringPooling.Apply(FileDb, false);
+
+            Assert.Contains("DateTimeKind=Utc", result);
+        }
+
+        [TestMethod]
+        public void Apply_DoesNotOverrideACallersTimestampKind()
+        {
+            var chosen = FileDb + "DateTimeKind=Local;";
+
+            var result = ConnectionStringPooling.Apply(chosen, false);
+
+            Assert.DoesNotContain("DateTimeKind=Utc", result);
         }
 
         [TestMethod]

--- a/Source/DotNetWorkQueue.Transport.SQLite/Basic/ConnectionStringPooling.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Basic/ConnectionStringPooling.cs
@@ -52,6 +52,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
     internal static class ConnectionStringPooling
     {
         private const string PoolingKeyword = "Pooling";
+        private const string DateTimeKindKeyword = "DateTimeKind";
 
         private static readonly IGetFileNameFromConnectionString FileNameParser =
             new GetFileNameFromConnectionString();
@@ -120,14 +121,23 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
                 return connectionString;
             }
 
+            var result = connectionString;
+
+            //Timestamps are written and read as UTC. Without this the provider converts a stored UTC
+            //value to local time on the way out and drops the Kind, so a history record written as
+            //04:05 came back as 22:05 the day before - see GitHub #311. Applied before the pooling
+            //decision below, which returns early in cases that have nothing to do with time.
+            if (!builder.ContainsKey(DateTimeKindKeyword))
+                result = Append(result, DateTimeKindKeyword, nameof(DateTimeKind.Utc));
+
             //an explicit Pooling=true or Pooling=false is the caller's decision; do not override it
             if (builder.ContainsKey(PoolingKeyword))
-                return connectionString;
+                return result;
 
             //an in-memory database is kept alive by SqLiteHoldConnection, and with shared cache a
             //pooled connection would keep it alive past the point the caller disposed of it
             if (FileNameParser.GetFileName(connectionString).IsInMemory)
-                return connectionString;
+                return result;
 
             //Append rather than returning builder.ConnectionString. The builder is used only to
             //inspect: round-tripping through it rewrites the caller's string, and for input it
@@ -135,9 +145,14 @@ namespace DotNetWorkQueue.Transport.SQLite.Basic
             //string=;;;" comes back as "pooling=True". Appending keeps whatever the caller passed
             //exactly as they passed it, so a connection string we misjudge still fails the way it
             //would have without us.
+            return Append(result, PoolingKeyword, "True");
+        }
+
+        private static string Append(string connectionString, string keyword, string value)
+        {
             var trimmed = connectionString.TrimEnd();
             var separator = trimmed.EndsWith(';') ? string.Empty : ";";
-            return trimmed + separator + PoolingKeyword + "=True;";
+            return trimmed + separator + keyword + "=" + value + ";";
         }
     }
 }


### PR DESCRIPTION
`EnqueuedUtc` held local time on PostgreSQL and SQLite. The column is documented as UTC, the dashboard renders it as UTC, and `IPurgeMessageHistory.Purge(olderThan)` compares a UTC cut-off against it — so purging by date removed the wrong window by the machine's offset.

One symptom, two different causes. Both were found by probing what each provider actually stores.

| | where it went wrong | stored value | fix |
|---|---|---|---|
| **SQLite** | read | `2001-02-03 04:05:06Z` — correct | connection `DateTimeKind=Utc` |
| **PostgreSQL** | write | `2001-02-02 22:05:06` — already shifted | columns become `timestamptz` |
| SQL Server | value correct, `Kind` Unspecified | correct | labelled on read |

**SQLite** is read-side only. `System.Data.SQLite` converts the stored UTC text to local on the way out and drops the `Kind`, because the connection's `DateTimeKind` defaults to `Unspecified`. Setting it to `Utc` fixes both directions and leaves the stored bytes untouched — **existing rows read correctly from now on**.

**PostgreSQL** is write-side. Npgsql maps a `DateTime` to `timestamp with time zone`; the columns were `timestamp`, so PostgreSQL converted the instant into the session time zone on the way in. Writing `Kind=Unspecified` instead is refused outright by Npgsql for that mapping, so the columns are `timestamptz` — which is what the provider was asking for all along. `QueuedDateTime` and `LastExceptionDate` had the same problem and the dashboard renders the first, so they move too.

## Where to look

`ConnectionStringPooling.Build` now applies the timestamp kind before the pooling decision, which returns early for cases that have nothing to do with time.

## Tests

The integration test added in #310 asserted the timestamp's *source* with a day of slack, because this bug made an exact comparison impossible. It compares exactly now, and asserts the `Kind`.

That second assertion is what makes it useful on CI. The value shift only appears on a machine that is not on UTC — Jenkins runs UTC and would never have seen it — but the `Kind` is wrong everywhere. With the fix reverted the test fails on all three transports under `TZ=UTC` as well as under the local offset.

Two SQLite pooling tests asserted the connection string came back byte-identical for an in-memory database; what they were really asserting is that it is not pooled, which still holds.

## Compatibility

Existing PostgreSQL queues keep their `timestamp` columns and their current behaviour — re-create a queue to pick up the fix, as with #299, and #308 tracks removing that caveat. SQLite needs nothing.

Validated: `Release -p:CI=true`; unit suites 1215 / 277 / 198 / 183 / 212 / 180 / 36 / 222 and SQLite 244; history integration on all six transports; dashboard integration 219/219; SQLite expiry, rollback, dequeue-eligibility and date-kind suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message history timestamps being shifted by local time zone offsets.
  * Ensured timestamps are consistently read and returned as UTC across supported database providers.
  * PostgreSQL now stores queue timestamp data with time zone support; existing queues require recreation to apply the schema change.
  * SQLite now reads and writes timestamps as UTC by default while preserving explicitly configured settings.
  * Improved timestamp accuracy for enqueue-time and history tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->