### PR TITLE
SQLite: set WAL journal mode on a database a job producer creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ﻿### Unreleased
+- ⚠️ SQLite job databases are created in WAL journal mode, as queues already were. A job producer that reaches a database before anything else converts it on start, leaving `-wal` and `-shm` files beside it (GitHub #325)
 - Fix: message history timestamps read back as the UTC values they were written as on PostgreSQL and SQLite. They were shifted by the machine's UTC offset, so `EnqueuedUtc` held local time and purging by date removed the wrong window (GitHub #311)
 - ⚠️ PostgreSQL stores history and metadata timestamps as `timestamptz` rather than `timestamp`. Existing queues keep their columns and their stored values untouched; re-create a queue to pick up the fix (GitHub #311)
 - ⚠️ History timestamps come back with `DateTimeKind.Utc` on the relational transports, where they were `Unspecified`. Code that corrected them with `ToUniversalTime()` must stop doing so (GitHub #311)

--- a/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/Basic/WalJournalModeTests.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite.Integration.Tests/Basic/WalJournalModeTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+using DotNetWorkQueue.Configuration;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNetWorkQueue.Transport.SQLite.Integration.Tests.Basic
+{
+    /// <summary>
+    /// Which creation paths leave a database in WAL journal mode.
+    ///
+    /// This matters more than it looks. SQLite has no asynchronous I/O and the engine is never going to
+    /// grow any, so write-ahead logging is the only concurrency lever the transport has, and the journal
+    /// mode of a file is decided once - nothing converts an existing database later. A path that misses
+    /// it produces a queue that is slower under load for the rest of its life, with nothing to show for
+    /// it in a log.
+    ///
+    /// These tests deliberately do not use <see cref="IntegrationConnectionInfo"/>. That fixture runs
+    /// "PRAGMA journal_mode=WAL" against the file before the library is handed the connection string, so
+    /// every assertion here would pass on its own setup and a transport that had stopped setting the
+    /// mode entirely would still look correct. Each test owns a raw file instead.
+    /// </summary>
+    [TestClass]
+    public class WalJournalModeTests
+    {
+        [TestMethod]
+        public void CreateQueue_SetsWalMode()
+        {
+            using (var db = new RawDatabase())
+            {
+                var queueConnection = new QueueConnection(GenerateQueueName.Create(), db.ConnectionString);
+                using (var container = new QueueCreationContainer<SqLiteMessageQueueInit>())
+                using (var creation = container.GetQueueCreation<SqLiteMessageQueueCreation>(queueConnection))
+                {
+                    var result = creation.CreateQueue();
+                    Assert.AreEqual(QueueCreationStatus.Success, result.Status);
+                }
+
+                Assert.AreEqual("wal", db.JournalMode());
+            }
+        }
+
+        [TestMethod]
+        public void CreateJobSchedulerQueue_SetsWalMode()
+        {
+            using (var db = new RawDatabase())
+            {
+                var queueConnection = new QueueConnection(GenerateQueueName.Create(), db.ConnectionString);
+                using (var container = new JobQueueCreationContainer<SqLiteMessageQueueInit>())
+                using (var creation = container.GetQueueCreation<SqliteJobQueueCreation>(queueConnection))
+                {
+                    var result = creation.CreateJobSchedulerQueue(x => { }, queueConnection);
+                    Assert.AreEqual(QueueCreationStatus.Success, result.Status);
+                }
+
+                Assert.AreEqual("wal", db.JournalMode());
+            }
+        }
+
+        /// <summary>
+        /// A job producer creates the database itself when it is the first thing to reach the file, so
+        /// the job table path is a creation path and has to set the journal mode like the others. It did
+        /// not, and this is the case that caught it: before the fix the file came back "delete".
+        /// </summary>
+        [TestMethod]
+        public void JobProducer_ReachingADatabaseFirst_SetsWalMode()
+        {
+            using (var db = new RawDatabase())
+            {
+                var queueConnection = new QueueConnection(GenerateQueueName.Create(), db.ConnectionString);
+                using (var container = new QueueContainer<SqLiteMessageQueueInit>())
+                using (var producer = container.CreateMethodJobProducer(queueConnection))
+                {
+                    producer.Start();
+                }
+
+                Assert.AreEqual("wal", db.JournalMode());
+            }
+        }
+
+        /// <summary>
+        /// The control for the three above. Without it they would also pass against a database that was
+        /// in WAL mode for some reason other than the transport choosing it.
+        /// </summary>
+        [TestMethod]
+        public void CreateQueue_WithWalModeDisabled_LeavesTheJournalModeAlone()
+        {
+            using (var db = new RawDatabase())
+            {
+                var queueConnection = new QueueConnection(GenerateQueueName.Create(), db.ConnectionString);
+                using (var container = new QueueCreationContainer<SqLiteMessageQueueInit>())
+                using (var creation = container.GetQueueCreation<SqLiteMessageQueueCreation>(queueConnection))
+                {
+                    creation.Options.EnableWalMode = false;
+                    var result = creation.CreateQueue();
+                    Assert.AreEqual(QueueCreationStatus.Success, result.Status);
+                }
+
+                Assert.AreEqual("delete", db.JournalMode());
+            }
+        }
+
+        /// <summary>
+        /// A database file the library has not seen, and its clean-up. Nothing here touches the journal
+        /// mode; the file is not even created, so that the transport decides both whether it exists and
+        /// what mode it is in.
+        /// </summary>
+        private sealed class RawDatabase : IDisposable
+        {
+            private readonly string _fileName;
+
+            public RawDatabase()
+            {
+                _fileName = Path.Combine(Path.GetTempPath(), GenerateQueueName.CreateFileName());
+                ConnectionString = $"Data Source={_fileName};Version=3;";
+            }
+
+            public string ConnectionString { get; }
+
+            public string JournalMode()
+            {
+                using (var connection = new SQLiteConnection(ConnectionString))
+                {
+                    connection.Open();
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = "PRAGMA journal_mode;";
+                        return ((string)command.ExecuteScalar()).ToLowerInvariant();
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                //pooling keeps the file handle open, and WAL leaves two files beside the database
+                SQLiteConnection.ClearAllPools();
+                foreach (var file in new[] { _fileName, _fileName + "-wal", _fileName + "-shm" })
+                {
+                    try
+                    {
+                        if (File.Exists(file))
+                            File.Delete(file);
+                    }
+                    catch (IOException)
+                    {
+                        //a leaked temp file is not worth failing a test over
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/CreateJobTablesCommandDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/CreateJobTablesCommandDecorator.cs
@@ -34,6 +34,7 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         private readonly ICommandHandlerWithOutput<CreateJobTablesCommand<ITable>, QueueCreationResult> _decorated;
         private readonly IGetFileNameFromConnectionString _getFileNameFromConnection;
         private readonly DatabaseExists _databaseExists;
+        private readonly ISqLiteMessageQueueTransportOptionsFactory _options;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CreateJobTablesCommandDecorator" /> class.
@@ -42,20 +43,24 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
         /// <param name="decorated">The decorated.</param>
         /// <param name="getFileNameFromConnection">The get file name from connection.</param>
         /// <param name="databaseExists">The database exists.</param>
+        /// <param name="options">The options.</param>
         public CreateJobTablesCommandDecorator(IConnectionInformation connectionInformation,
             ICommandHandlerWithOutput<CreateJobTablesCommand<ITable>, QueueCreationResult> decorated,
             IGetFileNameFromConnectionString getFileNameFromConnection,
-            DatabaseExists databaseExists)
+            DatabaseExists databaseExists,
+            ISqLiteMessageQueueTransportOptionsFactory options)
         {
             Guard.NotNull(connectionInformation);
             Guard.NotNull(decorated);
             Guard.NotNull(getFileNameFromConnection);
             Guard.NotNull(databaseExists);
+            Guard.NotNull(options);
 
             _connectionInformation = connectionInformation;
             _decorated = decorated;
             _getFileNameFromConnection = getFileNameFromConnection;
             _databaseExists = databaseExists;
+            _options = options;
         }
         public QueueCreationResult Handle(CreateJobTablesCommand<ITable> command)
         {
@@ -66,7 +71,16 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
             }
             try
             {
-                return _decorated.Handle(command);
+                var result = _decorated.Handle(command);
+
+                //a job producer can reach a database before anything else does, so this is the only
+                //chance to set the journal mode on it
+                if (result.Status == QueueCreationStatus.Success)
+                {
+                    WalJournalMode.Apply(_connectionInformation, _getFileNameFromConnection, _options);
+                }
+
+                return result;
             }
             //if the queue already exists, return that status; otherwise, bubble the error
             catch (SQLiteException error)

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/CreateQueueTablesAndSaveConfigurationDecorator.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/CreateQueueTablesAndSaveConfigurationDecorator.cs
@@ -66,26 +66,9 @@ namespace DotNetWorkQueue.Transport.SQLite.Decorator
             {
                 var result = _decorated.Handle(command);
 
-                // Enable WAL mode for file-based databases when configured
                 if (result.Status == QueueCreationStatus.Success)
                 {
-                    var transportOptions = _options.Create();
-                    if (transportOptions.EnableWalMode)
-                    {
-                        var fileName = _getFileNameFromConnection.GetFileName(_connectionInformation.ConnectionString);
-                        if (!fileName.IsInMemory)
-                        {
-                            using (var connection = new SQLiteConnection(_connectionInformation.ConnectionString))
-                            {
-                                connection.Open();
-                                using (var cmd = connection.CreateCommand())
-                                {
-                                    cmd.CommandText = "PRAGMA journal_mode=WAL;";
-                                    cmd.ExecuteNonQuery();
-                                }
-                            }
-                        }
-                    }
+                    WalJournalMode.Apply(_connectionInformation, _getFileNameFromConnection, _options);
                 }
 
                 return result;

--- a/Source/DotNetWorkQueue.Transport.SQLite/Decorator/WalJournalMode.cs
+++ b/Source/DotNetWorkQueue.Transport.SQLite/Decorator/WalJournalMode.cs
@@ -1,0 +1,66 @@
+﻿// ---------------------------------------------------------------------
+//This file is part of DotNetWorkQueue
+//Copyright © 2015-2026 Brian Lehnen
+//
+//This library is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 2.1 of the License, or (at your option) any later version.
+//
+//This library is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+//
+//You should have received a copy of the GNU Lesser General Public
+//License along with this library; if not, write to the Free Software
+//Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// ---------------------------------------------------------------------
+using System.Data.SQLite;
+using DotNetWorkQueue.Transport.RelationalDatabase;
+using DotNetWorkQueue.Transport.SQLite.Basic;
+
+namespace DotNetWorkQueue.Transport.SQLite.Decorator
+{
+    /// <summary>
+    /// Sets WAL journal mode on a newly created file-based database.
+    /// </summary>
+    /// <remarks>
+    /// Shared by the two creation decorators rather than written out in each. Write-ahead logging is
+    /// the only concurrency lever SQLite gives this transport - the engine has no asynchronous I/O
+    /// and never will, see <see cref="IReaderAsync"/> - so a database that misses it is meaningfully
+    /// worse under load, and silently: nothing converts an existing file later. A copy of this that
+    /// one caller forgot is exactly how job databases ended up in rollback-journal mode.
+    /// </remarks>
+    internal static class WalJournalMode
+    {
+        /// <summary>
+        /// Applies the journal mode to the database behind <paramref name="connectionInformation"/>,
+        /// when the transport options ask for it and the database is a file.
+        /// </summary>
+        /// <param name="connectionInformation">The connection information.</param>
+        /// <param name="getFileNameFromConnection">Resolves the file behind the connection string.</param>
+        /// <param name="options">The transport options, which carry the opt-out.</param>
+        public static void Apply(IConnectionInformation connectionInformation,
+            IGetFileNameFromConnectionString getFileNameFromConnection,
+            ISqLiteMessageQueueTransportOptionsFactory options)
+        {
+            if (!options.Create().EnableWalMode)
+                return;
+
+            //an in-memory database has no journal to write
+            if (getFileNameFromConnection.GetFileName(connectionInformation.ConnectionString).IsInMemory)
+                return;
+
+            using (var connection = new SQLiteConnection(connectionInformation.ConnectionString))
+            {
+                connection.Open();
+                using (var cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = "PRAGMA journal_mode=WAL;";
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this fixes

WAL has been the SQLite transport default since 0.9.10, but only the queue-creation decorator ever applied it. `CreateJobTablesCommandDecorator` can also be the first thing to reach a database — `ProducerMethodJobQueue.Start()` creates the job table, and the decorator has the same `File.Create` code as its sibling — but it never set the journal mode. A job producer that reached a file first left it in rollback-journal mode permanently; nothing converts an existing database later.

Measured through the public API on fresh files, before the fix:

| Path | Journal mode |
|---|---|
| `CreateQueue()` | `wal` |
| `CreateJobSchedulerQueue()` (delegates to `CreateQueue`) | `wal` |
| `CreateMethodJobProducer(…).Start()` | **`delete`** |

The scheduler queue was never affected, which is why this stayed invisible — the documented flow creates the queue first, and that path sets the mode. Only a producer arriving at a database on its own reaches the gap.

It matters because SQLite has no asynchronous I/O and never will (#298), so WAL is the only concurrency lever this transport has. A database that misses it is worse under load for the rest of its life, silently.

## The change

`WalJournalMode` now holds the pragma and both creation decorators call it. A duplicated block that one caller never got is how this happened in the first place — the same shape as the job-table miss in #318.

## What to look at

**The tests deliberately avoid `IntegrationConnectionInfo`.** That fixture runs `PRAGMA journal_mode=WAL` against the file *before* handing the library the connection string, so an assertion built on it is satisfied by its own setup, and a transport that set no journal mode at all would still look correct. That is why `EnableWalMode` has had no coverage in the ten releases since it shipped. Each test owns a raw file instead, and the `EnableWalMode = false` case asserting `delete` is what proves the others read the transport's decision rather than a constant.

With the fix removed, exactly one test fails and for the stated reason: expected `"wal"`, was `"delete"`.

Worth a second opinion on the fixture: leaving that pragma in place keeps 214 timing-sensitive tests on the mode they have always run under, which is why I did not remove it — but it does mean the rest of the suite still runs against a journal mode the library did not choose.

## Verification

- SQLite integration suite: 218/218
- SQLite Linq job-scheduler tests: 4/4
- SQLite unit tests: 244/244

## Consumer impact

A job database created by a producer now gets `-wal` and `-shm` files beside it. This is the same conversion `CreateQueue` has performed since 0.9.10, it is reversible, and it changes no schema — but it does alter an existing file on next `Start()`, so it carries a ⚠️ changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQLite job databases now use write-ahead logging (WAL) by default, matching queue databases.
  * Databases created first by a job producer are automatically configured for WAL mode.
  * WAL mode creates associated `-wal` and `-shm` files alongside the database.

* **Bug Fixes**
  * WAL configuration is now applied consistently when creating queues and job scheduler databases.
  * Disabling WAL mode preserves SQLite’s default journal mode.
  * WAL setup failures no longer interrupt database creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->