### PR TITLE
Document why retries cannot succeed inside a caller-held transaction (#309)

### DIFF
--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/DeleteTransactionalMessageCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/DeleteTransactionalMessageCommandHandler.cs
@@ -30,6 +30,21 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
     /// <summary>
     /// Deletes a transactional message from the queue
     /// </summary>
+    /// <remarks>
+    /// <para>A retry of this handler cannot succeed while the caller holds the transaction
+    /// (<c>EnableHoldTransactionUntilMessageCommitted</c>). PostgreSQL aborts a transaction as soon
+    /// as a statement in it fails, so every later statement returns <c>25P02</c>,
+    /// <c>in_failed_sql_transaction</c>; the work has to be redone on a new transaction, which only
+    /// the caller can open.</para>
+    /// <para>It is left wrapped in the retry decorator on purpose. The cost is bounded to a single
+    /// attempt: <c>25P02</c> is not one of the retryable states, and the pipeline's predicate runs
+    /// after every attempt, so the second failure propagates instead of backing off again. One
+    /// wasted retry of about half a second, on a path that is already failing, does not justify
+    /// teaching the decorator which commands run inside someone else's transaction. See GitHub
+    /// issue #309 for the measurement and the options that were weighed.</para>
+    /// <para>Any new handler that runs inside the caller's transaction inherits this, and nothing
+    /// will report it.</para>
+    /// </remarks>
     public class DeleteTransactionalMessageCommandHandler<TConnection, TTransaction, TCommand> : ICommandHandlerWithOutput<DeleteTransactionalMessageCommand, long>
         where TConnection : DbConnection
         where TTransaction : DbTransaction

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/DeleteTransactionalMessageCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/DeleteTransactionalMessageCommandHandlerAsync.cs
@@ -30,6 +30,21 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
     /// <summary>
     /// Deletes a transactional message from the queue
     /// </summary>
+    /// <remarks>
+    /// <para>A retry of this handler cannot succeed while the caller holds the transaction
+    /// (<c>EnableHoldTransactionUntilMessageCommitted</c>). PostgreSQL aborts a transaction as soon
+    /// as a statement in it fails, so every later statement returns <c>25P02</c>,
+    /// <c>in_failed_sql_transaction</c>; the work has to be redone on a new transaction, which only
+    /// the caller can open.</para>
+    /// <para>It is left wrapped in the retry decorator on purpose. The cost is bounded to a single
+    /// attempt: <c>25P02</c> is not one of the retryable states, and the pipeline's predicate runs
+    /// after every attempt, so the second failure propagates instead of backing off again. One
+    /// wasted retry of about half a second, on a path that is already failing, does not justify
+    /// teaching the decorator which commands run inside someone else's transaction. See GitHub
+    /// issue #309 for the measurement and the options that were weighed.</para>
+    /// <para>Any new handler that runs inside the caller's transaction inherits this, and nothing
+    /// will report it.</para>
+    /// </remarks>
     public class DeleteTransactionalMessageCommandHandlerAsync<TConnection, TTransaction, TCommand> : ICommandHandlerWithOutputAsync<DeleteTransactionalMessageCommand, long>
         where TConnection : DbConnection
         where TTransaction : DbTransaction

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandler.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandler.cs
@@ -30,6 +30,21 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
     /// <summary>
     /// Moves a record from the meta table to the error table
     /// </summary>
+    /// <remarks>
+    /// <para>A retry of this handler cannot succeed while the caller holds the transaction
+    /// (<c>EnableHoldTransactionUntilMessageCommitted</c>). PostgreSQL aborts a transaction as soon
+    /// as a statement in it fails, so every later statement returns <c>25P02</c>,
+    /// <c>in_failed_sql_transaction</c>; the work has to be redone on a new transaction, which only
+    /// the caller can open.</para>
+    /// <para>It is left wrapped in the retry decorator on purpose. The cost is bounded to a single
+    /// attempt: <c>25P02</c> is not one of the retryable states, and the pipeline's predicate runs
+    /// after every attempt, so the second failure propagates instead of backing off again. One
+    /// wasted retry of about half a second, on a path that is already failing, does not justify
+    /// teaching the decorator which commands run inside someone else's transaction. See GitHub
+    /// issue #309 for the measurement and the options that were weighed.</para>
+    /// <para>Any new handler that runs inside the caller's transaction inherits this, and nothing
+    /// will report it.</para>
+    /// </remarks>
     public class MoveRecordToErrorQueueCommandHandler<TConnection, TTransaction, TCommand> : ICommandHandler<MoveRecordToErrorQueueCommand<long>>
         where TConnection : DbConnection
         where TTransaction : DbTransaction

--- a/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
+++ b/Source/DotNetWorkQueue.Transport.RelationalDatabase/Basic/CommandHandler/MoveRecordToErrorQueueCommandHandlerAsync.cs
@@ -30,6 +30,21 @@ namespace DotNetWorkQueue.Transport.RelationalDatabase.Basic.CommandHandler
     /// <summary>
     /// Moves a record from the meta table to the error table
     /// </summary>
+    /// <remarks>
+    /// <para>A retry of this handler cannot succeed while the caller holds the transaction
+    /// (<c>EnableHoldTransactionUntilMessageCommitted</c>). PostgreSQL aborts a transaction as soon
+    /// as a statement in it fails, so every later statement returns <c>25P02</c>,
+    /// <c>in_failed_sql_transaction</c>; the work has to be redone on a new transaction, which only
+    /// the caller can open.</para>
+    /// <para>It is left wrapped in the retry decorator on purpose. The cost is bounded to a single
+    /// attempt: <c>25P02</c> is not one of the retryable states, and the pipeline's predicate runs
+    /// after every attempt, so the second failure propagates instead of backing off again. One
+    /// wasted retry of about half a second, on a path that is already failing, does not justify
+    /// teaching the decorator which commands run inside someone else's transaction. See GitHub
+    /// issue #309 for the measurement and the options that were weighed.</para>
+    /// <para>Any new handler that runs inside the caller's transaction inherits this, and nothing
+    /// will report it.</para>
+    /// </remarks>
     public class MoveRecordToErrorQueueCommandHandlerAsync<TConnection, TTransaction, TCommand> : ICommandHandlerAsync<MoveRecordToErrorQueueCommand<long>>
         where TConnection : DbConnection
         where TTransaction : DbTransaction


### PR DESCRIPTION
Documentation only — no behaviour change, no schema change.

## What this changes

Adds a `<remarks>` block to the four `Transport.RelationalDatabase` command handlers that run inside a transaction the caller holds (`EnableHoldTransactionUntilMessageCommitted`):

- `MoveRecordToErrorQueueCommandHandler` / `…Async`
- `DeleteTransactionalMessageCommandHandler` / `…Async`

The remark records that a retry of these handlers cannot succeed. PostgreSQL aborts a transaction at the first failing statement, so everything after it returns `25P02` (`in_failed_sql_transaction`) — the work has to be redone on a new transaction, and only the caller can open one.

It also records why they are still wrapped in the retry decorator. `25P02` is not one of the transport's 18 retryable SqlStates, and Polly evaluates `ShouldHandle` after every attempt, so the second failure propagates rather than backing off again. The cost is one retry of roughly half a second, on a path that is already failing.

## What to look at

Whether the constraint is stated where the next person would need it. The alternative — teaching the decorator which commands run inside someone else's transaction, via a marker on the command or a separate non-retrying registration — adds a concept to the transport in exchange for half a second on an error path. #309 carries the measurement behind that call.

The Redis and LiteDb `MoveRecordToErrorQueue` handlers have no caller-held transaction and are not in scope.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)