### PR TITLE
Serialise LiteDb table creation (#318)

### DIFF
--- a/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/ConcurrentQueueCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/ConcurrentQueueCreation.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.IntegrationTests.Shared;
+using DotNetWorkQueue.Transport.LiteDb.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.LiteDb.IntegrationTests
+{
+    /// <summary>
+    /// Several queues being created at once.
+    ///
+    /// LiteDB maps a type through a process-wide BsonMapper, and mapping one for the first time is not
+    /// thread safe - a second thread can see a half-built mapper and report a member that exists as
+    /// missing. Creating tables is serialised because of it (GitHub #318).
+    ///
+    /// What this test can and cannot do is worth being plain about: the fault needs the *first* use of
+    /// a type in the process, so once any other test in this assembly has touched LiteDB the mappers
+    /// are warm and it will not reproduce here whatever the lock does. It is kept because creating
+    /// queues concurrently is worth exercising on its own - a deadlock or a file-level collision in
+    /// this path would fail it - and because the serialisation it covers has no other test.
+    /// </summary>
+    [TestClass]
+    public class ConcurrentQueueCreation
+    {
+        [TestMethod]
+        public void CreatingManyQueuesAtOnce_AllSucceed()
+        {
+            const int queues = 16;
+            using (var connectionInfo = new IntegrationConnectionInfo(IntegrationConnectionInfo.ConnectionTypes.Direct))
+            {
+                var logProvider = LoggerShared.Create("concurrent-create", GetType().Name);
+                using (var queueCreator = new QueueCreationContainer<LiteDbMessageQueueInit>(
+                    serviceRegister => serviceRegister.Register(() => logProvider, LifeStyles.Singleton)))
+                {
+                    var created = new ConcurrentBag<LiteDbMessageQueueCreation>();
+                    var failures = new ConcurrentBag<string>();
+                    try
+                    {
+                        Parallel.For(0, queues, i =>
+                        {
+                            try
+                            {
+                                var connection = new QueueConnection(GenerateQueueName.Create(), connectionInfo.ConnectionString);
+                                var creation = queueCreator.GetQueueCreation<LiteDbMessageQueueCreation>(connection);
+                                created.Add(creation);
+                                var result = creation.CreateQueue();
+                                if (!result.Success)
+                                    failures.Add($"{result.Status}: {result.ErrorMessage}");
+                            }
+                            catch (Exception error)
+                            {
+                                failures.Add(error.GetType().Name + ": " + error.Message);
+                            }
+                        });
+
+                        Assert.IsEmpty(failures, string.Join(" | ", failures));
+                    }
+                    finally
+                    {
+                        foreach (var creation in created)
+                        {
+                            try { creation.RemoveQueue(); } catch { /* best effort */ }
+                            creation.Dispose();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/ConcurrentQueueCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB.IntegrationTests/ConcurrentQueueCreation.cs
@@ -25,6 +25,8 @@ namespace DotNetWorkQueue.Transport.LiteDb.IntegrationTests
     public class ConcurrentQueueCreation
     {
         [TestMethod]
+        //table creation takes a lock, so a mistake there hangs the run rather than failing it
+        [Timeout(30000)]
         public void CreatingManyQueuesAtOnce_AllSucceed()
         {
             const int queues = 16;

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/CreateJobTablesCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/CreateJobTablesCommandHandler.cs
@@ -54,9 +54,14 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
         /// <inheritdoc />
         public QueueCreationResult Handle(CreateJobTablesCommand<ITable> command)
         {
-            foreach (var table in command.Tables)
+            //the same gate the queue tables take: both map the same types through one global mapper,
+            //so a job queue starting alongside a message queue races exactly as two queues do
+            lock (SchemaCreation.Gate)
             {
-                table.Create(_connectionInformation, _options.Value, _tableNameHelper);
+                foreach (var table in command.Tables)
+                {
+                    table.Create(_connectionInformation, _options.Value, _tableNameHelper);
+                }
             }
             return new QueueCreationResult(QueueCreationStatus.Success);
         }

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/CreateQueueTablesAndSaveConfigurationCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/CreateQueueTablesAndSaveConfigurationCommandHandler.cs
@@ -63,21 +63,6 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             _serializer = serializer;
         }
 
-        /// <summary>
-        /// Serialises table creation across the process.
-        /// </summary>
-        /// <remarks>
-        /// LiteDB resolves <c>EnsureIndex(x =&gt; x.Member)</c> through <see cref="LiteDB.BsonMapper"/>'s
-        /// global instance, and mapping a type for the first time is not thread safe: another thread can
-        /// see an entity mapper whose member list is not yet populated and report a member that plainly
-        /// exists as missing. Two queues being created at once is enough - it was seen on CI, where the
-        /// integration tests create queues on four workers, and reproduces on demand with sixty-four
-        /// threads. Creating a queue is a rare, one-off operation, so serialising it costs nothing.
-        /// Pre-building the mappers instead was measured and is not sufficient.
-        /// See GitHub #318.
-        /// </remarks>
-        private static readonly object SchemaCreation = new object();
-
         /// <inheritdoc />
         public QueueCreationResult Handle(CreateQueueTablesAndSaveConfigurationCommand<ITable> command)
         {
@@ -88,7 +73,7 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
 
 
                 //create all tables - see SchemaCreation for why this is serialised
-                lock (SchemaCreation)
+                lock (SchemaCreation.Gate)
                 {
                     foreach (var table in command.Tables)
                     {

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/CreateQueueTablesAndSaveConfigurationCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/CommandHandler/CreateQueueTablesAndSaveConfigurationCommandHandler.cs
@@ -63,6 +63,21 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
             _serializer = serializer;
         }
 
+        /// <summary>
+        /// Serialises table creation across the process.
+        /// </summary>
+        /// <remarks>
+        /// LiteDB resolves <c>EnsureIndex(x =&gt; x.Member)</c> through <see cref="LiteDB.BsonMapper"/>'s
+        /// global instance, and mapping a type for the first time is not thread safe: another thread can
+        /// see an entity mapper whose member list is not yet populated and report a member that plainly
+        /// exists as missing. Two queues being created at once is enough - it was seen on CI, where the
+        /// integration tests create queues on four workers, and reproduces on demand with sixty-four
+        /// threads. Creating a queue is a rare, one-off operation, so serialising it costs nothing.
+        /// Pre-building the mappers instead was measured and is not sufficient.
+        /// See GitHub #318.
+        /// </remarks>
+        private static readonly object SchemaCreation = new object();
+
         /// <inheritdoc />
         public QueueCreationResult Handle(CreateQueueTablesAndSaveConfigurationCommand<ITable> command)
         {
@@ -72,10 +87,13 @@ namespace DotNetWorkQueue.Transport.LiteDb.Basic.CommandHandler
                 db.Database.Pragma("UTC_DATE", true);
 
 
-                //create all tables
-                foreach (var table in command.Tables)
+                //create all tables - see SchemaCreation for why this is serialised
+                lock (SchemaCreation)
                 {
-                    table.Create(_connectionInformation, _options.Value, _tableNameHelper);
+                    foreach (var table in command.Tables)
+                    {
+                        table.Create(_connectionInformation, _options.Value, _tableNameHelper);
+                    }
                 }
 
                 //save configuration

--- a/Source/DotNetWorkQueue.Transport.LiteDB/Basic/SchemaCreation.cs
+++ b/Source/DotNetWorkQueue.Transport.LiteDB/Basic/SchemaCreation.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+namespace DotNetWorkQueue.Transport.LiteDb.Basic
+{
+    /// <summary>
+    /// Serialises the creation of LiteDb tables across the process.
+    /// </summary>
+    /// <remarks>
+    /// LiteDB resolves <c>EnsureIndex(x =&gt; x.Member)</c> through <see cref="LiteDB.BsonMapper"/>'s
+    /// global instance, and mapping a type for the first time is not thread safe: another thread can
+    /// see an entity mapper whose member list is not yet populated and report a member that plainly
+    /// exists as missing. Two queues being created at once is enough - it was seen on CI, where the
+    /// integration tests create queues on four workers, and reproduces on demand with sixty-four
+    /// threads. Pre-building the mappers instead was measured and is not sufficient.
+    ///
+    /// The gate is shared rather than per-handler because the race is on one global mapper: queue
+    /// tables and job tables are created by different handlers, and a job queue starting at the same
+    /// moment as a message queue maps the same types. Creating either is a rare, one-off operation,
+    /// so serialising them costs nothing.
+    ///
+    /// See GitHub #318.
+    /// </remarks>
+    internal static class SchemaCreation
+    {
+        /// <summary>Hold this while creating tables.</summary>
+        internal static readonly object Gate = new object();
+    }
+}


### PR DESCRIPTION
Creating two queues at once could fail:

```
NotSupportedException: Member QueueId not found on BsonMapper for type
  DotNetWorkQueue.Transport.LiteDb.Schema.MetaDataErrorsTable
   at LiteDB.LinqExpressionVisitor.ResolveMember(MemberInfo member)
   at LiteDB.LiteCollection`1.EnsureIndex[K](Expression`1 keySelector, Boolean unique)
```

Seen on CI on a branch touching no LiteDb code, then on master.

## Cause

`GetCollection<T>` uses `BsonMapper.Global`, a process-wide static, and mapping a type for the first time is not thread safe: a second thread can see an entity mapper whose member list is not yet populated, and `EnsureIndex`'s LINQ resolver then reports a member that plainly exists as missing. The integration tests run four workers and every test creates a queue.

## Fix

Table creation takes a lock. Sixty-four concurrent first uses of one type reproduce the fault on **every** run; with the lock, **zero failures over four runs of sixty-four**. Creating a queue is a rare, one-off operation, so serializing it costs little.

## Two alternatives measured and rejected

- **Pre-building the mappers** (`BsonMapper.Global.ToDocument(...)`) still failed **one run in sixty-four** — something on the `EnsureIndex` path builds state the warm-up does not. This was the obvious fix and it does not hold.
- **Naming the field** — `EnsureIndex("QueueId", "$.QueueId", true)` — does avoid the resolver and gave zero failures, but it is twenty-one call sites and the two forms are not interchangeable: `EnsureIndex(x => x.Id)` resolves to the built-in `$._id` index rather than `$.Id`, returns `false`, and does not create the collection. A mechanical swap would have written an index on a field that does not exist.

## The test, and what it cannot do

`ConcurrentQueueCreation` creates sixteen queues at once. It **cannot** reproduce the original fault, and says so in its summary: that needs the first use of a type in the process, and any earlier test in the assembly warms the mapper. It is here because concurrent creation is worth exercising — a deadlock or a file-level collision in this path would fail it — and the serialisation it guards had no test at all. The reproduction that does bite is recorded in #318.

Validated: `Release -p:CI=true`; LiteDb unit 180/180, LiteDb integration 116/116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when creating multiple queues concurrently.
  - Prevented intermittent setup failures caused by simultaneous database table initialization.
  - Ensured queue and job database structures are initialized safely when created at the same time.

- **Tests**
  - Added coverage verifying that multiple queues can be created concurrently and successfully.
  - Added safeguards to detect stalled concurrent creation during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->